### PR TITLE
feat: new routing system build time changes

### DIFF
--- a/.changeset/spotty-cows-add.md
+++ b/.changeset/spotty-cows-add.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+New routing system build time processing + integration with worker script.

--- a/src/buildApplication/generateFunctionsMap.ts
+++ b/src/buildApplication/generateFunctionsMap.ts
@@ -4,12 +4,14 @@ import { dirname, join, relative } from 'path';
 import { parse, Node } from 'acorn';
 import { generate } from 'astring';
 import {
+	formatRoutePath,
 	normalizePath,
 	readJsonFile,
+	stripIndexRoute,
 	validateDir,
 	validateFile,
 } from '../utils';
-import { cliError, CliOptions } from '../cli';
+import { cliError, CliOptions, cliWarn } from '../cli';
 import { tmpdir } from 'os';
 
 /**
@@ -27,10 +29,9 @@ import { tmpdir } from 'os';
 export async function generateFunctionsMap(
 	functionsDir: string,
 	experimentalMinify: CliOptions['experimentalMinify']
-): Promise<{
-	functionsMap: Map<string, string>;
-	invalidFunctions: Set<string>;
-}> {
+): Promise<
+	Pick<DirectoryProcessingResults, 'functionsMap' | 'invalidFunctions'>
+> {
 	const processingSetup = {
 		functionsDir,
 		tmpFunctionsDir: join(tmpdir(), Math.random().toString(36).slice(2)),
@@ -43,6 +44,8 @@ export async function generateFunctionsMap(
 		functionsDir
 	);
 
+	await checkInvalidFunctions(processingResults);
+
 	if (experimentalMinify) {
 		await buildWebpackChunkFiles(
 			processingResults.webpackChunks,
@@ -51,6 +54,39 @@ export async function generateFunctionsMap(
 	}
 
 	return processingResults;
+}
+
+/**
+ * Process the invalid functions and check whether and valid function was created in the functions
+ * map to override it.
+ *
+ * The build output sometimes generates invalid functions at the root, while still creating the
+ * valid functions. With the base path and route groups, it might create the valid edge function
+ * inside a folder for the route group, but create an invalid one that maps to the same path
+ * at the root.
+ *
+ * When we process the directory, we might add the valid function to the map before we process the
+ * invalid one, so we need to check if the invalid one was added to the map and remove it from the
+ * set if it was.
+ *
+ * @param processingResults Object containing the results of processing a directory.
+ */
+async function checkInvalidFunctions({
+	functionsMap,
+	invalidFunctions,
+}: DirectoryProcessingResults): Promise<void> {
+	if (invalidFunctions.size > 0) {
+		for (const rawPath of invalidFunctions) {
+			const formattedPath = formatRoutePath(rawPath);
+
+			if (
+				functionsMap.has(formattedPath) ||
+				functionsMap.has(stripIndexRoute(formattedPath))
+			) {
+				invalidFunctions.delete(rawPath);
+			}
+		}
+	}
 }
 
 async function processDirectoryRecursively(
@@ -117,8 +153,25 @@ async function processFuncDirectory(
 		};
 	}
 
+	// There are instances where the build output will generate an uncompiled `middleware.js` file that is used as the entrypoint.
+	// This file is not able to be used as it is uncompiled, so we try and use the compiled `index.js` if it exists.
+	let isMiddleware = false;
+	if (functionConfig.entrypoint === 'middleware.js') {
+		isMiddleware = true;
+		functionConfig.entrypoint = 'index.js';
+	}
+
 	const functionFile = join(filepath, functionConfig.entrypoint);
 	if (!(await validateFile(functionFile))) {
+		if (isMiddleware) {
+			// We sometimes encounter an uncompiled `middleware.js` with no compiled `index.js` outside of a base path.
+			// Outside the base path, it should not be utilised, so it should be safe to ignore the function.
+			cliWarn(
+				`Detected an invalid middleware function for ${relativePath}. Skipping...`
+			);
+			return {};
+		}
+
 		return {
 			invalidFunctions: new Set([file]),
 		};
@@ -143,12 +196,15 @@ async function processFuncDirectory(
 	await mkdir(dirname(newFilePath), { recursive: true });
 	await writeFile(newFilePath, contents);
 
-	functionsMap.set(
-		normalizePath(
-			relative(setup.functionsDir, filepath).slice(0, -'.func'.length)
-		),
-		normalizePath(newFilePath)
-	);
+	const formattedPathName = formatRoutePath(relativePath);
+	const normalizedFilePath = normalizePath(newFilePath);
+
+	functionsMap.set(formattedPathName, normalizedFilePath);
+
+	if (formattedPathName.endsWith('/index')) {
+		// strip `/index` from the path name as the build output config doesn't rewrite `/index` to `/`
+		functionsMap.set(stripIndexRoute(formattedPathName), normalizedFilePath);
+	}
 
 	return {
 		functionsMap,

--- a/src/buildApplication/getVercelConfig.ts
+++ b/src/buildApplication/getVercelConfig.ts
@@ -25,3 +25,32 @@ export async function getVercelConfig(): Promise<VercelConfig> {
 
 	return config;
 }
+
+export function processVercelConfig(
+	config: VercelConfig
+): ProcessedVercelConfig {
+	const processedConfig: ProcessedVercelConfig = {
+		...config,
+		routes: {
+			none: [],
+			filesystem: [],
+			miss: [],
+			rewrite: [],
+			resource: [],
+			hit: [],
+			error: [],
+		},
+	};
+
+	let currentPhase: VercelHandleValue | 'none' = 'none';
+	for (const route of config.routes) {
+		if ('handle' in route) {
+			currentPhase = route.handle;
+			continue;
+		}
+
+		processedConfig.routes[currentPhase].push(route);
+	}
+
+	return processedConfig;
+}

--- a/src/buildApplication/middlewareManifest.ts
+++ b/src/buildApplication/middlewareManifest.ts
@@ -4,7 +4,10 @@
  *  should be refactored to use .vercel/output instead as soon as possible
  */
 
-import { readJsonFile } from '../utils';
+// NOTE: This file and the corresponding logic will be removed in the new routing system.
+
+import { readJsonFile, stripIndexRoute, stripRouteGroups } from '../utils';
+import type { NextJsConfigs } from './nextJsConfigs';
 
 export type EdgeFunctionDefinition = {
 	name: string;
@@ -31,7 +34,8 @@ export type MiddlewareManifestData = Awaited<
  * gets the parsed middleware manifest and validates it against the existing functions map.
  */
 export async function getParsedMiddlewareManifest(
-	functionsMap: Map<string, string>
+	functionsMap: Map<string, string>,
+	{ basePath }: NextJsConfigs
 ) {
 	// Annoying that we don't get this from the `.vercel` directory.
 	// Maybe we eventually just construct something similar from the `.vercel/output/functions` directory with the same magic filename/precendence rules?
@@ -42,12 +46,13 @@ export async function getParsedMiddlewareManifest(
 		throw new Error('Could not read the functions manifest.');
 	}
 
-	return parseMiddlewareManifest(middlewareManifest, functionsMap);
+	return parseMiddlewareManifest(middlewareManifest, functionsMap, basePath);
 }
 
 export function parseMiddlewareManifest(
 	middlewareManifest: MiddlewareManifest,
-	functionsMap: Map<string, string>
+	functionsMap: Map<string, string>,
+	basePath?: string
 ) {
 	if (middlewareManifest.version !== 2) {
 		throw new Error(
@@ -74,9 +79,12 @@ export function parseMiddlewareManifest(
 	const functionsEntries = Object.values(middlewareManifest.functions);
 
 	for (const [name, filepath] of functionsMap) {
+		// the .vc-config name includes the basePath, so we need to strip it for matching in the middleware manifest.
+		const fileName = (basePath ? name.replace(basePath, '') : name).slice(1);
+
 		if (
 			middlewareEntries.length > 0 &&
-			(name === 'middleware' || name === 'src/middleware')
+			(fileName === 'middleware' || fileName === 'src/middleware')
 		) {
 			for (const entry of middlewareEntries) {
 				if (entry?.name === 'middleware' || entry?.name === 'src/middleware') {
@@ -86,8 +94,16 @@ export function parseMiddlewareManifest(
 		}
 
 		for (const entry of functionsEntries) {
-			if (matchFunctionEntry(entry.name, name)) {
+			if (matchFunctionEntry(stripRouteGroups(entry.name), fileName)) {
 				hydratedFunctions.set(name, { matchers: entry.matchers, filepath });
+
+				// NOTE: Temporary to account for `/index` routes.
+				if (stripIndexRoute(name) !== name) {
+					hydratedFunctions.set(stripIndexRoute(name), {
+						matchers: entry.matchers,
+						filepath,
+					});
+				}
 			}
 		}
 	}

--- a/src/buildApplication/nextJsConfigs/getBasePath.ts
+++ b/src/buildApplication/nextJsConfigs/getBasePath.ts
@@ -1,3 +1,5 @@
+// NOTE: This file and the corresponding logic will be removed in the new routing system.
+
 import { cliWarn } from '../../cli';
 import { readJsonFile } from '../../utils';
 

--- a/src/buildApplication/nextJsConfigs/index.ts
+++ b/src/buildApplication/nextJsConfigs/index.ts
@@ -1,3 +1,5 @@
+// NOTE: This file and the corresponding logic will be removed in the new routing system.
+
 import { getBasePath } from './getBasePath';
 
 export type NextJsConfigs = {

--- a/src/buildApplication/processVercelOutput.ts
+++ b/src/buildApplication/processVercelOutput.ts
@@ -1,0 +1,126 @@
+import { resolve } from 'path';
+import {
+	addLeadingSlash,
+	normalizePath,
+	readPathsRecursively,
+	validateDir,
+} from '../utils';
+import { cliLog, cliWarn } from '../cli';
+import type { MiddlewareManifestData } from './middlewareManifest';
+import { processVercelConfig } from './getVercelConfig';
+
+/**
+ * Extract a list of static assets from the Vercel build output.
+ *
+ * @returns List of static asset paths.
+ */
+export async function getVercelStaticAssets(): Promise<string[]> {
+	const dir = resolve('.vercel/output/static');
+	if (!(await validateDir(dir))) {
+		cliLog('No static assets detected.');
+		return [];
+	}
+
+	return (await readPathsRecursively(dir)).map(file =>
+		normalizePath(file.replace(dir, ''))
+	);
+}
+
+export type ProcessedVercelOutput = {
+	vercelConfig: ProcessedVercelConfig;
+	functionsMap: ProcessedVercelBuildOutput;
+};
+
+/**
+ * Take the static assets and functions that are read from the file system and turn them into a map
+ * that can be consumed by the routing system.
+ *
+ * @param config Vercel build output config.
+ * @param staticAssets List of static asset paths from the file system.
+ * @param functionsMap Map of functions from the file system.
+ * @returns Processed Vercel build output map.
+ */
+export function processVercelOutput(
+	config: VercelConfig,
+	staticAssets: string[],
+	{ hydratedMiddleware, hydratedFunctions }: MiddlewareManifestData
+): ProcessedVercelOutput {
+	const processedConfig = processVercelConfig(config);
+
+	const functionsMap = new Map<string, BuildOutputItem>(
+		staticAssets.map(path => [path, { type: 'static' }])
+	);
+
+	// NOTE: The middleware manifest output is used temporarily to match routes + dynamic args. It will be replaced with the regular `functionsMap` in the final routing system.
+	hydratedFunctions.forEach(({ matchers, filepath }, key) => {
+		functionsMap.set(key, {
+			type: 'function',
+			entrypoint: filepath,
+			// NOTE: Usage of matchers will be removed in the final routing system.
+			matchers,
+		});
+	});
+	hydratedMiddleware.forEach(({ matchers, filepath }, key) => {
+		functionsMap.set(key, {
+			type: 'function',
+			entrypoint: filepath,
+			// NOTE: Usage of matchers will be removed in the final routing system.
+			matchers,
+		});
+	});
+
+	rewriteMiddlewarePaths(
+		functionsMap,
+		collectMiddlewarePaths(processedConfig.routes.none)
+	);
+
+	return {
+		vercelConfig: processedConfig,
+		functionsMap,
+	};
+}
+
+/**
+ * Collect all middleware paths from the Vercel build output config.
+ *
+ * @param routes Processed routes from the Vercel build output config.
+ * @returns Set of middleware paths.
+ */
+function collectMiddlewarePaths(routes: VercelSource[]): Set<string> {
+	const paths = new Set<string>();
+
+	for (const route of routes) {
+		if ('middlewarePath' in route && !!route.middlewarePath) {
+			paths.add(route.middlewarePath);
+		}
+	}
+
+	return paths;
+}
+
+/**
+ * Rewrite middleware paths in the functions map to match the build output config.
+ *
+ * Request path names will no longer accidently match middleware functions as the leading slash is
+ * removed from the path name for middleware in the build output config.
+ *
+ * @param functionsMap Map of path names to function entries.
+ * @param middlewarePaths Set of middleware paths.
+ */
+function rewriteMiddlewarePaths(
+	functionsMap: Map<string, BuildOutputItem>,
+	middlewarePaths: Set<string>
+): void {
+	for (const middlewarePath of middlewarePaths) {
+		const withLeadingSlash = addLeadingSlash(middlewarePath);
+		const entry = functionsMap.get(withLeadingSlash);
+
+		if (!entry || entry.type !== 'function') {
+			cliWarn(`Middleware path '${middlewarePath}' does not have a function.`);
+			continue;
+		}
+
+		functionsMap.set(middlewarePath, { ...entry, type: 'middleware' });
+		functionsMap.delete(withLeadingSlash);
+	}
+}

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,4 +1,5 @@
-import { readFile, stat } from 'fs/promises';
+import { readdir, readFile, stat } from 'fs/promises';
+import { resolve } from 'path';
 
 /**
  * Convert paths with backslashes to normalized paths with forward slashes.
@@ -87,4 +88,26 @@ export function validateFile(path: string) {
  */
 export function validateDir(path: string) {
 	return validatePathType(path, 'directory');
+}
+
+/**
+ * Recursively reads all file paths in a directory.
+ *
+ * @param dir Directory to recursively read from.
+ * @returns Array of all paths for all files in a directory.
+ */
+export async function readPathsRecursively(dir: string): Promise<string[]> {
+	const files = await readdir(dir);
+
+	const paths = await Promise.all(
+		files.map(async file => {
+			const path = resolve(dir, file);
+
+			return (await validateDir(path))
+				? await readPathsRecursively(path)
+				: [path];
+		})
+	);
+
+	return paths.flat();
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './fs';
 export * from './version';
 export * from './getSpawnCommand';
+export * from './routing';

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -1,0 +1,101 @@
+import { normalizePath } from './fs';
+
+/**
+ * Strip route groups from a path name.
+ *
+ * The build output config does not rewrite requests to route groups, so we need to strip route
+ * groups from the path name for file system matching.
+ *
+ * @example
+ * ```ts
+ * stripRouteGroups('(route-group)/path') // '/path'
+ * stripRouteGroups('/path/(route-group)/name') // '/path/name'
+ * stripRouteGroups('/path/name') // '/path/name'
+ * ```
+ *
+ * @param path Path name to strip route groups from.
+ * @returns Path name with route groups stripped.
+ */
+export function stripRouteGroups(path: string) {
+	return path.replace(/\/\(([^)]+)\)/g, '');
+}
+
+/**
+ * Strip `/index` from a path name.
+ *
+ * The build output config does not rewrite `/` to `/index`, so we need to strip `/index` from the
+ * path name for request matching.
+ *
+ * @example
+ * ```ts
+ * stripIndexRoute('/index') // '/'
+ * stripIndexRoute('/path/index') // '/path'
+ * stripIndexRoute('/path') // '/path'
+ * ```
+ *
+ * @param path Path name to strip `/index` from.
+ * @returns Path name with `/index` stripped.
+ */
+export function stripIndexRoute(path: string) {
+	// add leading slash back if it is stripped when `/index` is removed
+	return addLeadingSlash(path.replace(/\/index$/, ''));
+}
+
+/**
+ * Add a leading slash to a path name if it doesn't already have one.
+ *
+ * Used to ensure that the path name starts with a `/` for matching in the routing system.
+ *
+ * @example
+ * ```ts
+ * addLeadingSlash('path') // '/path'
+ * addLeadingSlash('/path') // '/path'
+ * ```
+ *
+ * @param path Path name to add a leading slash to.
+ * @returns Path name with a leading slash added.
+ */
+export function addLeadingSlash(path: string) {
+	return path.startsWith('/') ? path : `/${path}`;
+}
+
+/**
+ * Strip the `.func` extension from a path name.
+ *
+ * @example
+ * ```ts
+ * stripFuncExtension('path.func') // 'path'
+ * stripFuncExtension('path') // 'path'
+ * ```
+ *
+ * @param path Path name to strip the `.func` extension from.
+ * @returns Path name with the `.func` extension stripped.
+ */
+export function stripFuncExtension(path: string) {
+	return path.replace(/\.func$/, '');
+}
+
+/**
+ * Format a route's path name for matching in the routing system.
+ *
+ * - Strip the `.func` extension.
+ * - Normalize the path name.
+ * - Strip route groups (the build output config does not rewrite requests to route groups).
+ * - Add a leading slash.
+ *
+ * @example
+ * ```ts
+ * formatRoutePath('\\path') // '/path'
+ * formatRoutePath('path') // '/path'
+ * formatRoutePath('/(group)/path') // '/path'
+ * formatRoutePath('/path.func') // '/path'
+ * ```
+ *
+ * @param path Route path name to format.
+ * @returns Formatted route path name.
+ */
+export function formatRoutePath(path: string) {
+	return addLeadingSlash(
+		stripRouteGroups(addLeadingSlash(normalizePath(stripFuncExtension(path))))
+	);
+}

--- a/templates/_worker.js/index.ts
+++ b/templates/_worker.js/index.ts
@@ -1,44 +1,7 @@
 import { parse } from 'cookie';
+import { adjustRequestForVercel, hasField } from './utils';
 
-const hasField = (
-	{
-		request,
-		url,
-		cookies,
-	}: { request: Request; url: URL; cookies: Record<string, string> },
-	has: VercelSource['has'][0]
-) => {
-	switch (has.type) {
-		case 'host': {
-			// TODO: URL host, hostname or HTTP Header host?
-			return url.host === has.value;
-		}
-		case 'header': {
-			if (has.value !== undefined) {
-				return request.headers.get(has.key)?.match(has.value);
-			}
-
-			return request.headers.has(has.key);
-		}
-		case 'cookie': {
-			const cookie = cookies[has.key];
-
-			if (has.value !== undefined) {
-				return cookie?.match(has.value);
-			}
-
-			return cookie !== undefined;
-		}
-		case 'query': {
-			if (has.value !== undefined) {
-				return url.searchParams.get(has.key)?.match(has.value);
-			}
-
-			return url.searchParams.has(has.key);
-		}
-	}
-};
-
+// NOTE: Will be replaced in the new routing system.
 export const routesMatcher = (
 	{ request }: { request: Request },
 	routes?: VercelConfig['routes']
@@ -108,24 +71,11 @@ export const routesMatcher = (
 	return matchingRoutes;
 };
 
-type EdgeFunction = {
-	default: (
-		request: Request,
-		context: ExecutionContext
-	) => Response | Promise<Response>;
-};
+declare const __CONFIG__: ProcessedVercelConfig;
 
-type EdgeFunctions = {
-	matchers: { regexp: string }[];
-	entrypoint: Promise<EdgeFunction>;
-}[];
+declare const __BUILD_OUTPUT__: VercelBuildOutput;
 
-declare const __CONFIG__: VercelConfig;
-
-declare const __FUNCTIONS__: EdgeFunctions;
-
-declare const __MIDDLEWARE__: EdgeFunctions;
-
+// NOTE: Will be removed in the new routing system.
 declare const __BASE_PATH__: string;
 
 export default {
@@ -133,17 +83,31 @@ export default {
 		(globalThis.process.env as unknown) = { ...globalThis.process.env, ...env };
 
 		const { pathname } = new URL(request.url);
-		const routes = routesMatcher({ request }, __CONFIG__.routes);
+		// NOTE: Will be removed in the new routing system.
+		// middleware only occur in the `none` routing phase (i.e. before all other phases).
+		const routes = routesMatcher({ request }, __CONFIG__.routes.none);
 
+		// NOTE: Will be removed in the new routing system.
 		for (const route of routes) {
-			if ('middlewarePath' in route && route.middlewarePath in __MIDDLEWARE__) {
-				return await (
-					await __MIDDLEWARE__[route.middlewarePath].entrypoint
-				).default(request, context);
+			if (
+				'middlewarePath' in route &&
+				route.middlewarePath in __BUILD_OUTPUT__
+			) {
+				const item = __BUILD_OUTPUT__[route.middlewarePath];
+
+				if (item.type === 'middleware') {
+					return await (await item.entrypoint).default(request, context);
+				}
 			}
 		}
 
-		for (const { matchers, entrypoint } of Object.values(__FUNCTIONS__)) {
+		// NOTE: Will be replaced in the new routing system.
+		// Filtering for type `function` is temporary while the new routing system is being implemented.
+		for (const { matchers, entrypoint } of Object.values(
+			__BUILD_OUTPUT__
+		).filter(
+			item => item.type === 'function'
+		) as AdjustedBuildOutputFunction[]) {
 			let found = false;
 			for (const matcher of matchers) {
 				if (matcher.regexp) {
@@ -160,10 +124,7 @@ export default {
 
 					const nextJsPathnameMatcher = nextJsPathname.match(regexp);
 
-					if (
-						nextJsPathnameMatcher ||
-						`${nextJsPathname}/page`.replace('//page', '/page').match(regexp)
-					) {
+					if (nextJsPathnameMatcher) {
 						if (nextJsPathnameMatcher?.groups) {
 							const params = Object.entries(nextJsPathnameMatcher.groups);
 							const urlWithParams = new URL(request.url);
@@ -188,23 +149,3 @@ export default {
 		return env.ASSETS.fetch(request);
 	},
 } as ExportedHandler<{ ASSETS: Fetcher }>;
-
-/**
- * Adjusts the request so that it is formatted as if it were provided by Vercel
- *
- * @param request the original request received by the worker
- * @returns the adjusted request to pass to Next
- */
-function adjustRequestForVercel(request: Request): Request {
-	const adjustedHeaders = new Headers(request.headers);
-
-	if (request.cf) {
-		adjustedHeaders.append('x-vercel-ip-city', request.cf.city);
-		adjustedHeaders.append('x-vercel-ip-country', request.cf.country);
-		adjustedHeaders.append('x-vercel-ip-country-region', request.cf.region);
-		adjustedHeaders.append('x-vercel-ip-latitude', request.cf.latitude);
-		adjustedHeaders.append('x-vercel-ip-longitude', request.cf.longitude);
-	}
-
-	return new Request(request, { headers: adjustedHeaders });
-}

--- a/templates/_worker.js/utils/index.ts
+++ b/templates/_worker.js/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './matcher';
+export * from './request';

--- a/templates/_worker.js/utils/matcher.ts
+++ b/templates/_worker.js/utils/matcher.ts
@@ -1,0 +1,39 @@
+// NOTE: Will be refined in the new routing system.
+export const hasField = (
+	{
+		request,
+		url,
+		cookies,
+	}: { request: Request; url: URL; cookies: Record<string, string> },
+	has: VercelSource['has'][0]
+) => {
+	switch (has.type) {
+		case 'host': {
+			// TODO: URL host, hostname or HTTP Header host?
+			return url.host === has.value;
+		}
+		case 'header': {
+			if (has.value !== undefined) {
+				return request.headers.get(has.key)?.match(has.value);
+			}
+
+			return request.headers.has(has.key);
+		}
+		case 'cookie': {
+			const cookie = cookies[has.key];
+
+			if (has.value !== undefined) {
+				return cookie?.match(has.value);
+			}
+
+			return cookie !== undefined;
+		}
+		case 'query': {
+			if (has.value !== undefined) {
+				return url.searchParams.get(has.key)?.match(has.value);
+			}
+
+			return url.searchParams.has(has.key);
+		}
+	}
+};

--- a/templates/_worker.js/utils/request.ts
+++ b/templates/_worker.js/utils/request.ts
@@ -1,0 +1,19 @@
+/**
+ * Adjusts the request so that it is formatted as if it were provided by Vercel
+ *
+ * @param request the original request received by the worker
+ * @returns the adjusted request to pass to Next
+ */
+export function adjustRequestForVercel(request: Request): Request {
+	const adjustedHeaders = new Headers(request.headers);
+
+	if (request.cf) {
+		adjustedHeaders.append('x-vercel-ip-city', request.cf.city);
+		adjustedHeaders.append('x-vercel-ip-country', request.cf.country);
+		adjustedHeaders.append('x-vercel-ip-country-region', request.cf.region);
+		adjustedHeaders.append('x-vercel-ip-latitude', request.cf.latitude);
+		adjustedHeaders.append('x-vercel-ip-longitude', request.cf.longitude);
+	}
+
+	return new Request(request, { headers: adjustedHeaders });
+}

--- a/tests/src/buildApplication/generateFunctionsMap.test.ts
+++ b/tests/src/buildApplication/generateFunctionsMap.test.ts
@@ -7,27 +7,67 @@ beforeAll(() => {
 		return {
 			readFile: async (rawFile: string) => {
 				const file = normalizePath(rawFile);
+				if (
+					/invalidTest\/functions\/middlewarejs.*\/\.vc-config\.json/.test(file)
+				) {
+					return JSON.stringify({
+						runtime: 'edge',
+						entrypoint: 'middleware.js',
+					});
+				}
 				if (/invalidTest\/functions\/index.*\/\.vc-config\.json/.test(file)) {
 					return JSON.stringify({ runtime: 'nodejs', entrypoint: 'index.js' });
 				}
+				if (
+					/validTest\/functions\/middleware.*\/\.vc-config\.json/.test(file)
+				) {
+					return JSON.stringify({
+						name: 'middleware',
+						runtime: 'edge',
+						entrypoint: file.includes('middlewarejs')
+							? 'middleware.js'
+							: 'index.js',
+					});
+				}
 				if (/validTest\/functions\/.*\/\.vc-config\.json/.test(file)) {
-					return JSON.stringify({ runtime: 'edge', entrypoint: 'index.js' });
+					return JSON.stringify({
+						runtime:
+							file.includes('should-be-valid') && !file.includes('is-valid')
+								? 'nodejs'
+								: 'edge',
+						entrypoint: 'index.js',
+					});
 				}
 				return '';
 			},
 			mkdir: async () => null,
 			writeFile: async () => null,
 			stat: async (path: string) => {
+				const invalidFile =
+					path.includes('invalidTest') &&
+					path.includes('middlewarejs') &&
+					path.endsWith('.js');
 				const isFile = path.endsWith('.js') || path.endsWith('.json');
+
 				return {
-					isDirectory: () => !isFile,
-					isFile: () => isFile,
+					isDirectory: () => !invalidFile && !isFile,
+					isFile: () => !invalidFile && isFile,
 				};
 			},
 			readdir: async (rawDir: string) => {
 				const dir = normalizePath(rawDir);
 				if (['validTest/functions', 'invalidTest/functions'].includes(dir)) {
-					return ['api', 'index.func', 'index.rsc.func'];
+					return [
+						'api',
+						'index.func',
+						'index.rsc.func',
+						'middlewarejs.func',
+						'base/middleware.func',
+						'path/(group-1)/to/(group-2)/page.func',
+						'(is-valid)/should-be-valid.func', // valid
+						'should-be-valid.func', // invalid
+						'should-be-valid-alt.func', // invalid
+					];
 				}
 				if (
 					['validTest/functions/api', 'invalidTest/functions/api'].includes(dir)
@@ -50,11 +90,33 @@ describe('generateFunctionsMap', async () => {
 			'validTest/functions',
 			false
 		);
-		expect(invalidFunctions.size).toEqual(0);
-		expect(functionsMap.size).toEqual(3);
-		expect(functionsMap.get('index')).toMatch(/\/index\.func\.js$/);
-		expect(functionsMap.get('index.rsc')).toMatch(/\/index\.rsc\.func\.js$/);
-		expect(functionsMap.get('api/hello')).toMatch(/\/api\/hello\.func\.js$/);
+
+		expect(invalidFunctions.size).toEqual(1);
+		expect(Array.from(invalidFunctions.values())).toEqual([
+			'should-be-valid-alt.func',
+		]);
+
+		expect(functionsMap.size).toEqual(8);
+		// index
+		expect(functionsMap.get('/')).toMatch(/\/index\.func\.js$/);
+		expect(functionsMap.get('/index')).toMatch(/\/index\.func\.js$/);
+		expect(functionsMap.get('/index.rsc')).toMatch(/\/index\.rsc\.func\.js$/);
+		// nested route
+		expect(functionsMap.get('/api/hello')).toMatch(/\/api\/hello\.func\.js$/);
+		// middleware
+		expect(functionsMap.get('/middlewarejs')).toMatch(
+			/\/middlewarejs\.func\.js$/
+		);
+		expect(functionsMap.get('/base/middleware')).toMatch(
+			/\/base\/middleware\.func\.js$/
+		);
+		// route group
+		expect(functionsMap.get('/path/to/page')).toMatch(
+			/\/path\/\(group-1\)\/to\/\(group-2\)\/page\.func\.js$/
+		);
+		expect(functionsMap.get('/should-be-valid')).toMatch(
+			/\(is-valid\)\/should-be-valid\.func\.js$/
+		);
 	});
 
 	// TODO: add tests that also test the functions map with the experimentalMinify flag
@@ -64,9 +126,12 @@ describe('generateFunctionsMap', async () => {
 			'invalidTest/functions',
 			false
 		);
+
+		expect(invalidFunctions.size).toEqual(3);
 		expect(Array.from(invalidFunctions.values())).toEqual([
 			'index.func',
 			'index.rsc.func',
+			'should-be-valid-alt.func',
 		]);
 	});
 });

--- a/tests/src/buildApplication/getVercelConfig.test.ts
+++ b/tests/src/buildApplication/getVercelConfig.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from 'vitest';
+import { processVercelConfig } from '../../../src/buildApplication/getVercelConfig';
+
+describe('processVercelConfig', () => {
+	test('should process the handler phases correctly', () => {
+		const inputtedConfig: VercelConfig = {
+			version: 3,
+			routes: [
+				{ src: '/test-1', dest: '/test-2' },
+				{ handle: 'filesystem' },
+				{ src: '/test-3', dest: '/test-4' },
+				{ handle: 'miss' },
+				{ src: '/test-2', dest: '/test-6' },
+			],
+		};
+
+		expect(processVercelConfig(inputtedConfig)).toEqual({
+			version: 3,
+			routes: {
+				none: [{ src: '/test-1', dest: '/test-2' }],
+				filesystem: [{ src: '/test-3', dest: '/test-4' }],
+				miss: [{ src: '/test-2', dest: '/test-6' }],
+				rewrite: [],
+				resource: [],
+				hit: [],
+				error: [],
+			},
+		});
+	});
+});

--- a/tests/src/buildApplication/middlewareManifest.test.ts
+++ b/tests/src/buildApplication/middlewareManifest.test.ts
@@ -64,41 +64,47 @@ describe('parseMiddlewareManifest', () => {
 		};
 
 		const functionsMap = new Map(
-			['test', '[id]', '1/2/3', 'index', 'test', 'api/hello'].map(fn => [
-				fn,
-				`test/filepath/${fn}`,
-			])
+			['/test', '/[id]', '/1/2/3', '/', '/index', '/test', '/api/hello'].map(
+				fn => [fn, `test/filepath${fn === '/' ? '/index' : fn}`]
+			)
 		);
 
 		const expectedHydratedFunction = new Map([
 			[
-				'test',
+				'/test',
 				{ filepath: 'test/filepath/test', matchers: [{ regexp: 'regexpA' }] },
 			],
 			[
-				'[id]',
+				'/[id]',
 				{ filepath: 'test/filepath/[id]', matchers: [{ regexp: 'regexpB' }] },
 			],
 			[
-				'1/2/3',
+				'/1/2/3',
 				{
 					filepath: 'test/filepath/1/2/3',
 					matchers: [{ regexp: 'regexpC' }],
 				},
 			],
 			[
-				'index',
+				'/index',
 				{
 					filepath: 'test/filepath/index',
 					matchers: [{ regexp: 'regexpD' }],
 				},
 			],
 			[
-				'test',
+				'/',
+				{
+					filepath: 'test/filepath/index',
+					matchers: [{ regexp: 'regexpD' }],
+				},
+			],
+			[
+				'/test',
 				{ filepath: 'test/filepath/test', matchers: [{ regexp: 'regexpE' }] },
 			],
 			[
-				'api/hello',
+				'/api/hello',
 				{
 					filepath: 'test/filepath/api/hello',
 					matchers: [{ regexp: 'regexpF' }],

--- a/tests/src/buildApplication/processVercelOutput.test.ts
+++ b/tests/src/buildApplication/processVercelOutput.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'vitest';
+import { processVercelOutput } from '../../../src/buildApplication/processVercelOutput';
+
+describe('processVercelOutput', () => {
+	test('should process the config and build output correctly', () => {
+		const inputtedConfig: VercelConfig = {
+			version: 3,
+			routes: [
+				{ src: '/test-1', dest: '/test-2' },
+				{ src: '/use-middleware', middlewarePath: 'middleware' },
+				{ handle: 'filesystem' },
+				{ src: '/test-3', dest: '/test-4' },
+				{ handle: 'miss' },
+				{ src: '/test-2', dest: '/test-6' },
+			],
+		};
+
+		const processed = processVercelOutput(
+			inputtedConfig,
+			['/static/test.png'],
+			{
+				hydratedMiddleware: new Map([
+					['/middleware', { filepath: '/middleware/index.js', matchers: [] }],
+				]),
+				hydratedFunctions: new Map([
+					[
+						'/use-middleware',
+						{ filepath: '/use-middleware/index.js', matchers: [] },
+					],
+				]),
+			}
+		);
+
+		expect(processed).toEqual({
+			vercelConfig: {
+				version: 3,
+				routes: {
+					none: [
+						{ src: '/test-1', dest: '/test-2' },
+						{ src: '/use-middleware', middlewarePath: 'middleware' },
+					],
+					filesystem: [{ src: '/test-3', dest: '/test-4' }],
+					miss: [{ src: '/test-2', dest: '/test-6' }],
+					rewrite: [],
+					resource: [],
+					hit: [],
+					error: [],
+				},
+			},
+			functionsMap: new Map([
+				['/static/test.png', { type: 'static' }],
+				[
+					'/use-middleware',
+					{
+						entrypoint: '/use-middleware/index.js',
+						matchers: [],
+						type: 'function',
+					},
+				],
+				[
+					'middleware',
+					{
+						entrypoint: '/middleware/index.js',
+						matchers: [],
+						type: 'middleware',
+					},
+				],
+			]),
+		});
+	});
+});

--- a/vercel.types.d.ts
+++ b/vercel.types.d.ts
@@ -1,3 +1,7 @@
+/**
+ * Types for the Vercel build output configuration file.
+ */
+
 type VercelConfig = {
 	version: 3;
 	routes?: VercelRoute[];
@@ -98,3 +102,52 @@ type VercelOverride = {
 };
 
 type VercelOverrideConfig = Record<string, VercelOverride>;
+
+/**
+ * Types for the processed Vercel build output (config, functions + static assets).
+ */
+
+type ProcessedVercelRoutes = {
+	none: VercelSource[];
+	filesystem: VercelSource[];
+	miss: VercelSource[];
+	rewrite: VercelSource[];
+	resource: VercelSource[];
+	hit: VercelSource[];
+	error: VercelSource[];
+};
+type ProcessedVercelConfig = Override<
+	VercelConfig,
+	'routes',
+	ProcessedVercelRoutes
+>;
+
+type BuildOutputStaticAsset = { type: 'static' };
+type BuildOutputFunction = {
+	type: 'function' | 'middleware';
+	entrypoint: string;
+	// NOTE: Will be removed in the new routing system.
+	matchers: { regexp: string }[];
+};
+
+type BuildOutputItem = BuildOutputFunction | BuildOutputStaticAsset;
+type ProcessedVercelBuildOutput = Map<string, BuildOutputItem>;
+
+type Override<T, K extends keyof T, V> = Omit<T, K> & { [key in K]: V };
+
+type EdgeFunction = {
+	default: (
+		request: Request,
+		context: ExecutionContext
+	) => Response | Promise<Response>;
+};
+
+type AdjustedBuildOutputFunction = Override<
+	BuildOutputFunction,
+	'entrypoint',
+	Promise<EdgeFunction>
+>;
+
+type VercelBuildOutput = {
+	[key: string]: AdjustedBuildOutputFunction | BuildOutputStaticAsset;
+};


### PR DESCRIPTION
This PR is the first in a series of changes for the new routing system 😁. It addresses the build time aspect and does the following.

- New utility functions.
  - Formatting route paths.
    - Stripping `/index` so that file system matching in the new routing system works for requests to `/`.
    - Stripping route groups for matching in the file system in the new routing system as the build output config doesn't rewrite to route groups.
    - Stripping `.func` from path names.
    - Adding leading slashes to path names.
  - Reading path names recursively from the file system.
- Function map generation.
  - Warn for invalid middleware functions that are created outside of a base path as these shouldn't matter.
  - Account for middleware targeting an uncompiled entry when there is a valid compiled version in the same directory.
  - Check invalid functions against the functions map to see if valid ones were added from stripping route groups or `/index`.
  - Tests for new behaviour.
- Middleware manifest.
  - Support for additional function map entry for stripped index routes.
  - Strip the base path to match the middleware manifest.
  - Tests for new behaviour.
- Vercel config.
  - Process the Vercel config into a form that maps handler phase -> source routes.
  - Retrieve static assets from the file system.
  - Collect middleware paths from the build output config.
  - Rewrite the middleware paths into the same structure to match the Vercel config + avoid accidental path name matches in the new routing system.
  - Tests for new behaviour.
- Worker file.
  - Separate the `hasField` and `adjustRequestForVercel` into their own files.
  - Use new processed config and function map for requests.
- Types for processing the Vercel config and build output.

