### PR TITLE
fix: strange minification bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,12 @@ const transform = async ({
           );
 
           if (experimentalMinify) {
+            // TODO: Investigate alternatives or a real fix for this. Maybe a PR is needed in Next.js?
+            // This is a hack to fix an issue with --experimental-minify where compiled next/server/web/adapter.ts throws:
+            // `Unhandled Promise Rejection: TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))`
+            // Source code: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts#L237
+            contents = contents.replace(/(?:(return{response:\w+,waitUntil:Promise\.all\(\w+\[\w+\])(\)}))/gm, "$1??[]$2");
+
             const parsedContents = parse(contents, {
               ecmaVersion: "latest",
               sourceType: "module",


### PR DESCRIPTION
This is a follow-up to #88. When using the `--experimental-minify` flag, there is a strange bug after the Webpack chunks are minified. 

```
Unhandled Promise Rejection: TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
```

The cause of this appears to be the `waitUntil` value on the `FetchEvent` [class](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/fetch-event.ts#L9) through `NextFetchEvent` not being defined, despite a new instance of the class being [created](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts#L121).

The spot in the Next.js source code where this error is through is located [here](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts#L237). It does not make sense. When we don't minify the Webpack chunks, it is fine, but when we minify them, the error is thrown while running the minified app.

At the moment, I've committed a hack around it which should be replaced with something better in the future. It adds a nullish coalescing operator follow by a blank array so that the promise has an empty array to resolve, instead of trying to resolve undefined.

```ts
return { response: x2, waitUntil: Promise.all(h2[s]) };
```

![image](https://user-images.githubusercontent.com/10815538/224798172-bee0d539-3de3-48c5-adce-a43bf4ddb3a2.png)

<details>
<summary>Reproduction Steps</summary>

1. Run `npx vercel build` in the clone of [app-playground-edge ](https://github.com/james-elicx/app-playground-edge).
2. Copy `.next` and `.vercel` to the directory with the clone of this branch.
3. Commented out the `contents = contents.replace(.....)` that this PR added.
4. Added `AsyncLocalStorage` import and assigned it to `globalThis` in `globals.js`.
5. Added `node:async_hooks` as external to esbuild.
6. Ran `npm run build && node ./bin/index.js --skip-build --experimental-minify` to build next-on-pages and compile the `_worker.js` script.
7. Ran `cd .vercel/output/static && npx wrangler pages dev . --compatibility-date=2023-03-07 --compatibility-flag=nodejs_compat --bundle`
8. Pressed `b` to open the web page.
9. The error was thrown in the console I ran wrangler from.
</details>
