### PR TITLE
fix: external fetch requests

### DIFF
--- a/.changeset/forty-geese-reply.md
+++ b/.changeset/forty-geese-reply.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": patch
+---
+
+Fix fetch requests.

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,13 @@ const transform = async ({
             "$1true$3"
           );
 
+          // The workers runtime does not implement certain properties like `mode` or `credentials`.
+          // Due to this, we need to replace them with null so that request deduping cache key generation will work.
+          contents = contents.replace(
+            /(?:(JSON\.stringify\(\[\w+\.method\S+,)\w+\.mode(,\S+,)\w+\.credentials(,\S+,)\w+\.integrity(\]\)))/gm,
+            "$1null$2null$3null$4"
+          );
+
           if (experimentalMinify) {
             const parsedContents = parse(contents, {
               ecmaVersion: "latest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,8 +227,10 @@ const transform = async ({
             "$1true$3"
           );
 
+          // TODO: Investigate alternatives or a real fix. This hack is rather brittle.
           // The workers runtime does not implement certain properties like `mode` or `credentials`.
           // Due to this, we need to replace them with null so that request deduping cache key generation will work.
+          // https://github.com/vercel/next.js/blob/canary/packages/next/src/compiled/react/cjs/react.shared-subset.development.js#L198
           contents = contents.replace(
             /(?:(JSON\.stringify\(\[\w+\.method\S+,)\w+\.mode(,\S+,)\w+\.credentials(,\S+,)\w+\.integrity(\]\)))/gm,
             "$1null$2null$3null$4"


### PR DESCRIPTION
The Cloudflare workers runtime does not implement certain properties, for instance `mode` and `credentials`. When [generating](https://github.com/vercel/next.js/blob/canary/packages/next/src/compiled/react/cjs/react.shared-subset.development.js#L191) a cache key for request deduping, the React Fetch 'monkey-patch' implementation tries to read some of these properties.

Therefore, the simple solution is to replace these specific properties with `null` when we build the _worker.js script as they would have no effect on the cache keys anyway.

https://github.com/cloudflare/workerd/blob/main/src/workerd/api/http.h#L518
https://github.com/cloudflare/miniflare/blob/master/packages/core/src/standards/http.ts#L501

fixes #36