### PR TITLE
Ignore '.wrangler' directory in watch mode

### DIFF
--- a/.changeset/modern-candles-shave.md
+++ b/.changeset/modern-candles-shave.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Ignore '.wrangler' directory in watch mode

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ function setWatchMode(fn: () => void): void {
 			'node_modules',
 			'.vercel',
 			'.next',
+			'.wrangler',
 			'package-lock.json',
 			'yarn.lock',
 		],


### PR DESCRIPTION
I'm using a D1 DB locally at `.wrangler\state\d1\DB.sqlite3`, and running `next-on-pages --watch`

When a function writes to the DB, the sqlite file is modified and triggers a rebuild
I can't think of any valid reason to have .wrangler under the watch paths - I've tested locally and this fixes it