### PR TITLE
feat: remove private/telemetry files from the build output

### DIFF
--- a/.changeset/short-kiwis-train.md
+++ b/.changeset/short-kiwis-train.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Remove private/telemetry files from the build output.

--- a/src/buildApplication/buildApplication.ts
+++ b/src/buildApplication/buildApplication.ts
@@ -9,7 +9,7 @@ import { getNextJsConfigs } from './nextJsConfigs';
 import { getVercelConfig } from './getVercelConfig';
 import { buildWorkerFile } from './buildWorkerFile';
 import { generateFunctionsMap } from './generateFunctionsMap';
-import { buildVercelOutput } from './buildVercelOutput';
+import { buildVercelOutput, purgePrivateFiles } from './buildVercelOutput';
 import { buildMetadataFiles } from './buildMetadataFiles';
 import { validateDir } from '../utils';
 
@@ -25,6 +25,8 @@ export async function buildApplication({
 	if (!skipBuild) {
 		await buildVercelOutput();
 	}
+
+	await purgePrivateFiles();
 
 	await prepareAndBuildWorker({ experimentalMinify });
 	await buildMetadataFiles();

--- a/src/buildApplication/buildApplication.ts
+++ b/src/buildApplication/buildApplication.ts
@@ -9,7 +9,10 @@ import { getNextJsConfigs } from './nextJsConfigs';
 import { getVercelConfig } from './getVercelConfig';
 import { buildWorkerFile } from './buildWorkerFile';
 import { generateFunctionsMap } from './generateFunctionsMap';
-import { buildVercelOutput, purgePrivateFiles } from './buildVercelOutput';
+import {
+	buildVercelOutput,
+	deleteNextTelemetryFiles,
+} from './buildVercelOutput';
 import { buildMetadataFiles } from './buildMetadataFiles';
 import { validateDir } from '../utils';
 
@@ -26,7 +29,7 @@ export async function buildApplication({
 		await buildVercelOutput();
 	}
 
-	await purgePrivateFiles();
+	await deleteNextTelemetryFiles();
 
 	await prepareAndBuildWorker({ experimentalMinify });
 	await buildMetadataFiles();

--- a/src/buildApplication/buildVercelOutput.ts
+++ b/src/buildApplication/buildVercelOutput.ts
@@ -1,7 +1,8 @@
-import { writeFile, mkdir } from 'fs/promises';
+import { writeFile, mkdir, rm, readdir } from 'fs/promises';
 import { spawn } from 'child_process';
+import { join, resolve } from 'path';
 import { cliError, cliLog } from '../cli';
-import { validateFile } from '../utils';
+import { validateDir, validateFile } from '../utils';
 
 /**
  * Builds the Next.js output via the Vercel CLI
@@ -59,4 +60,25 @@ async function runVercelBuild(): Promise<void> {
 			}
 		});
 	});
+}
+
+/**
+ * Vercel and Next.js generate *private* files for telemetry purposes that are accessible as static assets (`.vercel/output/static/_next/__private/...`).
+ *
+ * The routing system for the build output *should* prevent these files from being accessible, but if someone were to exclude all static assets in an `_routes.json` file, they would be accessible.
+ *
+ * We do not need these files, nor do we want to run the risk of them being available. Therefore, we should purge them instead of uploading them to Cloudflare Pages.
+ */
+export async function purgePrivateFiles(): Promise<void> {
+	const nextDir = resolve('.vercel/output/static/_next');
+	const privateDir = join(nextDir, '__private');
+
+	if (await validateDir(privateDir)) {
+		await rm(privateDir, { recursive: true, force: true });
+
+		// Remove the `_next` directory if it's now empty
+		if ((await readdir(nextDir)).length === 0) {
+			await rm(nextDir, { recursive: true, force: true });
+		}
+	}
 }


### PR DESCRIPTION
Vercel and Next.js generate *private* files for telemetry purposes that are accessible as static assets.

`.vercel/output/static/_next/__private/trace` includes a full output of all info accrued. It also has full path names, which may pose security concerns if accessible (depending on where you are building).

While the new routing system *should* prevent these files from being accessible (if they have a record in the outputted config), they would still be accessible if someone modified an `_routes.json` file to exclude them from invocations.

We do not need these files, nor do we want to run the risk of them being available. Therefore, we should purge them instead of letting them be uploaded to Cloudflare Pages.