### PR TITLE
[Docs] Update README 'appDir' config diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Add the following to `next.config.js`:
 const nextConfig = {
   experimental: {
     runtime: "experimental-edge",
-  + appDir: true,
++   appDir: true,
   },
   reactStrictMode: true,
   swcMinify: true,


### PR DESCRIPTION
The diff for the Next 13 `appDir` config doesn't highlight properly because of the indentation of the `+`.

| **Before:** | **After:**|
|------------|-------|
|  <img src="https://user-images.githubusercontent.com/73045936/203484001-71be88c2-4494-4c46-aaa3-05a466adb697.png" width="400"> | <img src="https://user-images.githubusercontent.com/73045936/203484055-bfba74a1-2dbd-4d6d-a889-fc2fc5652938.png" width="400"> |

_P.S. Thanks for creating this awesome tool! Just something super minor I found._