### PR TITLE
Fix windows related error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/next-on-pages",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/next-on-pages",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "acorn": "^8.8.0",
         "astring": "^1.8.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,14 +444,14 @@ const transform = async ({
         .join(",")}};`
   );
 
-	const entryPoints = join(__dirname, "../templates/_worker.js").replaceAll(
-		"\\",
-		"/"
-	);
-	const inject = join(
-		__dirname,
-		"../templates/_worker.js/globals.js"
-	).replaceAll("\\", "/");
+  const entryPoints = join(
+    __dirname,
+    "../templates/_worker.js"
+  ).replaceAll("\\", "/");
+  const inject = join(
+    __dirname,
+    "../templates/_worker.js/globals.js"
+  ).replaceAll("\\", "/");
 
   await build({
     entryPoints: [entryPoints],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "es2021",
+		"module": "commonjs",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"skipLibCheck": true
+	},
+	"exclude": ["tests", "templates"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
-	"compilerOptions": {
-		"target": "es2021",
-		"module": "commonjs",
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"strict": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"skipLibCheck": true
-	},
-	"exclude": ["tests", "templates"]
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["tests", "templates"]
 }


### PR DESCRIPTION
This pr was created to solve:
1. The problem that esbuild can't recognize windows back-slash `\` during the build and cause error
> Solved by normalize the back-slash to forward-slash with `replaceAll()`
> The place that use path normalization:
> + [L433](https://github.com/LOLBRUHNICE/next-on-pages/blob/main/src/index.ts#L433)
> + [L442](https://github.com/LOLBRUHNICE/next-on-pages/blob/main/src/index.ts#L442)
> + [L447-L455](https://github.com/LOLBRUHNICE/next-on-pages/blob/main/src/index.ts#L447-L455)
2. The problem that windows cant use spawn function(from child_process) as it will cause the error
`spawn npm ENOENT`
> Solved by using `exec()` instead of `spawn()`
> The place that use `spawn()`:
> + [L3](https://github.com/LOLBRUHNICE/next-on-pages/blob/main/src/index.ts#L3)
> + [L51](https://github.com/LOLBRUHNICE/next-on-pages/blob/main/src/index.ts#L51)
> Fixes #52 

Additional changes:
- Added tsconfig.json and set the target to es2021 in order to use `replaceAll()`