### PR TITLE
show a user-friendly error message on unknown cli flag

### DIFF
--- a/.changeset/smart-cows-joke.md
+++ b/.changeset/smart-cows-joke.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Show a user-friendly error message for an unknown CLI flag


### PR DESCRIPTION
Currently, if an unknown argument is passed to the cli, an error is shown with the ZodError message. This error is not user-friendly. The ZodError message should be replaced with a clear and concise message that informs the user that the argument they have passed is not recognized, and show the help menu for valid arguments. 
This will improve the user experience and make it easier for users to work with the cli.

**Current message:** 
```
/Users/tarun/Documents/Personal/open-src/next-on-pages/dist/index.js:735
    throw result.error;
    ^

ZodError: [
  {
    "code": "unrecognized_keys",
    "keys": [
      "--hel"
    ],
    "path": [],
    "message": "Unrecognized key(s) in object: '--hel'"
  }
]
    at Object.get error [as error] (/Users/tarun/Documents/Personal/open-src/next-on-pages/dist/index.js:637:23)
    at ZodEffects.parse (/Users/tarun/Documents/Personal/open-src/next-on-pages/dist/index.js:735:18)
    at parseCliArgs (/Users/tarun/Documents/Personal/open-src/next-on-pages/dist/index.js:4343:6)
    at runNextOnPages (/Users/tarun/Documents/Personal/open-src/next-on-pages/dist/index.js:13787:16)
    at Object.<anonymous> (/Users/tarun/Documents/Personal/open-src/next-on-pages/dist/index.js:13785:1)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12) {
  issues: [
    {
      code: 'unrecognized_keys',
      keys: [ '--hel' ],
      path: [],
      message: "Unrecognized key(s) in object: '--hel'"
    }
  ],
  addIssue: [Function (anonymous)],
  addIssues: [Function (anonymous)]
}
```

**New Message:** 
```

⚡️ Unknown option(s): -vd
⚡️ Usage: npx @cloudflare/next-on-pages [options]
⚡️ 
⚡️ Options:
⚡️ 
⚡️ --help, -h:                 Shows this help message
⚡️ 
⚡️ --version, -v:              Shows the version of the package
⚡️ 
⚡️ --skip-build, -s:           Doesn't run 'vercel build' automatically
⚡️ 
⚡️ 
⚡️ --experimental-minify, -m:  Attempts to minify the functions of a project (by de-duping webpack chunks)
⚡️ 
⚡️ --watch, -w:                Automatically rebuilds when the project is edited
⚡️ 
⚡️ --no-color, -c:             Disable colored output
⚡️ 
⚡️ GitHub: https://github.com/cloudflare/next-on-pages
⚡️ 'Docs: https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/
```