### PR TITLE
add support for middleware in src dir

### DIFF
--- a/.changeset/smooth-nails-smash.md
+++ b/.changeset/smooth-nails-smash.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": patch
+---
+
+add support for middleware in src dir

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,9 +369,9 @@ const transform = async ({
   const middlewareEntries = Object.values(middlewareManifest.middleware);
   const functionsEntries = Object.values(middlewareManifest.functions);
   for (const [name, filepath] of functionsMap) {
-    if (name === "middleware" && middlewareEntries.length > 0) {
+    if (middlewareEntries.length > 0 && (name === "middleware" || name === "src/middleware")) {
       for (const entry of middlewareEntries) {
-        if ("middleware" === entry?.name) {
+        if (entry?.name === "middleware" || entry?.name === "src/middleware") {
           hydratedMiddleware.set(name, { matchers: entry.matchers, filepath });
         }
       }


### PR DESCRIPTION
Minor change to support middleware in `src` directory: https://nextjs.org/docs/advanced-features/src-directory

Otherwise the build is failing with:
```
ERROR: Could not map all functions to an entry in the manifest
```