### PR TITLE
Improve cli logs style

### DIFF
--- a/.changeset/nine-bikes-poke.md
+++ b/.changeset/nine-bikes-poke.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Improve cli logs style

--- a/.changeset/nine-bikes-poke.md
+++ b/.changeset/nine-bikes-poke.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': minor
 ---
 
-Improve cli logs style
+Add colors to cli logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "@cloudflare/next-on-pages",
-	"version": "0.6.0",
+	"version": "0.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cloudflare/next-on-pages",
-			"version": "0.6.0",
+			"version": "0.8.0",
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"astring": "^1.8.4",
+				"chalk": "^5.2.0",
 				"chokidar": "^3.5.3",
 				"cookie": "^0.5.0",
 				"esbuild": "^0.15.3",
@@ -2133,6 +2134,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/boxen/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2288,15 +2305,11 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+			"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
 			"engines": {
-				"node": ">=10"
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
@@ -3341,6 +3354,22 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/eslint/node_modules/cross-spawn": {
@@ -6675,6 +6704,22 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/tty-table/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6796,6 +6841,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/yeoman/update-notifier?sponsor=1"
+			}
+		},
+		"node_modules/update-notifier/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/update-notifier/node_modules/semver": {
@@ -8814,6 +8875,18 @@
 				"type-fest": "^0.20.2",
 				"widest-line": "^3.1.0",
 				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"peer": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				}
 			}
 		},
 		"brace-expansion": {
@@ -8936,13 +9009,9 @@
 			}
 		},
 		"chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"requires": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			}
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+			"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
 		},
 		"chardet": {
 			"version": "0.7.0",
@@ -9608,6 +9677,16 @@
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
 				"cross-spawn": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -12081,6 +12160,18 @@
 				"strip-ansi": "^6.0.0",
 				"wcwidth": "^1.0.1",
 				"yargs": "^17.1.1"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				}
 			}
 		},
 		"type-check": {
@@ -12172,6 +12263,16 @@
 				"xdg-basedir": "^4.0.0"
 			},
 			"dependencies": {
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"peer": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
 				"semver": {
 					"version": "7.3.7",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	"dependencies": {
 		"acorn": "^8.8.0",
 		"astring": "^1.8.4",
+		"chalk": "^5.2.0",
 		"chokidar": "^3.5.3",
 		"cookie": "^0.5.0",
 		"esbuild": "^0.15.3",

--- a/src/buildApplication/buildApplication.ts
+++ b/src/buildApplication/buildApplication.ts
@@ -58,7 +58,7 @@ async function prepareAndBuildWorker(
 		vercelConfig = await getVercelConfig();
 	} catch (e) {
 		if (e instanceof Error) {
-			cliError(e.message, true);
+			cliError(e.message, { showReport: true });
 		}
 		exit(1);
 	}
@@ -95,7 +95,7 @@ async function prepareAndBuildWorker(
 		);
 	} catch (e: unknown) {
 		if (e instanceof Error) {
-			cliError(e.message, true);
+			cliError(e.message, { showReport: true });
 		}
 		exit(1);
 	}

--- a/src/buildApplication/buildVercelOutput.ts
+++ b/src/buildApplication/buildVercelOutput.ts
@@ -24,7 +24,7 @@ export async function buildVercelOutput(): Promise<void> {
 	await generateProjectJsonFileIfNeeded();
 	cliLog('Project is ready');
 	await runVercelBuild(pkgMng);
-	cliSuccess('Building Completed.\n');
+	cliLog('Completed `npx vercel build`.\n');
 }
 
 /**

--- a/src/buildApplication/buildVercelOutput.ts
+++ b/src/buildApplication/buildVercelOutput.ts
@@ -1,7 +1,7 @@
 import { writeFile, mkdir, rm, rmdir } from 'fs/promises';
 import { spawn } from 'child_process';
 import { join, resolve } from 'path';
-import { cliLog, cliSuccess } from '../cli';
+import { cliLog } from '../cli';
 import { validateDir, validateFile } from '../utils';
 import { getCurrentPackageManager } from './getCurrentPackageManager';
 import { PackageManager, getSpawnCommand } from '../utils/getSpawnCommand';

--- a/src/buildApplication/buildVercelOutput.ts
+++ b/src/buildApplication/buildVercelOutput.ts
@@ -1,7 +1,7 @@
 import { writeFile, mkdir, rm, rmdir } from 'fs/promises';
 import { spawn } from 'child_process';
 import { join, resolve } from 'path';
-import { cliError, cliLog } from '../cli';
+import { cliLog, cliSuccess } from '../cli';
 import { validateDir, validateFile } from '../utils';
 import { getCurrentPackageManager } from './getCurrentPackageManager';
 import { PackageManager, getSpawnCommand } from '../utils/getSpawnCommand';
@@ -24,7 +24,7 @@ export async function buildVercelOutput(): Promise<void> {
 	await generateProjectJsonFileIfNeeded();
 	cliLog('Project is ready');
 	await runVercelBuild(pkgMng);
-	cliLog('Building Completed.\n');
+	cliSuccess('Building Completed.\n');
 }
 
 /**
@@ -51,8 +51,12 @@ async function runVercelBuild(pkgMng: PackageManager): Promise<void> {
 
 		const installVercel = spawn(pkgMngCMD, ['add', 'vercel', '-D']);
 
-		installVercel.stdout.on('data', data => cliLog(`\n${data}`, true));
-		installVercel.stderr.on('data', data => cliError(`\n${data}`, false, true));
+		installVercel.stdout.on('data', data =>
+			cliLog(`\n${data}`, { fromVercelCli: true })
+		);
+		installVercel.stderr.on('data', data =>
+			cliLog(`\n${data}`, { fromVercelCli: true })
+		);
 
 		await new Promise((resolve, reject) => {
 			installVercel.on('close', code => {
@@ -75,8 +79,12 @@ async function runVercelBuild(pkgMng: PackageManager): Promise<void> {
 		'build',
 	]);
 
-	vercelBuild.stdout.on('data', data => cliLog(`\n${data}`, true));
-	vercelBuild.stderr.on('data', data => cliError(`\n${data}`, false, true));
+	vercelBuild.stdout.on('data', data =>
+		cliLog(`\n${data}`, { fromVercelCli: true })
+	);
+	vercelBuild.stderr.on('data', data =>
+		cliLog(`\n${data}`, { fromVercelCli: true })
+	);
 
 	await new Promise((resolve, reject) => {
 		vercelBuild.on('close', code => {

--- a/src/buildApplication/buildVercelOutput.ts
+++ b/src/buildApplication/buildVercelOutput.ts
@@ -55,6 +55,9 @@ async function runVercelBuild(pkgMng: PackageManager): Promise<void> {
 			cliLog(`\n${data}`, { fromVercelCli: true })
 		);
 		installVercel.stderr.on('data', data =>
+			// here we use cliLog instead of cliError because the Vercel cli
+			// currently displays non-error messages in stderr
+			// so we just display all Vercel logs as standard logs
 			cliLog(`\n${data}`, { fromVercelCli: true })
 		);
 
@@ -83,6 +86,9 @@ async function runVercelBuild(pkgMng: PackageManager): Promise<void> {
 		cliLog(`\n${data}`, { fromVercelCli: true })
 	);
 	vercelBuild.stderr.on('data', data =>
+		// here we use cliLog instead of cliError because the Vercel cli
+		// currently displays non-error messages in stderr
+		// so we just display all Vercel logs as standard logs
 		cliLog(`\n${data}`, { fromVercelCli: true })
 	);
 

--- a/src/buildApplication/buildWorkerFile.ts
+++ b/src/buildApplication/buildWorkerFile.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'fs/promises';
 import { join } from 'path';
 import { build } from 'esbuild';
 import { tmpdir } from 'os';
-import { cliLog } from '../cli';
+import { cliSuccess } from '../cli';
 import { NextJsConfigs } from './nextJsConfigs';
 import { generateGlobalJs } from './generateGlobalJs';
 import { ProcessedVercelOutput } from './processVercelOutput';
@@ -70,5 +70,5 @@ export async function buildWorkerFile(
 		minify: experimentalMinify,
 	});
 
-	cliLog("Generated '.vercel/output/static/_worker.js'.");
+	cliSuccess("Generated '.vercel/output/static/_worker.js'.");
 }

--- a/src/buildApplication/generateFunctionsMap.ts
+++ b/src/buildApplication/generateFunctionsMap.ts
@@ -304,9 +304,9 @@ function extractWebpackChunks(
 					cliError(
 						`
 							ERROR: Detected a collision with '--experimental-minify'.
-							Try removing the '--experimental-minify' argument.
+							       Try removing the '--experimental-minify' argument.
 						`,
-						{ fromVercelCli: true, spaced: true }
+						{ spaced: true }
 					);
 					exit(1);
 				}

--- a/src/buildApplication/generateFunctionsMap.ts
+++ b/src/buildApplication/generateFunctionsMap.ts
@@ -301,8 +301,13 @@ function extractWebpackChunks(
 				if (
 					existingWebpackChunks.get(key) !== generate(chunkExpression.value)
 				) {
-					cliError("ERROR: Detected a collision with '--experimental-minify'.");
-					cliError("Try removing the '--experimental-minify' argument.", true);
+					cliError(
+						`
+							ERROR: Detected a collision with '--experimental-minify'.
+							Try removing the '--experimental-minify' argument.
+						`,
+						{ fromVercelCli: true, spaced: true }
+					);
 					exit(1);
 				}
 			}

--- a/src/buildApplication/generateGlobalJs.ts
+++ b/src/buildApplication/generateGlobalJs.ts
@@ -26,16 +26,17 @@ function getNodeEnv(): string {
 
 	const nextJsNodeEnvs = Object.values(NextJsNodeEnv);
 	if (!(nextJsNodeEnvs as string[]).includes(processNodeEnv)) {
-		cliWarn('');
-		cliWarn(`
+		cliWarn(
+			`
 			WARNING:
 			    The current value of the environment variable NODE_ENV is "${processNodeEnv}",
 			    but the supported values are: ${nextJsNodeEnvs
 						.map(env => `"${env}"`)
 						.join(', ')}.
 			    See: https://nextjs.org/docs/basic-features/environment-variables.
-		`);
-		cliWarn('');
+		`,
+			{ spaced: true }
+		);
 	}
 
 	return processNodeEnv;

--- a/src/buildApplication/getCurrentPackageManager.ts
+++ b/src/buildApplication/getCurrentPackageManager.ts
@@ -2,7 +2,7 @@ import YAML from 'js-yaml';
 import { spawn } from 'child_process';
 import { readFile } from 'fs/promises';
 import { validateFile, getSpawnCommand, PackageManager } from '../utils';
-import { cliLog } from '../cli';
+import { cliError } from '../cli';
 
 export async function getCurrentPackageManager(): Promise<PackageManager> {
 	const userAgent = process.env.npm_config_user_agent;
@@ -19,7 +19,7 @@ export async function getCurrentPackageManager(): Promise<PackageManager> {
 		getYarnV.stdout.on('data', data => {
 			yarnV = `${data}`.trimEnd();
 		});
-		getYarnV.stderr.on('data', data => cliLog(`\n${data}`));
+		getYarnV.stderr.on('data', data => cliError(`\n${data}`));
 		await new Promise((resolve, reject) => {
 			getYarnV.on('close', code => {
 				if (code === 0) {

--- a/src/buildApplication/getCurrentPackageManager.ts
+++ b/src/buildApplication/getCurrentPackageManager.ts
@@ -2,7 +2,7 @@ import YAML from 'js-yaml';
 import { spawn } from 'child_process';
 import { readFile } from 'fs/promises';
 import { validateFile, getSpawnCommand, PackageManager } from '../utils';
-import { cliError } from '../cli';
+import { cliLog } from '../cli';
 
 export async function getCurrentPackageManager(): Promise<PackageManager> {
 	const userAgent = process.env.npm_config_user_agent;
@@ -19,9 +19,7 @@ export async function getCurrentPackageManager(): Promise<PackageManager> {
 		getYarnV.stdout.on('data', data => {
 			yarnV = `${data}`.trimEnd();
 		});
-		getYarnV.stderr.on('data', data => {
-			cliError(data);
-		});
+		getYarnV.stderr.on('data', data => cliLog(`\n${data}`));
 		await new Promise((resolve, reject) => {
 			getYarnV.on('close', code => {
 				if (code === 0) {

--- a/src/buildApplication/nextJsConfigs/getBasePath.ts
+++ b/src/buildApplication/nextJsConfigs/getBasePath.ts
@@ -26,9 +26,12 @@ export async function getBasePath(): Promise<string | null> {
 
 	if (!routesManifest || routesManifest.version !== 3) {
 		cliWarn(
-			'Warning: Could not read basePath from .next/routes-manifest.json file'
+			`
+			  Warning: Could not read basePath from .next/routes-manifest.json 
+				filefalling back to empty basePath
+			`,
+			{ spaced: true }
 		);
-		cliWarn('falling back to empty basePath');
 		return null;
 	}
 

--- a/src/buildApplication/nextJsConfigs/getBasePath.ts
+++ b/src/buildApplication/nextJsConfigs/getBasePath.ts
@@ -27,8 +27,7 @@ export async function getBasePath(): Promise<string | null> {
 	if (!routesManifest || routesManifest.version !== 3) {
 		cliWarn(
 			`
-			  Warning: Could not read basePath from .next/routes-manifest.json 
-				filefalling back to empty basePath
+			Warning: Could not read basePath from .next/routes-manifest.json file, falling back to empty basePath
 			`,
 			{ spaced: true }
 		);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import dedent from 'dedent-tabs';
 import { z } from 'zod';
 import { argumentParser } from 'zodcli';
+import chalk, { ChalkInstance } from 'chalk';
 
 // A helper type to handle command line flags. Defaults to false
 const flag = z
@@ -18,6 +19,7 @@ const cliOptions = z
 		skipBuild: flag,
 		experimentalMinify: flag,
 		version: flag,
+		noColor: flag,
 	})
 	.strict();
 
@@ -37,9 +39,15 @@ export function parseCliArgs() {
 			s: 'skipBuild',
 			e: 'experimentalMinify',
 			w: 'watch',
+			nc: 'noColor',
 		},
 	}).parse(process.argv.slice(2));
 }
+
+type LogOptions = {
+	fromVercelCli?: boolean;
+	spaced?: boolean;
+};
 
 /**
  * Prints the help message that users get when they provide the help option
@@ -63,36 +71,73 @@ export function printCliHelpMessage(): void {
 
 		--watch, -w:                Automatically rebuilds when the project is edited
 
+		--no-color, -nc:            Disable colored output
 
 		GitHub: https://github.com/cloudflare/next-on-pages
 		'Docs: https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/
 	`);
 }
 
-export function cliLog(message: string, fromVercelCli = false): void {
+export function cliLog(
+	message: string,
+	{ fromVercelCli, spaced }: LogOptions = {}
+): void {
 	// eslint-disable-next-line no-console
-	console.log(prepareCliMessage(message, fromVercelCli));
+	console.log(prepareCliMessage(message, { fromVercelCli, spaced }));
+}
+
+export function cliSuccess(
+	message: string,
+	{ fromVercelCli, spaced }: LogOptions = {}
+): void {
+	// eslint-disable-next-line no-console
+	console.log(
+		prepareCliMessage(message, {
+			fromVercelCli,
+			styleFromater: chalk.green,
+			spaced,
+		})
+	);
 }
 
 export function cliError(
 	message: string,
-	reportIssue = false,
-	fromVercelCli = false
+	{
+		showReport: shouldReport,
+		fromVercelCli,
+		spaced,
+	}: LogOptions & {
+		showReport?: boolean;
+	} = {}
 ): void {
 	// eslint-disable-next-line no-console
-	console.error(prepareCliMessage(message, fromVercelCli));
-	if (reportIssue) {
+	console.error(
+		prepareCliMessage(message, {
+			fromVercelCli,
+			styleFromater: chalk.red,
+			spaced,
+		})
+	);
+	if (shouldReport) {
 		cliError(
 			'Please report this at https://github.com/cloudflare/next-on-pages/issues.',
-			false,
-			fromVercelCli
+			{ fromVercelCli }
 		);
 	}
 }
 
-export function cliWarn(message: string, fromVercelCli = false): void {
+export function cliWarn(
+	message: string,
+	{ fromVercelCli, spaced }: LogOptions = {}
+): void {
 	// eslint-disable-next-line no-console
-	console.warn(prepareCliMessage(message, fromVercelCli));
+	console.warn(
+		prepareCliMessage(message, {
+			fromVercelCli,
+			styleFromater: chalk.yellow,
+			spaced,
+		})
+	);
 }
 
 /**
@@ -101,13 +146,29 @@ export function cliWarn(message: string, fromVercelCli = false): void {
  * the function also removes extra indentation on the message allowing us to indent the messages
  * in the code as we please (see https://www.npmjs.com/package/dedent-tabs)
  */
-function prepareCliMessage(message: string, fromVercelCli: boolean): string {
-	return dedent(message)
+function prepareCliMessage(
+	message: string,
+	{
+		fromVercelCli,
+		styleFromater,
+		spaced,
+	}: LogOptions & {
+		styleFromater?: ChalkInstance;
+	}
+): string {
+	const preparedMessage = dedent(message)
 		.split('\n')
-		.map(line => `${getCliPrefix(fromVercelCli)} ${line}`)
+		.map(
+			line =>
+				`${getCliPrefix(fromVercelCli)} ${
+					styleFromater ? styleFromater(line) : line
+				}`
+		)
 		.join('\n');
+
+	return spaced ? `\n${preparedMessage}\n` : preparedMessage;
 }
 
 function getCliPrefix(fromVercelCli: boolean): string {
-	return fromVercelCli ? '▲' : '⚡️';
+	return fromVercelCli ? '▲ ' : '⚡️';
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ export function parseCliArgs() {
 			s: 'skipBuild',
 			e: 'experimentalMinify',
 			w: 'watch',
-			nc: 'noColor',
+			c: 'noColor',
 		},
 	}).parse(process.argv.slice(2));
 }
@@ -71,7 +71,7 @@ export function printCliHelpMessage(): void {
 
 		--watch, -w:                Automatically rebuilds when the project is edited
 
-		--no-color, -nc:            Disable colored output
+		--no-color, -c:             Disable colored output
 
 		GitHub: https://github.com/cloudflare/next-on-pages
 		'Docs: https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,7 +94,7 @@ export function cliSuccess(
 	console.log(
 		prepareCliMessage(message, {
 			fromVercelCli,
-			styleFromater: chalk.green,
+			styleFormatter: chalk.green,
 			spaced,
 		})
 	);
@@ -114,7 +114,7 @@ export function cliError(
 	console.error(
 		prepareCliMessage(message, {
 			fromVercelCli,
-			styleFromater: chalk.red,
+			styleFormatter: chalk.red,
 			spaced,
 		})
 	);
@@ -134,7 +134,7 @@ export function cliWarn(
 	console.warn(
 		prepareCliMessage(message, {
 			fromVercelCli,
-			styleFromater: chalk.yellow,
+			styleFormatter: chalk.yellow,
 			spaced,
 		})
 	);
@@ -150,10 +150,10 @@ function prepareCliMessage(
 	message: string,
 	{
 		fromVercelCli,
-		styleFromater,
+		styleFormatter,
 		spaced,
 	}: LogOptions & {
-		styleFromater?: ChalkInstance;
+		styleFormatter?: ChalkInstance;
 	}
 ): string {
 	const preparedMessage = dedent(message)
@@ -161,7 +161,7 @@ function prepareCliMessage(
 		.map(
 			line =>
 				`${getCliPrefix(fromVercelCli)} ${
-					styleFromater ? styleFromater(line) : line
+					styleFormatter ? styleFormatter(line) : line
 				}`
 		)
 		.join('\n');


### PR DESCRIPTION
@dario-piotrowicz

Refactored logger: This is the main change of this pull request, where the logger has been refactored. The blockPrefix flag has been added, which makes all block messages the same.

Added flag: --no-color, -nc: A new flag has been added to disable colored output.

Investigated solutions to separate log instances: There were some investigations made to separate log instances, and one possible solution was added to make it easier. Another possible solution was to add information about the previous log statement, and add an extra \n if it is different, but it was not considered appropriate.

ink: This one is interesting. Was looking on this only after refactoring, If it is small app, I dont think it is nice to use. But I might be wrong.

Im not sure where exactly should I add separation. So I added only one for `CliLogger.success`

UPD:
Started over again and just added some options for loggers.
Added chalk package.
Created logger function that will parse logs from readable stream and log result accordingly.