### PR TITLE
fix: use miniflare for vitest due to edge runtime environment bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cloudflare/next-on-pages",
-	"version": "0.6.0",
+	"version": "0.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cloudflare/next-on-pages",
-			"version": "0.6.0",
+			"version": "0.8.0",
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"astring": "^1.8.4",
@@ -32,7 +32,8 @@
 				"p-limit": "^4.0.0",
 				"prettier": "^2.8.4",
 				"typescript": "^4.7.4",
-				"vitest": "^0.26.3"
+				"vitest": "^0.26.3",
+				"vitest-environment-miniflare": "^2.13.0"
 			},
 			"peerDependencies": {
 				"vercel": "^28.0.2"
@@ -851,6 +852,12 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"node_modules/@iarna/toml": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+			"dev": true
+		},
 		"node_modules/@manypkg/find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -952,6 +959,245 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@miniflare/cache": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.13.0.tgz",
+			"integrity": "sha512-y3SdN3SVyPECWmLAEGkkrv0RB+LugEPs/FeXn8QtN9aE1vyj69clOAgmsDzoh1DpFfFsLKRiv05aWs4m79P8Xw==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"http-cache-semantics": "^4.1.0",
+				"undici": "5.20.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/core": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.13.0.tgz",
+			"integrity": "sha512-YJ/C0J3k+7xn4gvlMpvePnM3xC8nOnkweW96cc0IA8kJ1JSmScOO2tZ7rrU1RyDgp6StkAtQBw4yC0wYeFycBw==",
+			"dev": true,
+			"dependencies": {
+				"@iarna/toml": "^2.2.5",
+				"@miniflare/queues": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/watcher": "2.13.0",
+				"busboy": "^1.6.0",
+				"dotenv": "^10.0.0",
+				"kleur": "^4.1.4",
+				"set-cookie-parser": "^2.4.8",
+				"undici": "5.20.0",
+				"urlpattern-polyfill": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/d1": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.13.0.tgz",
+			"integrity": "sha512-OslqjO8iTcvzyrC0spByftMboRmHJEyHyTHnlKkjWDGdQQztEOjso2Xj+3I4SZIeUYvbzDRhKLS2QXI9a8LS5A==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.7"
+			}
+		},
+		"node_modules/@miniflare/durable-objects": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.13.0.tgz",
+			"integrity": "sha512-CRGVBPO9vY4Fc3aV+pdPRVVeYIt64vQqvw+BJbyW+TQtqVP2CGQeziJGnCfcONNNKyooZxGyUkHewUypyH+Qhg==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/storage-memory": "2.13.0",
+				"undici": "5.20.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/html-rewriter": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.13.0.tgz",
+			"integrity": "sha512-XhN7Icyzvtvu+o/A0hrnSiSmla78seCaNwQ9M1TDHxt352I/ahPX4wtPXs6GbKqY0/i+V6yoG2KGFRQ/j59cQQ==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"html-rewriter-wasm": "^0.4.1",
+				"undici": "5.20.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/kv": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.13.0.tgz",
+			"integrity": "sha512-J0AS5x3g/YVOmHMxMAZs07nRXRvSo9jyuC0eikTBf+4AABvBIyvVYmdTjYNjCmr8O5smcfWBX5S27HelD3aAAQ==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/shared": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/queues": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.13.0.tgz",
+			"integrity": "sha512-Gf/a6M1mJL03iOvNqh3JNahcBfvEMPHnO28n0gkCoyYWGvddIr9lwCdFIa0qwNJsC1fIDRxhPg8PZ5cQLBMwRA==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/shared": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.7"
+			}
+		},
+		"node_modules/@miniflare/r2": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.13.0.tgz",
+			"integrity": "sha512-/5k6GHOYMNV/oBtilV9HDXBkJUrx8oXVigG5vxbnzEGRXyVRmR+Glzu7mFT8JiE94XiEbXHk9Qvu1S5Dej3wBw==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/shared": "2.13.0",
+				"undici": "5.20.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/runner-vm": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.13.0.tgz",
+			"integrity": "sha512-VmKtF2cA8HmTuLXor1THWY0v+DmaobPct63iLcgWIaUdP3MIvL+9X8HDXFAviCR7bCTe6MKxckHkaOj0IE0aJQ==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/shared": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/shared": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.13.0.tgz",
+			"integrity": "sha512-m8YFQzKmbjberrV9hPzNcQjNCXxjTjXUpuNrIGjAJO7g+BDztUHaZbdd26H9maBDlkeiWxA3hf0mDyCT/6MCMA==",
+			"dev": true,
+			"dependencies": {
+				"@types/better-sqlite3": "^7.6.0",
+				"kleur": "^4.1.4",
+				"npx-import": "^1.1.4",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/shared-test-environment": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/shared-test-environment/-/shared-test-environment-2.13.0.tgz",
+			"integrity": "sha512-I90e0hVdsR0pD0JZoetlw03gpQ05WnXPCHOdhBxROTrfy+YLP19zIFgvJpKC8WyKrcwABRwetWx7tIMI03qU0g==",
+			"dev": true,
+			"dependencies": {
+				"@cloudflare/workers-types": "^4.20221111.1",
+				"@miniflare/cache": "2.13.0",
+				"@miniflare/core": "2.13.0",
+				"@miniflare/d1": "2.13.0",
+				"@miniflare/durable-objects": "2.13.0",
+				"@miniflare/html-rewriter": "2.13.0",
+				"@miniflare/kv": "2.13.0",
+				"@miniflare/queues": "2.13.0",
+				"@miniflare/r2": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/sites": "2.13.0",
+				"@miniflare/storage-memory": "2.13.0",
+				"@miniflare/web-sockets": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/shared-test-environment/node_modules/@cloudflare/workers-types": {
+			"version": "4.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230404.0.tgz",
+			"integrity": "sha512-fG3oaJX1icfsGV74nhx1+AC6opvZsGqnpx6FvrcVqQaBmCNkjKNqDRFrpasXWFiOIvysBXHKQAzsAJkBZgnM+A==",
+			"dev": true
+		},
+		"node_modules/@miniflare/sites": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.13.0.tgz",
+			"integrity": "sha512-/tuzIu00o6CF2tkSv01q02MgEShXBSKx85h9jwWvc+6u7prGacAOer0FA1YNRFbE+t9QIfutAkoPGMA9zYf8+Q==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/kv": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/storage-file": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/storage-file": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.13.0.tgz",
+			"integrity": "sha512-LuAeAAY5046rq5U1eFLVkz+ppiFEWytWacpkQw92DvVKFFquZcXSj6WPxZF4rSs23WDk+rdcwuLekbb52aDR7A==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/storage-memory": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/storage-memory": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.13.0.tgz",
+			"integrity": "sha512-FnkYcBNXa/ym1ksNilNZycg9WYYKo6cWKplVBeSthRon3e8QY6t3n7/XRseBUo7O6mhDybVTy4wNCP1R2nBiEw==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/shared": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/watcher": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.13.0.tgz",
+			"integrity": "sha512-teAacWcpMStoBLbLae95IUaL5lPzjPlXa9lhK9CbRaio/KRMibTMRGWrYos3IVGQRZvklvLwcms/nTvgcdb6yw==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/shared": "2.13.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/web-sockets": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.13.0.tgz",
+			"integrity": "sha512-+U2/HCf+BetRIgjAnNQjkuN6UeAjQmXifhQC+7CCaX834XJhrKXoR6z2xr2xkg1qj0qQs4D2jWG0KzrO5OUpug==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"undici": "5.20.0",
+				"ws": "^8.2.2"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1015,6 +1261,15 @@
 				"minimatch": "^3.0.4",
 				"mkdirp": "^1.0.4",
 				"path-browserify": "^1.0.1"
+			}
+		},
+		"node_modules/@types/better-sqlite3": {
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.4.tgz",
+			"integrity": "sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/chai": {
@@ -2167,6 +2422,42 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
 		},
+		"node_modules/builtins": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+			"integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.0.0"
+			}
+		},
+		"node_modules/builtins/node_modules/semver": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+			"integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/busboy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dev": true,
+			"dependencies": {
+				"streamsearch": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			}
+		},
 		"node_modules/cacheable-request": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
@@ -2746,6 +3037,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+			"integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/duplexer3": {
@@ -3580,6 +3880,91 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/execa": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+			"integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.1",
+				"human-signals": "^3.0.1",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^3.0.7",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/execa/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/execa/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/execa/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/exit-hook": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
@@ -4103,11 +4488,16 @@
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
+		"node_modules/html-rewriter-wasm": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.1.tgz",
+			"integrity": "sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q==",
+			"dev": true
+		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-			"peer": true
+			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
 		},
 		"node_modules/http-status": {
 			"version": "1.5.2",
@@ -4136,6 +4526,15 @@
 			"resolved": "https://registry.npmjs.org/human-id/-/human-id-1.0.2.tgz",
 			"integrity": "sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==",
 			"dev": true
+		},
+		"node_modules/human-signals": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+			"integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",
@@ -4484,6 +4883,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-string": {
@@ -4873,6 +5284,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4891,6 +5308,18 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mimic-response": {
@@ -5128,6 +5557,33 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/npm-run-path": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+			"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/npmlog": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
@@ -5138,6 +5594,33 @@
 				"console-control-strings": "^1.1.0",
 				"gauge": "^3.0.0",
 				"set-blocking": "^2.0.0"
+			}
+		},
+		"node_modules/npx-import": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/npx-import/-/npx-import-1.1.4.tgz",
+			"integrity": "sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==",
+			"dev": true,
+			"dependencies": {
+				"execa": "^6.1.0",
+				"parse-package-name": "^1.0.0",
+				"semver": "^7.3.7",
+				"validate-npm-package-name": "^4.0.0"
+			}
+		},
+		"node_modules/npx-import/node_modules/semver": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+			"integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/object-assign": {
@@ -5191,6 +5674,21 @@
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/optionator": {
@@ -5368,6 +5866,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/parse-package-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-package-name/-/parse-package-name-1.0.0.tgz",
+			"integrity": "sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==",
+			"dev": true
 		},
 		"node_modules/path-browserify": {
 			"version": "1.0.1",
@@ -6140,6 +6644,12 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
 		},
+		"node_modules/set-cookie-parser": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+			"dev": true
+		},
 		"node_modules/shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -6345,6 +6855,15 @@
 				"mixme": "^0.5.1"
 			}
 		},
+		"node_modules/streamsearch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6413,6 +6932,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/strip-indent": {
@@ -6749,6 +7280,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/undici": {
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"dev": true,
+			"dependencies": {
+				"busboy": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=12.18"
+			}
+		},
 		"node_modules/unique-string": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -6833,6 +7376,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/urlpattern-polyfill": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
+			"integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==",
+			"dev": true
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6847,6 +7396,18 @@
 			"dependencies": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"node_modules/validate-npm-package-name": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
+			"integrity": "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==",
+			"dev": true,
+			"dependencies": {
+				"builtins": "^5.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/vercel": {
@@ -6996,6 +7557,25 @@
 				}
 			}
 		},
+		"node_modules/vitest-environment-miniflare": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/vitest-environment-miniflare/-/vitest-environment-miniflare-2.13.0.tgz",
+			"integrity": "sha512-0QzUf++N2fKYaUt55IlgxR9cIRWWj1/qoFsxErd2DbmA3zyDhzvTy5WlDpGRAXLeYMiLdAXvL9LSnLC5g3CCrw==",
+			"dev": true,
+			"dependencies": {
+				"@miniflare/queues": "2.13.0",
+				"@miniflare/runner-vm": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/shared-test-environment": "2.13.0",
+				"undici": "5.20.0"
+			},
+			"engines": {
+				"node": ">=16.13"
+			},
+			"peerDependencies": {
+				"vitest": ">=0.23.0"
+			}
+		},
 		"node_modules/wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -7129,6 +7709,27 @@
 				"is-typedarray": "^1.0.0",
 				"signal-exit": "^3.0.2",
 				"typedarray-to-buffer": "^3.1.5"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/xdg-basedir": {
@@ -7931,6 +8532,12 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"@iarna/toml": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+			"dev": true
+		},
 		"@manypkg/find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -8023,6 +8630,199 @@
 				}
 			}
 		},
+		"@miniflare/cache": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.13.0.tgz",
+			"integrity": "sha512-y3SdN3SVyPECWmLAEGkkrv0RB+LugEPs/FeXn8QtN9aE1vyj69clOAgmsDzoh1DpFfFsLKRiv05aWs4m79P8Xw==",
+			"dev": true,
+			"requires": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"http-cache-semantics": "^4.1.0",
+				"undici": "5.20.0"
+			}
+		},
+		"@miniflare/core": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.13.0.tgz",
+			"integrity": "sha512-YJ/C0J3k+7xn4gvlMpvePnM3xC8nOnkweW96cc0IA8kJ1JSmScOO2tZ7rrU1RyDgp6StkAtQBw4yC0wYeFycBw==",
+			"dev": true,
+			"requires": {
+				"@iarna/toml": "^2.2.5",
+				"@miniflare/queues": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/watcher": "2.13.0",
+				"busboy": "^1.6.0",
+				"dotenv": "^10.0.0",
+				"kleur": "^4.1.4",
+				"set-cookie-parser": "^2.4.8",
+				"undici": "5.20.0",
+				"urlpattern-polyfill": "^4.0.3"
+			}
+		},
+		"@miniflare/d1": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.13.0.tgz",
+			"integrity": "sha512-OslqjO8iTcvzyrC0spByftMboRmHJEyHyTHnlKkjWDGdQQztEOjso2Xj+3I4SZIeUYvbzDRhKLS2QXI9a8LS5A==",
+			"dev": true,
+			"requires": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0"
+			}
+		},
+		"@miniflare/durable-objects": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.13.0.tgz",
+			"integrity": "sha512-CRGVBPO9vY4Fc3aV+pdPRVVeYIt64vQqvw+BJbyW+TQtqVP2CGQeziJGnCfcONNNKyooZxGyUkHewUypyH+Qhg==",
+			"dev": true,
+			"requires": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/storage-memory": "2.13.0",
+				"undici": "5.20.0"
+			}
+		},
+		"@miniflare/html-rewriter": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.13.0.tgz",
+			"integrity": "sha512-XhN7Icyzvtvu+o/A0hrnSiSmla78seCaNwQ9M1TDHxt352I/ahPX4wtPXs6GbKqY0/i+V6yoG2KGFRQ/j59cQQ==",
+			"dev": true,
+			"requires": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"html-rewriter-wasm": "^0.4.1",
+				"undici": "5.20.0"
+			}
+		},
+		"@miniflare/kv": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.13.0.tgz",
+			"integrity": "sha512-J0AS5x3g/YVOmHMxMAZs07nRXRvSo9jyuC0eikTBf+4AABvBIyvVYmdTjYNjCmr8O5smcfWBX5S27HelD3aAAQ==",
+			"dev": true,
+			"requires": {
+				"@miniflare/shared": "2.13.0"
+			}
+		},
+		"@miniflare/queues": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.13.0.tgz",
+			"integrity": "sha512-Gf/a6M1mJL03iOvNqh3JNahcBfvEMPHnO28n0gkCoyYWGvddIr9lwCdFIa0qwNJsC1fIDRxhPg8PZ5cQLBMwRA==",
+			"dev": true,
+			"requires": {
+				"@miniflare/shared": "2.13.0"
+			}
+		},
+		"@miniflare/r2": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.13.0.tgz",
+			"integrity": "sha512-/5k6GHOYMNV/oBtilV9HDXBkJUrx8oXVigG5vxbnzEGRXyVRmR+Glzu7mFT8JiE94XiEbXHk9Qvu1S5Dej3wBw==",
+			"dev": true,
+			"requires": {
+				"@miniflare/shared": "2.13.0",
+				"undici": "5.20.0"
+			}
+		},
+		"@miniflare/runner-vm": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.13.0.tgz",
+			"integrity": "sha512-VmKtF2cA8HmTuLXor1THWY0v+DmaobPct63iLcgWIaUdP3MIvL+9X8HDXFAviCR7bCTe6MKxckHkaOj0IE0aJQ==",
+			"dev": true,
+			"requires": {
+				"@miniflare/shared": "2.13.0"
+			}
+		},
+		"@miniflare/shared": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.13.0.tgz",
+			"integrity": "sha512-m8YFQzKmbjberrV9hPzNcQjNCXxjTjXUpuNrIGjAJO7g+BDztUHaZbdd26H9maBDlkeiWxA3hf0mDyCT/6MCMA==",
+			"dev": true,
+			"requires": {
+				"@types/better-sqlite3": "^7.6.0",
+				"kleur": "^4.1.4",
+				"npx-import": "^1.1.4",
+				"picomatch": "^2.3.1"
+			}
+		},
+		"@miniflare/shared-test-environment": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/shared-test-environment/-/shared-test-environment-2.13.0.tgz",
+			"integrity": "sha512-I90e0hVdsR0pD0JZoetlw03gpQ05WnXPCHOdhBxROTrfy+YLP19zIFgvJpKC8WyKrcwABRwetWx7tIMI03qU0g==",
+			"dev": true,
+			"requires": {
+				"@cloudflare/workers-types": "^4.20221111.1",
+				"@miniflare/cache": "2.13.0",
+				"@miniflare/core": "2.13.0",
+				"@miniflare/d1": "2.13.0",
+				"@miniflare/durable-objects": "2.13.0",
+				"@miniflare/html-rewriter": "2.13.0",
+				"@miniflare/kv": "2.13.0",
+				"@miniflare/queues": "2.13.0",
+				"@miniflare/r2": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/sites": "2.13.0",
+				"@miniflare/storage-memory": "2.13.0",
+				"@miniflare/web-sockets": "2.13.0"
+			},
+			"dependencies": {
+				"@cloudflare/workers-types": {
+					"version": "4.20230404.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230404.0.tgz",
+					"integrity": "sha512-fG3oaJX1icfsGV74nhx1+AC6opvZsGqnpx6FvrcVqQaBmCNkjKNqDRFrpasXWFiOIvysBXHKQAzsAJkBZgnM+A==",
+					"dev": true
+				}
+			}
+		},
+		"@miniflare/sites": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.13.0.tgz",
+			"integrity": "sha512-/tuzIu00o6CF2tkSv01q02MgEShXBSKx85h9jwWvc+6u7prGacAOer0FA1YNRFbE+t9QIfutAkoPGMA9zYf8+Q==",
+			"dev": true,
+			"requires": {
+				"@miniflare/kv": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/storage-file": "2.13.0"
+			}
+		},
+		"@miniflare/storage-file": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.13.0.tgz",
+			"integrity": "sha512-LuAeAAY5046rq5U1eFLVkz+ppiFEWytWacpkQw92DvVKFFquZcXSj6WPxZF4rSs23WDk+rdcwuLekbb52aDR7A==",
+			"dev": true,
+			"requires": {
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/storage-memory": "2.13.0"
+			}
+		},
+		"@miniflare/storage-memory": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.13.0.tgz",
+			"integrity": "sha512-FnkYcBNXa/ym1ksNilNZycg9WYYKo6cWKplVBeSthRon3e8QY6t3n7/XRseBUo7O6mhDybVTy4wNCP1R2nBiEw==",
+			"dev": true,
+			"requires": {
+				"@miniflare/shared": "2.13.0"
+			}
+		},
+		"@miniflare/watcher": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.13.0.tgz",
+			"integrity": "sha512-teAacWcpMStoBLbLae95IUaL5lPzjPlXa9lhK9CbRaio/KRMibTMRGWrYos3IVGQRZvklvLwcms/nTvgcdb6yw==",
+			"dev": true,
+			"requires": {
+				"@miniflare/shared": "2.13.0"
+			}
+		},
+		"@miniflare/web-sockets": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.13.0.tgz",
+			"integrity": "sha512-+U2/HCf+BetRIgjAnNQjkuN6UeAjQmXifhQC+7CCaX834XJhrKXoR6z2xr2xkg1qj0qQs4D2jWG0KzrO5OUpug==",
+			"dev": true,
+			"requires": {
+				"@miniflare/core": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"undici": "5.20.0",
+				"ws": "^8.2.2"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -8071,6 +8871,15 @@
 				"minimatch": "^3.0.4",
 				"mkdirp": "^1.0.4",
 				"path-browserify": "^1.0.1"
+			}
+		},
+		"@types/better-sqlite3": {
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.4.tgz",
+			"integrity": "sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
 			}
 		},
 		"@types/chai": {
@@ -8847,6 +9656,35 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
 		},
+		"builtins": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+			"integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+					"integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
+		"busboy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dev": true,
+			"requires": {
+				"streamsearch": "^1.1.0"
+			}
+		},
 		"cacheable-request": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
@@ -9284,6 +10122,12 @@
 			"requires": {
 				"is-obj": "^2.0.0"
 			}
+		},
+		"dotenv": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+			"integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+			"dev": true
 		},
 		"duplexer3": {
 			"version": "0.1.5",
@@ -9795,6 +10639,66 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"execa": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+			"integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.1",
+				"human-signals": "^3.0.1",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^3.0.7",
+				"strip-final-newline": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"exit-hook": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
@@ -10188,11 +11092,16 @@
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
+		"html-rewriter-wasm": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.1.tgz",
+			"integrity": "sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q==",
+			"dev": true
+		},
 		"http-cache-semantics": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-			"peer": true
+			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
 		},
 		"http-status": {
 			"version": "1.5.2",
@@ -10214,6 +11123,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/human-id/-/human-id-1.0.2.tgz",
 			"integrity": "sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==",
+			"dev": true
+		},
+		"human-signals": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+			"integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
 			"dev": true
 		},
 		"iconv-lite": {
@@ -10452,6 +11367,12 @@
 			"requires": {
 				"call-bind": "^1.0.2"
 			}
+		},
+		"is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true
 		},
 		"is-string": {
 			"version": "1.0.7",
@@ -10759,6 +11680,12 @@
 				}
 			}
 		},
+		"merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -10772,6 +11699,12 @@
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
 			}
+		},
+		"mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
@@ -10945,6 +11878,23 @@
 			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
 			"peer": true
 		},
+		"npm-run-path": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+			"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+			"dev": true,
+			"requires": {
+				"path-key": "^4.0.0"
+			},
+			"dependencies": {
+				"path-key": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+					"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+					"dev": true
+				}
+			}
+		},
 		"npmlog": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
@@ -10955,6 +11905,29 @@
 				"console-control-strings": "^1.1.0",
 				"gauge": "^3.0.0",
 				"set-blocking": "^2.0.0"
+			}
+		},
+		"npx-import": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/npx-import/-/npx-import-1.1.4.tgz",
+			"integrity": "sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==",
+			"dev": true,
+			"requires": {
+				"execa": "^6.1.0",
+				"parse-package-name": "^1.0.0",
+				"semver": "^7.3.7",
+				"validate-npm-package-name": "^4.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+					"integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"object-assign": {
@@ -10993,6 +11966,15 @@
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^4.0.0"
 			}
 		},
 		"optionator": {
@@ -11123,6 +12105,12 @@
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
 			"integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
 			"peer": true
+		},
+		"parse-package-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-package-name/-/parse-package-name-1.0.0.tgz",
+			"integrity": "sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==",
+			"dev": true
 		},
 		"path-browserify": {
 			"version": "1.0.1",
@@ -11666,6 +12654,12 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
 		},
+		"set-cookie-parser": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+			"dev": true
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -11843,6 +12837,12 @@
 				"mixme": "^0.5.1"
 			}
 		},
+		"streamsearch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"dev": true
+		},
 		"string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -11896,6 +12896,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true
+		},
+		"strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
 			"dev": true
 		},
 		"strip-indent": {
@@ -12135,6 +13141,15 @@
 				"which-boxed-primitive": "^1.0.2"
 			}
 		},
+		"undici": {
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"dev": true,
+			"requires": {
+				"busboy": "^1.6.0"
+			}
+		},
 		"unique-string": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -12200,6 +13215,12 @@
 				"prepend-http": "^2.0.0"
 			}
 		},
+		"urlpattern-polyfill": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
+			"integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==",
+			"dev": true
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12214,6 +13235,15 @@
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"validate-npm-package-name": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
+			"integrity": "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==",
+			"dev": true,
+			"requires": {
+				"builtins": "^5.0.0"
 			}
 		},
 		"vercel": {
@@ -12283,6 +13313,19 @@
 				"tinyspy": "^1.0.2",
 				"vite": "^3.0.0 || ^4.0.0",
 				"vite-node": "0.26.3"
+			}
+		},
+		"vitest-environment-miniflare": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/vitest-environment-miniflare/-/vitest-environment-miniflare-2.13.0.tgz",
+			"integrity": "sha512-0QzUf++N2fKYaUt55IlgxR9cIRWWj1/qoFsxErd2DbmA3zyDhzvTy5WlDpGRAXLeYMiLdAXvL9LSnLC5g3CCrw==",
+			"dev": true,
+			"requires": {
+				"@miniflare/queues": "2.13.0",
+				"@miniflare/runner-vm": "2.13.0",
+				"@miniflare/shared": "2.13.0",
+				"@miniflare/shared-test-environment": "2.13.0",
+				"undici": "5.20.0"
 			}
 		},
 		"wcwidth": {
@@ -12398,6 +13441,13 @@
 				"signal-exit": "^3.0.2",
 				"typedarray-to-buffer": "^3.1.5"
 			}
+		},
+		"ws": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"dev": true,
+			"requires": {}
 		},
 		"xdg-basedir": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"p-limit": "^4.0.0",
 		"prettier": "^2.8.4",
 		"typescript": "^4.7.4",
-		"vitest": "^0.26.3"
+		"vitest": "^0.26.3",
+		"vitest-environment-miniflare": "^2.13.0"
 	}
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
 	test: {
 		include: ['tests/**/*.test.ts'],
-		environment: 'edge-runtime',
+		environment: 'miniflare',
 	},
 });


### PR DESCRIPTION
The default `edge-runtime` vitest environment appears to not fully support `ArrayBuffer` - https://github.com/vitest-dev/vitest/issues/2884. This causes issues when trying to use `new Response(...)`.

Specifically, it results in `TypeError: Cannot read properties of undefined (reading 'isView')` when trying to construct a new response.

This PR changes the environment we use to Miniflare (`vitest-environment-miniflare`).

An alternate POV is that since we're building for Cloudflare Workers, it might make more sense to use the Miniflare vitest environment as well.
