### PR TITLE
Support utilizing the package manager used in the project

### DIFF
--- a/.changeset/nice-eyes-flash.md
+++ b/.changeset/nice-eyes-flash.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Added support to utilize the package manager used in the project

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
 	"name": "@cloudflare/next-on-pages",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cloudflare/next-on-pages",
-			"version": "0.5.0",
+			"version": "0.6.0",
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"astring": "^1.8.4",
 				"chokidar": "^3.5.3",
 				"cookie": "^0.5.0",
 				"esbuild": "^0.15.3",
+				"js-yaml": "^4.1.0",
 				"zod": "^3.21.4",
 				"zodcli": "^0.0.4"
 			},
@@ -23,6 +24,7 @@
 				"@changesets/cli": "^2.26.0",
 				"@cloudflare/workers-types": "^3.14.1",
 				"@types/cookie": "^0.5.1",
+				"@types/js-yaml": "^4.0.5",
 				"@typescript-eslint/eslint-plugin": "^5.54.1",
 				"@typescript-eslint/parser": "^5.54.1",
 				"dedent-tabs": "^0.10.3",
@@ -583,6 +585,28 @@
 				"js-yaml": "^3.13.1"
 			}
 		},
+		"node_modules/@changesets/parse/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/@changesets/parse/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/@changesets/pre": {
 			"version": "1.0.14",
 			"resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
@@ -771,24 +795,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@eslint/eslintrc/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
-		},
-		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
@@ -1049,6 +1055,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/@types/js-yaml": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+			"integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+			"dev": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
@@ -1993,13 +2005,9 @@
 			"peer": true
 		},
 		"node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -3327,12 +3335,6 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/eslint/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
-		},
 		"node_modules/eslint/node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3385,18 +3387,6 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/eslint/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/eslint/node_modules/locate-path": {
@@ -4586,13 +4576,11 @@
 			"dev": true
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "^2.0.1"
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
@@ -4712,6 +4700,28 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/load-yaml-file/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/load-yaml-file/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/local-pkg": {
@@ -5746,6 +5756,28 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/read-yaml-file/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/read-yaml-file/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -7597,6 +7629,27 @@
 			"requires": {
 				"@changesets/types": "^5.2.1",
 				"js-yaml": "^3.13.1"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@changesets/pre": {
@@ -7755,21 +7808,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"argparse": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-					"dev": true,
-					"requires": {
-						"argparse": "^2.0.1"
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7986,6 +8024,12 @@
 					"dev": true
 				}
 			}
+		},
+		"@types/js-yaml": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+			"integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+			"dev": true
 		},
 		"@types/json-schema": {
 			"version": "7.0.11",
@@ -8591,13 +8635,9 @@
 			"peer": true
 		},
 		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"array-union": {
 			"version": "2.1.0",
@@ -9477,12 +9517,6 @@
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"argparse": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-					"dev": true
-				},
 				"cross-spawn": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -9517,15 +9551,6 @@
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.3"
-					}
-				},
-				"js-yaml": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-					"dev": true,
-					"requires": {
-						"argparse": "^2.0.1"
 					}
 				},
 				"locate-path": {
@@ -10410,13 +10435,11 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "^2.0.1"
 			}
 		},
 		"json-buffer": {
@@ -10518,6 +10541,27 @@
 				"js-yaml": "^3.13.0",
 				"pify": "^4.0.1",
 				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				}
 			}
 		},
 		"local-pkg": {
@@ -11246,6 +11290,27 @@
 				"js-yaml": "^3.6.1",
 				"pify": "^4.0.1",
 				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				}
 			}
 		},
 		"readable-stream": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"chokidar": "^3.5.3",
 		"cookie": "^0.5.0",
 		"esbuild": "^0.15.3",
+		"js-yaml": "^4.1.0",
 		"zod": "^3.21.4",
 		"zodcli": "^0.0.4"
 	},
@@ -36,6 +37,7 @@
 		"@changesets/cli": "^2.26.0",
 		"@cloudflare/workers-types": "^3.14.1",
 		"@types/cookie": "^0.5.1",
+		"@types/js-yaml": "^4.0.5",
 		"@typescript-eslint/eslint-plugin": "^5.54.1",
 		"@typescript-eslint/parser": "^5.54.1",
 		"dedent-tabs": "^0.10.3",

--- a/src/buildApplication/buildApplication.ts
+++ b/src/buildApplication/buildApplication.ts
@@ -25,9 +25,17 @@ export async function buildApplication({
 	skipBuild,
 	experimentalMinify,
 }: Pick<CliOptions, 'skipBuild' | 'experimentalMinify'>) {
+	let buildSuccess = true;
 	if (!skipBuild) {
-		await buildVercelOutput();
+		try {
+			await buildVercelOutput();
+		} catch (err) {
+			cliError(err.message);
+			buildSuccess = false;
+		}
 	}
+
+	if (!buildSuccess) return;
 
 	await deleteNextTelemetryFiles();
 

--- a/src/buildApplication/checkPackageManager.ts
+++ b/src/buildApplication/checkPackageManager.ts
@@ -1,0 +1,50 @@
+import YAML from 'js-yaml';
+import { spawn } from 'child_process';
+import { readFile } from 'fs/promises';
+import { validateFile } from '../utils';
+import { cliError } from '../cli';
+
+export async function checkPackageManager() {
+	const userAgent = process.env.npm_config_user_agent;
+
+	const hasYarnLock = await validateFile('yarn.lock');
+	const hasPnpmLock = await validateFile('pnpm-lock.yaml');
+
+	if ((userAgent && userAgent.startsWith('pnpm')) || hasPnpmLock) return 'pnpm';
+
+	if ((userAgent && userAgent.startsWith('yarn')) || hasYarnLock) {
+		const yarn = process.platform === 'win32' ? 'yarn.cmd' : 'yarn';
+		const getYarnV = spawn(yarn, ['-v']);
+		let yarnV = '';
+		getYarnV.stdout.on('data', data => {
+			yarnV = `${data}`.trimEnd();
+		});
+		getYarnV.stderr.on('data', data => {
+			cliError(data);
+		});
+		await new Promise((resolve, reject) => {
+			getYarnV.on('close', code => {
+				if (code === 0) {
+					resolve(null);
+				} else {
+					reject();
+				}
+			});
+		});
+		if (!yarnV.startsWith('1.')) {
+			await validateFile('.yarnrc.yml');
+			const yarnYAML = YAML.load(await readFile('.yarnrc.yml', 'utf-8')) as {
+				nodeLinker: 'node-modules' | string;
+			};
+			if (yarnYAML.nodeLinker !== 'node-modules')
+				throw new Error(`
+				Next-On-Pages doesn't support Plug'n'Play features from yarn berry.
+
+				If you want to use Next-On-Pages with yarn berry,
+				please add "nodeLinker: node-modules" to your .yarnrc.yml
+				`);
+			return 'yarn (berry)';
+		} else return 'yarn (classic)';
+	}
+	return 'npm';
+}


### PR DESCRIPTION
This pr is created to add support for next-on-pages to utilize the package manager used in the project,
if user using:
- npm - use npx to build as before
- pnpm - use pnpx to build
- yarn (classic) - install vercel first(since yarn classic doesn't have dlx) and build
- yarn (berry) - use yarn dlx to build
> Only allow to run with yarn berry with the nodeLinker was set to node-modules, because vercel doesn't support Plug'n'Play

This pr is backward compatible for the next-on-pages projects which ware created before.
