### PR TITLE
Add globalThis.AsyncLocalStorage for 13.X versions of Next.js

### DIFF
--- a/.changeset/seven-cougars-fly.md
+++ b/.changeset/seven-cougars-fly.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+feat: Add support for current 13.X versions of Next.js

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Reference:
 
 1. Add a `NODE_VERSION` environment variable set to `16` or greater (`18` is not supported yet, See [Build Image Update Discussion](https://github.com/cloudflare/pages-build-image/discussions/1).
 
+1. In the Pages project **Settings** > **Functions** > **Compatibility Flags**, add the `nodejs_compat` and ensure the **Compatibility Date** is set to at least `2022-11-30`.
+
 1. The project should now be ready to deploy. Create a new deployment.
 
 ## `@cloudflare/next-on-pages` CLI

--- a/templates/_worker.js/index.ts
+++ b/templates/_worker.js/index.ts
@@ -117,7 +117,7 @@ type EdgeFunction = {
 
 type EdgeFunctions = {
 	matchers: { regexp: string }[];
-	entrypoint: EdgeFunction;
+	entrypoint: Promise<EdgeFunction>;
 }[];
 
 declare const __CONFIG__: Config;
@@ -137,10 +137,9 @@ export default {
 
 		for (const route of routes) {
 			if ('middlewarePath' in route && route.middlewarePath in __MIDDLEWARE__) {
-				return await __MIDDLEWARE__[route.middlewarePath].entrypoint.default(
-					request,
-					context
-				);
+				return await (
+					await __MIDDLEWARE__[route.middlewarePath].entrypoint
+				).default(request, context);
 			}
 		}
 
@@ -182,7 +181,7 @@ export default {
 
 			if (found) {
 				const adjustedRequest = adjustRequestForVercel(request);
-				return entrypoint.default(adjustedRequest, context);
+				return (await entrypoint).default(adjustedRequest, context);
 			}
 		}
 


### PR DESCRIPTION
To test:

- `npx create-next-app@latest next-app`
  - Opt in to using the `app/` dir
- Add `export const config = { runtime: "edge" };` to `app/api/hello/route.ts` and `export const config = { runtime: "experimental-edge" };` to `app/page.tsx`
- `npx https://prerelease-registry.devprod.cloudflare.dev/next-on-pages/runs/4451651690/npm-package-next-on-pages-115`
- `npx wrangler@latest pages dev .vercel/output/static --compatibility-flag=nodejs_compat`