### PR TITLE
Next.js 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/next-on-pages",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "bin": "./bin/index.js",
   "scripts": {
     "build": "npx esbuild --bundle --platform=node ./src/index.ts --external:esbuild --external:chokidar --outfile=./dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,13 +378,23 @@ const transform = async ({
     }
 
     for (const entry of functionsEntries) {
-      if (`pages/${name}` === entry?.name) {
+      if (
+        `pages/${name}` === entry?.name ||
+        `app${name !== "index" ? `/${name}` : ""}/page` === entry?.name
+      ) {
         hydratedFunctions.set(name, { matchers: entry.matchers, filepath });
       }
     }
   }
 
-  if (hydratedMiddleware.size + hydratedFunctions.size !== functionsMap.size) {
+  const rscFunctions = [...functionsMap.keys()].filter((name) =>
+    name.endsWith(".rsc")
+  );
+
+  if (
+    hydratedMiddleware.size + hydratedFunctions.size !==
+    functionsMap.size - rscFunctions.length
+  ) {
     console.error(
       "⚡️ ERROR: Could not map all functions to an entry in the manifest."
     );

--- a/templates/_worker.js/index.ts
+++ b/templates/_worker.js/index.ts
@@ -144,7 +144,11 @@ export default {
       let found = false;
       for (const matcher of matchers) {
         if (matcher.regexp) {
-          if (pathname.match(new RegExp(matcher?.regexp))) {
+          const regexp = new RegExp(matcher?.regexp);
+          if (
+            pathname.match(regexp) ||
+            `${pathname}/page`.replace("//page", "/page").match(regexp)
+          ) {
             found = true;
             break;
           }


### PR DESCRIPTION
Next.js 12 should continue to work, Next.js 13 now works, including the new [experimental `app` directory](https://beta.nextjs.org/docs/routing/fundamentals#the-app-directory).

Check out the README.md for an updated guide on creating a new Next.js 13 app!

Fixes #9 