### PR TITLE
spread env into process.env

### DIFF
--- a/.changeset/young-coins-appear.md
+++ b/.changeset/young-coins-appear.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": minor
+---
+
+Environment variables and bindings are now available on `process.env` from within your SSR'd pages/API handlers!

--- a/templates/_worker.js/index.ts
+++ b/templates/_worker.js/index.ts
@@ -128,6 +128,8 @@ declare const __MIDDLEWARE__: EdgeFunctions;
 
 export default {
   async fetch(request, env, context) {
+    globalThis.process.env = { ...globalThis.process.env, ...env };
+
     const { pathname } = new URL(request.url);
     const routes = routesMatcher({ request }, __CONFIG__.routes);
 


### PR DESCRIPTION
in the _worker.js template take the provided env and spread its values into the global process.env so that bindings can be accessed in the Next.js application