### PR TITLE
fix: minification

### DIFF
--- a/.changeset/twenty-spoons-search.md
+++ b/.changeset/twenty-spoons-search.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": patch
+---
+
+Fix Webpack minification and toggle esbuild minification.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@cloudflare/next-on-pages",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/next-on-pages",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "acorn": "^8.8.0",
-        "astring": "^1.8.3",
+        "astring": "^1.8.4",
         "chokidar": "^3.5.3",
         "cookie": "^0.5.0",
         "esbuild": "^0.15.3"
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/astring": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.3.tgz",
-      "integrity": "sha512-sRpyiNrx2dEYIMmUXprS8nlpRg2Drs8m9ElX9vVEXaCB4XEAJhKfs7IcX0IwShjuOAjLR6wzIrgoptz1n19i1A==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.4.tgz",
+      "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw==",
       "bin": {
         "astring": "bin/astring"
       }
@@ -7430,9 +7430,9 @@
       "dev": true
     },
     "astring": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.3.tgz",
-      "integrity": "sha512-sRpyiNrx2dEYIMmUXprS8nlpRg2Drs8m9ElX9vVEXaCB4XEAJhKfs7IcX0IwShjuOAjLR6wzIrgoptz1n19i1A=="
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.4.tgz",
+      "integrity": "sha512-97a+l2LBU3Op3bBQEff79i/E4jMD2ZLFD8rHx9B6mXyB2uQwhJQYfiDqUwtfjF4QA1F2qs//N6Cw8LetMbQjcw=="
     },
     "async-sema": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "acorn": "^8.8.0",
-    "astring": "^1.8.3",
+    "astring": "^1.8.4",
     "chokidar": "^3.5.3",
     "cookie": "^0.5.0",
     "esbuild": "^0.15.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -490,6 +490,7 @@ const transform = async ({
       __CONFIG__: JSON.stringify(config),
     },
     outfile: ".vercel/output/static/_worker.js",
+    minify: experimentalMinify,
   });
 
   console.log("⚡️ Generated '.vercel/output/static/_worker.js'.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ const transform = async ({
                   expression.callee?.type === "MemberExpression" &&
                   expression.callee.object?.type === "AssignmentExpression" &&
                   expression.callee.object.left?.object?.name === "self" &&
-                  expression.callee.object.left.property?.value ===
+                  expression.callee.object.left.property?.name ===
                     "webpackChunk_N_E" &&
                   expression.arguments?.[0]?.elements?.[1]?.type ===
                     "ObjectExpression"

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,12 @@ const transform = async ({
           );
 
           if (experimentalMinify) {
+            // TODO: Investigate alternatives or a real fix for this. Maybe a PR is needed in Next.js?
+            // This is a hack to fix an issue with --experimental-minify where compiled next/server/web/adapter.ts throws:
+            // `Unhandled Promise Rejection: TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))`
+            // Source code: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts#L237
+            contents = contents.replace(/(?:(return{response:\w+,waitUntil:Promise\.all\(\w+\[\w+\])(\)}))/gm, "$1??[]$2");
+
             const parsedContents = parse(contents, {
               ecmaVersion: "latest",
               sourceType: "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,12 +228,6 @@ const transform = async ({
           );
 
           if (experimentalMinify) {
-            // TODO: Investigate alternatives or a real fix for this. Maybe a PR is needed in Next.js?
-            // This is a hack to fix an issue with --experimental-minify where compiled next/server/web/adapter.ts throws:
-            // `Unhandled Promise Rejection: TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))`
-            // Source code: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts#L237
-            contents = contents.replace(/(?:(return{response:\w+,waitUntil:Promise\.all\(\w+\[\w+\])(\)}))/gm, "$1??[]$2");
-
             const parsedContents = parse(contents, {
               ecmaVersion: "latest",
               sourceType: "module",


### PR DESCRIPTION
### Bullet point version:

- Fix which property is checked for `webpackChunk_N_E`
- Use regex to hack around a bug caused by our webpack minification. It doesn't appear to cause issues.
- Set esbuild's `minify` option to be enabled when the user uses `--experimental-minify`
 
### Statistics:

Build is 3289854 bytes
  - change (regular): -19566933 bytes.
  - change (esbuild): -12028637 bytes.
  - change (experim): -2272043 bytes.
  - change (exp+esb): +0 bytes.

### Long version:

The primary reason minification was failing was due to checking the wrong property for `webpackChunk_N_E`. This was actually stored under `name` instead of `value`. Below is an example of the property object:
```
Node3 {
  type: 'Identifier',
  start: 57372,
  end: 57388,
  name: 'webpackChunk_N_E'
}
```

I did actually end up coming across a bug that only occurs if you use `--experimental-minify`, meaning it doesn't occur when there is no minification, and it doesn't occur if you only use esbuild's minification. It is rather bizarre. The below part of one of the minified webpack chunks results in an error due to the value being undefined. I have traced this back to [next/server/web/adapter.ts](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts#L237) in the next.js repo.

```
return { response: x2, waitUntil: Promise.all(h2[s]) };
```

I've thought and thought about this but I cannot figure out why it is occurring. Well, I can, because I did console.log on each value, but the point is that it *shouldn't* happen, but for some reason, it does when we minify the webpack chunks.

![image](https://user-images.githubusercontent.com/10815538/223544316-3ff2a5ea-d2b8-4ebd-87a6-2df99d077aaf.png)

At the moment, my workaround for this bug is using regex to replace the instances of it in each relevant chunk to have a nullish coalescing operator followed by an empty array. This means that instead of erroring out and breaking because it received undefined, it gets an empty array.

From the testing in vercel/app-playground that I did locally when trying this fix, it doesn't seem like it is causing any noticeable issues. I've done a lot of playing around and have encountered no issues caused by it.

As minify is experimental like the flag states, I feel that this is an acceptable hack around for the bug until a better solution can be identified, if any.

The final change I have made is to toggle esbuild's `minify` option when the user uses `--experimental-minify`

I do think that there is probably going to be more room for optimization with other parts. For example, the metadata for static routes is written in the final _worker.js 38 times for vercel/app-playground. But those would be optimizations to explore in another PR.

fixes #47