### PR TITLE
rename beta-release workflow

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Beta Release
 
 on:
   push:


### PR DESCRIPTION
Minor, just to distinguish the workflow on github:
![Screenshot 2023-03-20 at 12 40 51](https://user-images.githubusercontent.com/61631103/226342287-92f60d27-174c-49da-8ff3-d15bed9666a1.png)