### PR TITLE
Set `x-matched-path` fixing dynamic routing

### DIFF
--- a/templates/_worker.js/index.ts
+++ b/templates/_worker.js/index.ts
@@ -140,7 +140,8 @@ export default {
       }
     }
 
-    for (const { matchers, entrypoint } of Object.values(__FUNCTIONS__)) {
+    for (const [key, value] of Object.entries(__FUNCTIONS__)) {
+      const { matchers, entrypoint } = value;
       let found = false;
       for (const matcher of matchers) {
         if (matcher.regexp) {
@@ -156,10 +157,20 @@ export default {
       }
 
       if (found) {
-        return entrypoint.default(request, context);
+        return entrypoint.default(cloneRequest(request, key), context);
       }
     }
 
     return env.ASSETS.fetch(request);
   },
 } as ExportedHandler<{ ASSETS: Fetcher }>;
+
+function cloneRequest(request: Request, matchedPath: string): Request {
+  const requestInit = {
+    ...request,
+    // Ensure `x-matched-path` is set so Next.js#handleRequest can properly recognize dynamic routes
+    headers: { ...request.headers, "x-matched-path": matchedPath },
+  };
+
+  return new Request(request.url, requestInit);
+}


### PR DESCRIPTION
This PR ensures `x-matched-path` is set, so `Next.js#handleRequest` is able to recognize and render dynamic routes.

It appears Next.js uses this header [pretty extensively](https://github.com/vercel/next.js/blob/cafbe2a0ade6375681224ff79799ececdbd821f2/packages/next/src/server/base-server.ts#L534) in it's base-server, to determine whether or not we're in an edge runtime. Without this header, Next.js doesn't match the URL segments resulting in a "Internal Server Error" page.

I'm happy to change any part of this PR, but think this might be one of the "cleaner" solutions I've been able to come up with.

---
I've also created a reproduction of this bug, along with a patched version of `next-on-pages` that proves that this solution works over here: https://github.com/hanford/next-on-pages-32


closes #32 