### PR TITLE
add next-on-pages version to CLI

### DIFF
--- a/.changeset/famous-ravens-pump.md
+++ b/.changeset/famous-ravens-pump.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+show the CLI version and also add the --version flag

--- a/src/buildApplication/buildMetadataFiles.ts
+++ b/src/buildApplication/buildMetadataFiles.ts
@@ -1,5 +1,5 @@
 import { writeFile } from 'fs/promises';
-import { version as nextOnPagesVersion } from '../../package.json';
+import { nextOnPagesVersion } from '../utils';
 
 /**
  * Builds metadata files needed for the worker to correctly run.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ export type CliOptions = {
 	watch: boolean;
 	skipBuild: boolean;
 	experimentalMinify: boolean;
+	version: boolean;
 };
 
 /**
@@ -20,6 +21,7 @@ export function getCliOptions(): CliOptions {
 		watch: process.argv.includes('--watch'),
 		skipBuild: process.argv.includes('--skip-build'),
 		experimentalMinify: process.argv.includes('--experimental-minify'),
+		version: process.argv.includes('--version'),
 	};
 }
 
@@ -35,6 +37,8 @@ export function printCliHelpMessage(): void {
 		Options:
 
 		--help:                Shows this help message
+
+		--version:             Shows the version of the package
 
 		--skip-build:          Doesn't run 'vercel build' automatically
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { watch } from 'chokidar';
 import pLimit from 'p-limit';
 import { cliLog, CliOptions, getCliOptions, printCliHelpMessage } from './cli';
 import { buildApplication } from './buildApplication';
+import { nextOnPagesVersion } from './utils';
 
 const limit = pLimit(1);
 
@@ -9,14 +10,18 @@ const cliOptions = getCliOptions();
 runNextOnPages(cliOptions);
 
 function runNextOnPages(options: CliOptions): void {
-	cliLog('@cloudflare/next-on-pages CLI');
+	if (options.version) {
+		// eslint-disable-next-line no-console -- for the version lets simply print it plainly
+		console.log(nextOnPagesVersion);
+		return;
+	}
+
+	cliLog(`@cloudflare/next-on-pages CLI v.${nextOnPagesVersion}`);
 
 	if (options.help) {
 		printCliHelpMessage();
 		return;
 	}
-
-	runBuild(options);
 
 	if (options.watch) {
 		setWatchMode(() => runBuild(options));

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './fs';
+export * from './version';

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,4 @@
+import { version } from '../../package.json';
+
+/** Current version of the @cloudflare/next-on-pages package */
+export const nextOnPagesVersion = version;


### PR DESCRIPTION
Adding the next-on-pages version to the CLI messages, I think it's going to be convenient for two reasons:
 - if we switch between different versions for example for testing things this can help double checking what the current version is
 - when people open issues and provide the CLI output the version might get included which would be helpful
 
Results:
![Screenshot at 2023-04-02 17-38-02](https://user-images.githubusercontent.com/61631103/229366642-8d0c5268-2391-4598-a93a-eaf8ab1a9c77.png)

![Screenshot at 2023-04-02 17-38-26](https://user-images.githubusercontent.com/61631103/229366659-95e81d29-1258-44c1-bbd4-5156110b9881.png)