### PR TITLE
fix: remove vercel installation

### DIFF
--- a/.changeset/perfect-pens-breathe.md
+++ b/.changeset/perfect-pens-breathe.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+remove redundant vercel install

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ type LooseNode = Node & {
 };
 
 const prepVercel = async () => {
+  console.log("⚡️");
+  console.log("⚡️ Preparing project for 'npx vercel build'...");
+  console.log("⚡️");
   try {
     await stat(".vercel/project.json");
   } catch {
@@ -35,38 +38,8 @@ const prepVercel = async () => {
     );
   }
   console.log("⚡️");
-  console.log("⚡️ Installing 'vercel' CLI...");
   console.log("⚡️");
-
-  const vercelBuild = spawn("npm", ["install", "-D", "vercel"]);
-
-  vercelBuild.stdout.on("data", (data) => {
-    const lines: string[] = data.toString().split("\n");
-    lines.map((line) => {
-      console.log(`▲ ${line}`);
-    });
-  });
-
-  vercelBuild.stderr.on("data", (data) => {
-    const lines: string[] = data.toString().split("\n");
-    lines.map((line) => {
-      console.log(`▲ ${line}`);
-    });
-  });
-
-  await new Promise((resolve, reject) => {
-    vercelBuild.on("close", (code) => {
-      if (code === 0) {
-        resolve(null);
-      } else {
-        reject();
-      }
-    });
-  });
-
-  console.log("⚡️");
-  console.log("⚡️");
-  console.log("⚡️ Completed 'npx vercel build'.");
+  console.log("⚡️ Project ready for 'npx vercel build'...");
   console.log("⚡️");
 };
 


### PR DESCRIPTION
The step executing the actual build defaults to `npx`. The redundant Vercel CLI installation can be removed.

This automatically means that `pnpm` is now supported without fuss (package managers are recognized correctly and automatically) and slightly cleaner.

The main point it Vercel CLI only needs the config files to be in place, and that's what the code change does.

Closes #17
Closes #6 