### PR TITLE
fix: windows file paths not matching middleware manifest

### DIFF
--- a/.changeset/ninety-queens-pump.md
+++ b/.changeset/ninety-queens-pump.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": patch
+---
+
+Fix Windows file paths not matching entries in the middleware manifest.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { watch } from "chokidar";
 import pLimit from "p-limit";
 import acorn, { parse, Node } from "acorn";
 import { generate } from "astring";
+import { normalizePath } from './utils';
 
 type LooseNode = Node & {
   expression?: LooseNode;
@@ -307,8 +308,8 @@ const transform = async ({
 
           // `\\` needs to be replaced with `/` for Windows so that it can match the path correctly in the middleware manifest.
           functionsMap.set(
-            relative(functionsDir, filepath).slice(0, -".func".length).replace(/\\/g, "/"),
-            newFilePath.replace(/\\/g, "/")
+            normalizePath(relative(functionsDir, filepath).slice(0, -".func".length)),
+            normalizePath(newFilePath)
           );
         } else if (isDirectory) {
           await walk(filepath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,9 +305,10 @@ const transform = async ({
           await mkdir(dirname(newFilePath), { recursive: true });
           await writeFile(newFilePath, contents);
 
+          // `\\` needs to be replaced with `\` for Windows so that it can match the path correctly in the middleware manifest.
           functionsMap.set(
-            relative(functionsDir, filepath).slice(0, -".func".length),
-            newFilePath
+            relative(functionsDir, filepath).slice(0, -".func".length).replace(/\\/g, "/"),
+            newFilePath.replace(/\\/g, "/")
           );
         } else if (isDirectory) {
           await walk(filepath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,7 +305,7 @@ const transform = async ({
           await mkdir(dirname(newFilePath), { recursive: true });
           await writeFile(newFilePath, contents);
 
-          // `\\` needs to be replaced with `\` for Windows so that it can match the path correctly in the middleware manifest.
+          // `\\` needs to be replaced with `/` for Windows so that it can match the path correctly in the middleware manifest.
           functionsMap.set(
             relative(functionsDir, filepath).slice(0, -".func".length).replace(/\\/g, "/"),
             newFilePath.replace(/\\/g, "/")

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { watch } from "chokidar";
 import pLimit from "p-limit";
 import acorn, { parse, Node } from "acorn";
 import { generate } from "astring";
-import { normalizePath } from './utils';
+import { normalizePath } from "./utils";
 
 type LooseNode = Node & {
   expression?: LooseNode;

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,6 @@ const transform = async ({
           await mkdir(dirname(newFilePath), { recursive: true });
           await writeFile(newFilePath, contents);
 
-          // `\\` needs to be replaced with `/` for Windows so that it can match the path correctly in the middleware manifest.
           functionsMap.set(
             normalizePath(relative(functionsDir, filepath).slice(0, -".func".length)),
             normalizePath(newFilePath)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { normalizePath } from './paths';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export { normalizePath } from './paths';
+export { normalizePath } from "./paths";

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -19,4 +19,4 @@
  * ```
  */
 export const normalizePath = (path: string) =>
-  path.startsWith('\\\\?\\') ? path : path.replace(/\\/g, '/');
+  path.startsWith("\\\\?\\") ? path : path.replace(/\\/g, "/");

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,22 @@
+/**
+ * Convert paths with backslashes to normalized paths with forward slashes.
+ * 
+ * Extended-length paths on Windows (starting with \\\\?\\) are not normalized due to
+ * exceeding the MAX_PATH (260 characters). They need this prefix so that Windows can
+ * identify them as an extended-length path.
+ * 
+ * This is useful when building a project on Windows as the path names in the Next.js
+ * build output middleware manifest are in the forward slash format, while Windows
+ * uses backslashes.
+ * 
+ * @param path A path with backslashes.
+ * @returns A path with forward slashes.
+ * 
+ * @example
+ * ```ts
+ * const normalized = normalizePath("D:\\path\\with\\backslashes");
+ * // normalized === "D:/path/with/backslashes"
+ * ```
+ */
+export const normalizePath = (path: string) =>
+  path.startsWith('\\\\?\\') ? path : path.replace(/\\/g, '/');

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "vitest";
+import { normalizePath } from '../src/utils';
+
+describe("normalizePath", () => {
+  test("windows long path name format should not normalize", () => {
+    const path = "\\\\?\\D:\\very long path";
+
+    expect(normalizePath(path)).toEqual(path);
+  });
+
+  test("windows short path name format normalizes", () => {
+    const path = "D:\\very short path";
+    const expected = "D:/very short path";
+
+    expect(normalizePath(path)).toEqual(expected);
+  });
+
+  test("unix path name format normalizes (no change)", () => {
+    const path = "/home/unix/path";
+
+    expect(normalizePath(path)).toEqual(path);
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { normalizePath } from '../src/utils';
+import { normalizePath } from "../src/utils";
 
 describe("normalizePath", () => {
   test("windows long path name format should not normalize", () => {


### PR DESCRIPTION
On Windows, the file paths may use `\\` instead of `/`.

This would result in the error `Could not map all functions to an entry in the manifest.` being thrown.

When we are running through the middleware manifest entries and checking that our function entries exist in it, we are comparing an entry with `/` in it to our path with `\`  in it.

This change replaces the `\\` with `/` so they are in the same format as the middleware manifest when adding to the functions map.