### PR TITLE
add missing await for staticStaticDir removal

### DIFF
--- a/src/buildApplication/generateFunctionsMap.ts
+++ b/src/buildApplication/generateFunctionsMap.ts
@@ -399,7 +399,7 @@ async function tryToFixFaviconFunc(): Promise<void> {
 		// let's delete the .vercel/output/static/static directory so that extra media
 		// files are not uploaded unnecessarily to Cloudflare Pages
 		const staticStaticDir = resolve('.vercel', 'output', 'static', 'static');
-		rm(staticStaticDir, { recursive: true, force: true });
+		await rm(staticStaticDir, { recursive: true, force: true });
 	} catch {
 		cliWarn('Warning: No static favicon file found');
 	}


### PR DESCRIPTION
I have seen a number of the following:
![Screenshot 2023-04-19 at 23 41 37](https://user-images.githubusercontent.com/61631103/233215683-cb6c8a3e-a85c-45c6-9e1c-97b5b94674c7.png)

Introduced by https://github.com/cloudflare/next-on-pages/pull/173 (sorry my bad 😓)

I'm pretty sure this uncaught exception is caused because we don't away the `rm`, I didn't await it because I don't think it is necessary to wait for the directory to get deleted, but I am adding it back since we need it to avoid this uncaught exception (alternatively I could use `validateDir` here but between that adding the `await` I think that the latter is just simpler/cleaner (also `validateDir` would need to be awaited too))

___

PS: since this is fixing an issue not yet released I think I don't need to create a changeset (this will just be part of #173's changeset)