### PR TITLE
Implement support for `next.config#basePath`

### DIFF
--- a/.changeset/wild-eyes-wink.md
+++ b/.changeset/wild-eyes-wink.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": patch
+---
+
+Add support for Next.js [basepath](https://nextjs.org/docs/api-reference/next.config.js/basepath)

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,17 +133,37 @@ const transform = async ({
     exit(1);
   }
 
+  // RoutesManifest.version and RoutesManifest.basePath are the only fields accessed
   interface RoutesManifest {
     version: 3;
-    pages404: boolean;
     basePath: string;
-    // TODO type these?
-    redirects: unknown;
+    pages404: boolean;
+    redirects: {
+      source: string;
+      destination: string;
+      basePath: boolean | undefined;
+      internal: boolean;
+      statusCode: number;
+      regex: string;
+    }[];
+    dynamicRoutes: {
+      page: string;
+      regex: string;
+      routeKeys: any; // object of dynamic parameters;
+      namedRegex: string;
+    };
+    staticRoutes: {
+      page: string;
+      regex: string;
+      routeKeys: any; // object of dynamic parameters;
+      namedRegex: string;
+    }[];
+    rsc: {
+      header: string;
+      varyHeader: string;
+    };
     headers: unknown;
-    dynamicRoutes: unknown;
-    staticRoutes: unknown;
     dataRoutes: unknown;
-    rsc: unknown;
     rewrites: unknown;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ const transform = async ({
     console.log("⚡️ Using basePath ", basePath);
   }
 
-  const functionsDir = resolve(".vercel/output/functions" + basePath);
+  const functionsDir = resolve(`.vercel/output/functions${basePath}`);
   let functionsExist = false;
   try {
     await stat(functionsDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,34 +137,6 @@ const transform = async ({
   interface RoutesManifest {
     version: 3;
     basePath: string;
-    pages404: boolean;
-    redirects: {
-      source: string;
-      destination: string;
-      basePath: boolean | undefined;
-      internal: boolean;
-      statusCode: number;
-      regex: string;
-    }[];
-    dynamicRoutes: {
-      page: string;
-      regex: string;
-      routeKeys: any; // object of dynamic parameters;
-      namedRegex: string;
-    };
-    staticRoutes: {
-      page: string;
-      regex: string;
-      routeKeys: any; // object of dynamic parameters;
-      namedRegex: string;
-    }[];
-    rsc: {
-      header: string;
-      varyHeader: string;
-    };
-    headers: unknown;
-    dataRoutes: unknown;
-    rewrites: unknown;
   }
 
   let routesManifest: RoutesManifest;

--- a/templates/_worker.js/index.ts
+++ b/templates/_worker.js/index.ts
@@ -149,7 +149,7 @@ export default {
       for (const matcher of matchers) {
         if (matcher.regexp) {
           const regexp = new RegExp(matcher?.regexp);
-          const nextPathname = __BASE_PATH__
+          const nextPathname = pathname.startsWith(__BASE_PATH__)
             ? // Remove basePath from URL, also squish `//` into `/`
               // If the baseUrl is set to "/docs" the following will happen:
               // `/docs/profile/settings` -> `/profile/settings`

--- a/templates/_worker.js/index.ts
+++ b/templates/_worker.js/index.ts
@@ -149,10 +149,19 @@ export default {
       for (const matcher of matchers) {
         if (matcher.regexp) {
           const regexp = new RegExp(matcher?.regexp);
+          const nextPathname = __BASE_PATH__
+            ? // Remove basePath from URL, also squish `//` into `/`
+              // If the baseUrl is set to "/docs" the following will happen:
+              // `/docs/profile/settings` -> `/profile/settings`
+              // `/docs` -> `/`
+              // `/docs/` -> `/`
+              // `/docs/_next/static/main.js` -> `/_next/static/main.js`
+              pathname.replace(__BASE_PATH__, "/").replace("//", "/")
+            : pathname;
+
           if (
-            pathname.match(regexp) ||
-            `${pathname}/page`.replace("//page", "/page").match(regexp) ||
-            pathname.replace(__BASE_PATH__, "").match(regexp)
+            nextPathname.match(regexp) ||
+            `${nextPathname}/page`.replace("//page", "/page").match(regexp)
           ) {
             found = true;
             break;

--- a/templates/_worker.js/index.ts
+++ b/templates/_worker.js/index.ts
@@ -126,6 +126,8 @@ declare const __FUNCTIONS__: EdgeFunctions;
 
 declare const __MIDDLEWARE__: EdgeFunctions;
 
+declare const __BASE_PATH__: string;
+
 export default {
   async fetch(request, env, context) {
     globalThis.process.env = { ...globalThis.process.env, ...env };
@@ -149,7 +151,8 @@ export default {
           const regexp = new RegExp(matcher?.regexp);
           if (
             pathname.match(regexp) ||
-            `${pathname}/page`.replace("//page", "/page").match(regexp)
+            `${pathname}/page`.replace("//page", "/page").match(regexp) ||
+            pathname.replace(__BASE_PATH__, "").match(regexp)
           ) {
             found = true;
             break;


### PR DESCRIPTION
The [basepath](https://nextjs.org/docs/api-reference/next.config.js/basepath) feature in Next.js allows applications to be hosted specific paths on the same domain like the following:

example.com/user/account <-- Next.js App 1
example.com/store/checkout <-- Next.js App 2

---

Currently `@cloudflare/next-on-pages` errors when using the basepath option, this PR aims at adding support by reading the basePath value from the build output, `.next/routes-manifest.json`, and then inlines the value into the Worker. 

Upon receiving a request, the worker will strip the `basePath` value from the pathname, and then run the matching logic with the stripped pathname. This appears to play nicely with everything else inside of Next's `base-server#handleRequest`, though I'm happy to move things around if there is a better way..?

Also happy to chat real time in the Cloudflare Discord, with my username being @hanford. 

---

closes https://github.com/cloudflare/next-on-pages/issues/42