### PR TITLE
fix: copy static prerendered routes to the static directory

### DIFF
--- a/.changeset/orange-colts-fly.md
+++ b/.changeset/orange-colts-fly.md
@@ -4,4 +4,4 @@
 
 Fix static route handling in the app directory and copy prerendered routes to the build output static directory.
 
-If an app directory projets builds pages without specifying a runtime and has no server-side functionality, it defaults to generating static pages. These pages are in the form of prerendered routes, which are stored in the build output directory with prerender configs, fallback files, and functions. The functions it creates are not necessary and will be invalid nodejs functions as no runtime was specified, and the fallback files can instead be used as static assets for the pages.
+If an app directory project builds pages without specifying a runtime and has no server-side functionality, it defaults to generating static pages. These pages are in the form of prerendered routes, which are stored in the build output directory with prerender configs, fallback files, and functions. The functions it creates are not necessary and will be invalid nodejs functions as no runtime was specified, and the fallback files can instead be used as static assets for the pages.

--- a/.changeset/orange-colts-fly.md
+++ b/.changeset/orange-colts-fly.md
@@ -3,3 +3,5 @@
 ---
 
 Fix static route handling in the app directory and copy prerendered routes to the build output static directory.
+
+If an app directory projets builds pages without specifying a runtime and has no server-side functionality, it defaults to generating static pages. These pages are in the form of prerendered routes, which are stored in the build output directory with prerender configs, fallback files, and functions. The functions it creates are not necessary and will be invalid nodejs functions as no runtime was specified, and the fallback files can instead be used as static assets for the pages.

--- a/.changeset/orange-colts-fly.md
+++ b/.changeset/orange-colts-fly.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix static route handling in the app directory and copy prerendered routes to the build output static directory.

--- a/src/buildApplication/buildApplication.ts
+++ b/src/buildApplication/buildApplication.ts
@@ -74,10 +74,8 @@ async function prepareAndBuildWorker(
 		return;
 	}
 
-	const { invalidFunctions, functionsMap } = await generateFunctionsMap(
-		functionsDir,
-		options.experimentalMinify
-	);
+	const { invalidFunctions, functionsMap, prerenderedRoutes } =
+		await generateFunctionsMap(functionsDir, options.experimentalMinify);
 
 	if (functionsMap.size === 0) {
 		cliLog('No functions detected.');
@@ -109,6 +107,7 @@ async function prepareAndBuildWorker(
 	const processedVercelOutput = processVercelOutput(
 		vercelConfig,
 		staticAssets,
+		prerenderedRoutes,
 		middlewareManifestData
 	);
 

--- a/src/buildApplication/buildWorkerFile.ts
+++ b/src/buildApplication/buildWorkerFile.ts
@@ -21,7 +21,7 @@ function constructBuildOutputRecord(item: BuildOutputItem) {
 		? `{
 				type: ${JSON.stringify(item.type)},
 				path: ${item.path ? JSON.stringify(item.path) : undefined},
-				contentType: ${item.contentType ? JSON.stringify(item.contentType) : undefined}
+				headers: ${item.headers ? JSON.stringify(item.headers) : undefined}
 			}`
 		: `{
 				type: ${JSON.stringify(item.type)},

--- a/src/buildApplication/fixPrerenderedRoutes.ts
+++ b/src/buildApplication/fixPrerenderedRoutes.ts
@@ -1,0 +1,208 @@
+import { cliWarn } from '../cli';
+import {
+	formatRoutePath,
+	normalizePath,
+	readJsonFile,
+	stripIndexRoute,
+	validateFile,
+} from '../utils';
+import { join, relative, resolve, dirname } from 'path';
+import { mkdir, copyFile } from 'fs/promises';
+
+export type VercelPrerenderConfig = {
+	type: string;
+	sourcePath?: string;
+	fallback: { type: string; mode: number; fsPath: string };
+	initialHeaders?: Record<string, string>;
+};
+
+export type PrerenderedFileData = {
+	headers?: Record<string, string>;
+	overrides?: string[];
+};
+
+/**
+ * Retrieve a valid prerendered route config.
+ *
+ * @param baseDir Base directory for the prerendered routes.
+ * @param file Prerendered config file name.
+ * @param dirName Directory name to use for the route.
+ * @returns A valid prerendered route config, or null if the config is invalid.
+ */
+async function getRouteConfig(
+	baseDir: string,
+	file: string,
+	dirName: string
+): Promise<VercelPrerenderConfig | null> {
+	const configPath = join(baseDir, file);
+	const config = await readJsonFile<VercelPrerenderConfig>(configPath);
+
+	if (
+		config?.type?.toLowerCase() !== 'prerender' ||
+		config?.fallback?.type?.toLowerCase() !== 'filefsref' ||
+		!config?.fallback?.fsPath
+	) {
+		const relativeName = normalizePath(join(dirName, file));
+		cliWarn(`Invalid prerender config for ${relativeName}`);
+		return null;
+	}
+
+	return config;
+}
+
+/**
+ * Retrieve the path to the prerendered route, if it exists.
+ *
+ * @param config.fallback Fallback file configuration.
+ * @param dirName Directory name to use for the route.
+ * @param outputDir Vercel build output directory.
+ * @returns The path to the prerendered route, or null if it does not exist.
+ */
+async function getRoutePath(
+	{ fallback }: VercelPrerenderConfig,
+	dirName: string,
+	outputDir: string
+): Promise<string | null> {
+	const oldRoute = normalizePath(join(dirName, fallback.fsPath));
+	const oldFile = join(outputDir, 'functions', oldRoute);
+
+	// Check the prerendered file exists.
+	if (!(await validateFile(oldFile))) {
+		cliWarn(`Could not find prerendered file for ${oldRoute}`);
+		return null;
+	}
+
+	return oldFile;
+}
+
+/**
+ * Retrieve the new destination for the prerendered file, if no file already exists.
+ *
+ * @param config.fallback Fallback file configuration.
+ * @param dirName Directory name to use for the route.
+ * @param outputDir Vercel build output directory.
+ * @returns The new destination for the prerendered file, or null if a file already exists.
+ */
+async function getRouteDest(
+	{ fallback }: VercelPrerenderConfig,
+	dirName: string,
+	outputDir: string
+): Promise<{ newFile: string; newRoute: string } | null> {
+	const newRoute = normalizePath(
+		join(
+			dirName,
+			fallback.fsPath.replace(/(?:\.rsc)?\.prerender-fallback/gi, '')
+		)
+	);
+	const newFile = join(outputDir, 'static', newRoute);
+
+	// Check if a static file already exists at the new location.
+	if (await validateFile(newFile)) {
+		cliWarn(`Prerendered file already exists for ${newRoute}`);
+		return null;
+	}
+
+	return { newFile, newRoute };
+}
+
+/**
+ * Validate a prerendered route and retrieve its config file, original file path, and new destination.
+ *
+ * @param baseDir Base directory for the prerendered routes.
+ * @param file Prerendered config file name.
+ * @param outputDir Vercel build output directory.
+ * @returns Information for a valid prerendered route, or null if the route is invalid.
+ */
+async function validateRoute(baseDir: string, file: string, outputDir: string) {
+	const dirName = relative(join(outputDir, 'functions'), baseDir);
+	const config = await getRouteConfig(baseDir, file, dirName);
+	if (!config) return null;
+
+	const oldFile = await getRoutePath(config, dirName, outputDir);
+	if (!oldFile) return null;
+
+	const dest = await getRouteDest(config, dirName, outputDir);
+	if (!dest) return null;
+
+	return { config, oldFile, newFile: dest.newFile, newRoute: dest.newRoute };
+}
+
+/**
+ * Copy a prerendered file to its new destination.
+ *
+ * @param oldFile Prerendered file path.
+ * @param newFile Destination for the prerendered file.
+ */
+async function createNewRouteFile(oldFile: string, newFile: string) {
+	await mkdir(dirname(newFile), { recursive: true });
+	await copyFile(oldFile, newFile);
+}
+
+/**
+ * Create a list of overrides for a new route.
+ *
+ * @param newRoute New route to create overrides for.
+ * @returns List of overrides for the new route.
+ */
+function getRouteOverrides(newRoute: string): string[] {
+	// Create override entries that might normally be created through the build output config.
+	const formattedPathName = normalizePath(formatRoutePath(newRoute));
+	const withoutHtmlExt = formattedPathName.replace(/\.html$/, '');
+	const strippedIndexRoute = stripIndexRoute(withoutHtmlExt);
+	const overrides = new Set(
+		[formattedPathName, withoutHtmlExt, strippedIndexRoute].filter(
+			route => route !== `/${newRoute}`
+		)
+	);
+
+	return [...overrides];
+}
+
+/**
+ * Extracts the prerendered routes from a list of routes, copies the prerendered files to the
+ * `.vercel/static/output` directory, and returns a list of non-prerendered routes.
+ *
+ * Additionally, it creates paths to use for overrides for the routing process, along with the
+ * correct headers to apply.
+ *
+ * @param prerenderedRoutes Map of prerendered files.
+ * @param files File paths to check for prerendered routes.
+ * @param baseDir Base directory for the routes.
+ * @returns List of non-prerendered routes.
+ */
+export async function fixPrerenderedRoutes(
+	prerenderedRoutes: Map<string, PrerenderedFileData>,
+	files: string[],
+	baseDir: string
+): Promise<string[]> {
+	const outputDir = resolve('.vercel', 'output');
+	const configs = files.filter(file =>
+		/.+\.prerender-config\.json$/gi.test(file)
+	);
+
+	const validRoutePaths = new Set<string>();
+
+	for (const file of configs) {
+		const routeInfo = await validateRoute(baseDir, file, outputDir);
+		if (!routeInfo) continue;
+
+		const { config, oldFile, newFile, newRoute } = routeInfo;
+		await createNewRouteFile(oldFile, newFile);
+
+		prerenderedRoutes.set(`/${newRoute}`, {
+			headers: config.initialHeaders,
+			overrides: getRouteOverrides(newRoute),
+		});
+
+		const oldFunc = file.replace(/\.prerender-config\.json$/gi, '.func');
+
+		validRoutePaths.add(file); // original config file
+		validRoutePaths.add(normalizePath(relative(baseDir, oldFile))); // original static file
+		validRoutePaths.add(oldFunc); // original function directory
+	}
+
+	// Remove files related to the prerendered routes from the functions list.
+	const functionFiles = files.filter(file => !validRoutePaths.has(file));
+
+	return functionFiles;
+}

--- a/src/buildApplication/generateFunctionsMap.ts
+++ b/src/buildApplication/generateFunctionsMap.ts
@@ -399,9 +399,9 @@ async function tryToFixFaviconFunc(): Promise<void> {
 }
 
 export type VercelPrerenderConfig = {
-	type: 'Prerender' | string;
+	type: string;
 	sourcePath?: string;
-	fallback: { type: 'FileFsRef' | string; mode: number; fsPath: string };
+	fallback: { type: string; mode: number; fsPath: string };
 	initialHeaders?: Record<string, string>;
 };
 export type PrerenderedFileData = {
@@ -410,8 +410,8 @@ export type PrerenderedFileData = {
 };
 
 /**
- * Extract the prerendered routes from a list of routes, copy the prerendered files to the static
- * output directory, and return a list of non-prerendered routes.
+ * Extracts the prerendered routes from a list of routes, copies the prerendered files to the
+ * `.vercel/static/output` directory, and returns a list of non-prerendered routes.
  *
  * Additionally, it creates paths to use for overrides for the routing process, along with the
  * correct headers to apply.

--- a/src/buildApplication/generateFunctionsMap.ts
+++ b/src/buildApplication/generateFunctionsMap.ts
@@ -16,6 +16,8 @@ import { cliError, cliWarn } from '../cli';
 import { tmpdir } from 'os';
 import type * as AST from 'ast-types/gen/kinds';
 import assert from 'node:assert';
+import type { PrerenderedFileData } from './fixPrerenderedRoutes';
+import { fixPrerenderedRoutes } from './fixPrerenderedRoutes';
 
 /**
  * Creates new files containing the Vercel built functions but adjusted so that they can be later
@@ -396,115 +398,6 @@ async function tryToFixFaviconFunc(): Promise<void> {
 	} catch {
 		cliWarn('Warning: No static favicon file found');
 	}
-}
-
-export type VercelPrerenderConfig = {
-	type: string;
-	sourcePath?: string;
-	fallback: { type: string; mode: number; fsPath: string };
-	initialHeaders?: Record<string, string>;
-};
-export type PrerenderedFileData = {
-	headers?: Record<string, string>;
-	overrides?: string[];
-};
-
-/**
- * Extracts the prerendered routes from a list of routes, copies the prerendered files to the
- * `.vercel/static/output` directory, and returns a list of non-prerendered routes.
- *
- * Additionally, it creates paths to use for overrides for the routing process, along with the
- * correct headers to apply.
- *
- * @param prerenderedRoutes Map of prerendered files.
- * @param files File paths to check for prerendered routes.
- * @param baseDir Base directory for the routes.
- * @returns List of non-prerendered routes.
- */
-async function fixPrerenderedRoutes(
-	prerenderedRoutes: Map<string, PrerenderedFileData>,
-	files: string[],
-	baseDir: string
-): Promise<string[]> {
-	const outputDir = resolve('.vercel', 'output');
-	// Get the prerender configs
-	const prerenderConfigs = files.filter(file =>
-		/.+\.prerender-config\.json$/gi.test(file)
-	);
-
-	const validPrerenderedRoutes = (
-		await Promise.all(
-			prerenderConfigs.map(async file => {
-				const configPath = join(baseDir, file);
-				const dirName = relative(join(outputDir, 'functions'), baseDir);
-				const config = await readJsonFile<VercelPrerenderConfig>(configPath);
-
-				if (
-					config?.type?.toLowerCase() !== 'prerender' ||
-					config?.fallback?.type?.toLowerCase() !== 'filefsref' ||
-					!config?.fallback?.fsPath
-				) {
-					const relativeName = normalizePath(join(dirName, file));
-					cliWarn(`Invalid prerender config for ${relativeName}`);
-					return [];
-				}
-				const { fallback } = config;
-
-				const oldRoute = normalizePath(join(dirName, fallback.fsPath));
-				const oldFile = join(outputDir, 'functions', oldRoute);
-				// Check the prerendered file exists.
-				if (!(await validateFile(oldFile))) {
-					cliWarn(`Could not find prerendered file for ${oldRoute}`);
-					return [];
-				}
-
-				const newRoute = normalizePath(
-					join(
-						dirName,
-						fallback.fsPath.replace(/(?:\.rsc)?\.prerender-fallback/gi, '')
-					)
-				);
-				const newFile = join(outputDir, 'static', newRoute);
-				// Check if a static file already exists at the new location.
-				if (await validateFile(newFile)) {
-					cliWarn(`Prerendered file already exists for ${newRoute}`);
-					return [];
-				}
-
-				await mkdir(dirname(newFile), { recursive: true });
-				await copyFile(oldFile, newFile);
-
-				// Create override entries that might normally be created through the build output config.
-				const formattedPathName = normalizePath(formatRoutePath(newRoute));
-				const withoutHtmlExt = formattedPathName.replace(/\.html$/, '');
-				const strippedIndexRoute = stripIndexRoute(withoutHtmlExt);
-				const overrides = new Set(
-					[formattedPathName, withoutHtmlExt, strippedIndexRoute].filter(
-						route => route !== `/${newRoute}`
-					)
-				);
-
-				prerenderedRoutes.set(`/${newRoute}`, {
-					headers: config.initialHeaders,
-					overrides: [...overrides],
-				});
-
-				const oldFunc = file.replace(/\.prerender-config\.json$/gi, '.func');
-
-				// Return the configs, static files, and function directories that can be ignored.
-				return [file, relative(baseDir, oldFile), oldFunc];
-			})
-		)
-	)
-		.flat()
-		.filter(Boolean) as string[];
-
-	// Remove files related to the prerendered routes from the functions list.
-	const functionFiles = files.filter(
-		file => !validPrerenderedRoutes.includes(file)
-	);
-
-	return functionFiles;
 }
 
 type ProcessingSetup = {

--- a/src/buildApplication/processVercelOutput.ts
+++ b/src/buildApplication/processVercelOutput.ts
@@ -9,7 +9,7 @@ import {
 import { cliLog, cliWarn } from '../cli';
 import type { MiddlewareManifestData } from './middlewareManifest';
 import { processVercelConfig } from './getVercelConfig';
-import type { PrerenderedFileData } from './generateFunctionsMap';
+import type { PrerenderedFileData } from './fixPrerenderedRoutes';
 
 /**
  * Extract a list of static assets from the Vercel build output.

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,5 +1,5 @@
-import { readdir, readFile, stat } from 'fs/promises';
-import { resolve } from 'path';
+import { readdir, readFile, stat, mkdir, copyFile } from 'fs/promises';
+import { resolve, dirname } from 'path';
 
 /**
  * Convert paths with backslashes to normalized paths with forward slashes.
@@ -114,4 +114,16 @@ export async function readPathsRecursively(dir: string): Promise<string[]> {
 	} catch {
 		return [];
 	}
+}
+
+/**
+ * Copies a file from one location to another, it also creates the destination
+ * directory if it doesn't exist
+ *
+ * @param sourceFile Original file path.
+ * @param destFile Destination for the file.
+ */
+export async function copyFileWithDir(sourceFile: string, destFile: string) {
+	await mkdir(dirname(destFile), { recursive: true });
+	await copyFile(sourceFile, destFile);
 }

--- a/tests/src/buildApplication/generateFunctionsMap.test.ts
+++ b/tests/src/buildApplication/generateFunctionsMap.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect, vi } from 'vitest';
+import type { VercelPrerenderConfig } from '../../../src/buildApplication/generateFunctionsMap';
 import { generateFunctionsMap } from '../../../src/buildApplication/generateFunctionsMap';
 import mockFs from 'mock-fs';
 import type { DirectoryItems } from 'mock-fs/lib/filesystem';
+import { join } from 'path';
 
 describe('generateFunctionsMap', async () => {
 	describe('without experimentalMinify should correctly handle', () => {
@@ -123,6 +125,279 @@ describe('generateFunctionsMap', async () => {
 		mockedWarn.mockRestore();
 	});
 
+	describe('prerendered routes should be handled correctly', () => {
+		test('succeeds for root-level prerendered index route', async () => {
+			const { functionsMap, prerenderedRoutes } =
+				await generateFunctionsMapFrom({
+					'page.func': validFuncDir,
+					'page.rsc.func': validFuncDir,
+					'index.func': invalidFuncDir,
+					'index.rsc.func': invalidFuncDir,
+					'index.prerender-config.json': mockPrerenderConfigFile('index', {
+						vary: true,
+					}),
+					'index.prerender-fallback.html': '',
+					'index.rsc.prerender-config.json': mockPrerenderConfigFile(
+						'index.rsc',
+						{ rscType: true, vary: true }
+					),
+					'index.rsc.prerender-fallback.rsc': '',
+				});
+
+			expect(functionsMap.size).toEqual(2);
+			expect(functionsMap.get('/page')).toMatch(/\/page\.func\.js$/);
+			expect(functionsMap.get('/page.rsc')).toMatch(/\/page\.rsc\.func\.js$/);
+
+			expect(prerenderedRoutes.size).toEqual(2);
+			expect(prerenderedRoutes.get('/index.html')).toEqual({
+				headers: { vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+				overrides: ['/index', '/'],
+			});
+			expect(prerenderedRoutes.get('/index.rsc')).toEqual({
+				headers: {
+					'content-type': 'text/x-component',
+					vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+				},
+				overrides: [],
+			});
+		});
+
+		test('succeeds for nested prerendered routes', async () => {
+			const { functionsMap, prerenderedRoutes } =
+				await generateFunctionsMapFrom({
+					'index.func': validFuncDir,
+					'index.rsc.func': validFuncDir,
+					nested: {
+						'foo.func': invalidFuncDir,
+						'foo.rsc.func': invalidFuncDir,
+						'foo.prerender-config.json': mockPrerenderConfigFile('foo', {
+							vary: true,
+						}),
+						'foo.prerender-fallback.html': '',
+						'foo.rsc.prerender-config.json': mockPrerenderConfigFile(
+							'foo.rsc',
+							{ rscType: true, vary: true }
+						),
+						'foo.rsc.prerender-fallback.rsc': '',
+						'bar.func': invalidFuncDir,
+						'bar.prerender-config.json': mockPrerenderConfigFile('bar', {
+							vary: true,
+						}),
+						'bar.prerender-fallback.html': '',
+					},
+				});
+
+			expect(functionsMap.size).toEqual(3);
+			expect(functionsMap.get('/')).toMatch(/\/index\.func\.js$/);
+			expect(functionsMap.get('/index')).toMatch(/\/index\.func\.js$/);
+			expect(functionsMap.get('/index.rsc')).toMatch(/\/index\.rsc\.func\.js$/);
+
+			expect(prerenderedRoutes.size).toEqual(3);
+			expect(prerenderedRoutes.get('/nested/foo.html')).toEqual({
+				headers: { vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+				overrides: ['/nested/foo'],
+			});
+			expect(prerenderedRoutes.get('/nested/foo.rsc')).toEqual({
+				headers: {
+					'content-type': 'text/x-component',
+					vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+				},
+				overrides: [],
+			});
+			expect(prerenderedRoutes.get('/nested/bar.html')).toEqual({
+				headers: { vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+				overrides: ['/nested/bar'],
+			});
+		});
+
+		test('succeeds for prerendered routes inside route groups', async () => {
+			const { functionsMap, prerenderedRoutes } =
+				await generateFunctionsMapFrom({
+					'index.func': validFuncDir,
+					'index.rsc.func': validFuncDir,
+					nested: {
+						'(route-group)': {
+							'foo.func': invalidFuncDir,
+							'foo.prerender-config.json': mockPrerenderConfigFile('foo', {
+								vary: true,
+							}),
+							'foo.prerender-fallback.html': '',
+						},
+					},
+				});
+
+			expect(functionsMap.size).toEqual(3);
+			expect(functionsMap.get('/')).toMatch(/\/index\.func\.js$/);
+			expect(functionsMap.get('/index')).toMatch(/\/index\.func\.js$/);
+			expect(functionsMap.get('/index.rsc')).toMatch(/\/index\.rsc\.func\.js$/);
+
+			expect(prerenderedRoutes.size).toEqual(1);
+			expect(prerenderedRoutes.get('/nested/(route-group)/foo.html')).toEqual({
+				headers: { vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+				overrides: ['/nested/foo.html', '/nested/foo'],
+			});
+		});
+
+		test('fails with existing static file', async () => {
+			const mockedWarn = vi
+				.spyOn(console, 'warn')
+				.mockImplementation(() => null);
+
+			const { functionsMap, invalidFunctions, prerenderedRoutes } =
+				await generateFunctionsMapFrom(
+					{
+						'index.func': invalidFuncDir,
+						'index.rsc.func': invalidFuncDir,
+						'index.prerender-config.json': mockPrerenderConfigFile('index', {
+							vary: true,
+						}),
+						'index.prerender-fallback.html': '',
+						'index.rsc.prerender-config.json': mockPrerenderConfigFile(
+							'index.rsc',
+							{ rscType: true, vary: true }
+						),
+						'index.rsc.prerender-fallback.rsc': '',
+					},
+					{ 'index.rsc': '' }
+				);
+
+			expect(functionsMap.size).toEqual(0);
+
+			expect(prerenderedRoutes.size).toEqual(1);
+			expect(prerenderedRoutes.get('/index.html')).toEqual({
+				headers: { vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+				overrides: ['/index', '/'],
+			});
+
+			expect(invalidFunctions.size).toEqual(1);
+			expect(invalidFunctions.has('index.rsc.func')).toEqual(true);
+
+			expect(mockedWarn).toHaveBeenCalledTimes(1);
+			expect(mockedWarn).toHaveBeenCalledWith(
+				expect.stringMatching(/Prerendered file already exists for index.rsc/)
+			);
+			mockedWarn.mockRestore();
+		});
+
+		test('fails with existing nested static file', async () => {
+			const mockedWarn = vi
+				.spyOn(console, 'warn')
+				.mockImplementation(() => null);
+
+			const { functionsMap, invalidFunctions, prerenderedRoutes } =
+				await generateFunctionsMapFrom(
+					{
+						nested: {
+							'page.func': invalidFuncDir,
+							'page.rsc.func': invalidFuncDir,
+							'page.prerender-config.json': mockPrerenderConfigFile('page', {
+								vary: true,
+							}),
+							'page.prerender-fallback.html': '',
+							'page.rsc.prerender-config.json': mockPrerenderConfigFile(
+								'page.rsc',
+								{ rscType: true, vary: true }
+							),
+							'page.rsc.prerender-fallback.rsc': '',
+						},
+					},
+					{ nested: { 'page.rsc': '' } }
+				);
+
+			expect(functionsMap.size).toEqual(0);
+
+			expect(prerenderedRoutes.size).toEqual(1);
+			expect(prerenderedRoutes.get('/nested/page.html')).toEqual({
+				headers: { vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+				overrides: ['/nested/page'],
+			});
+
+			expect(invalidFunctions.size).toEqual(1);
+			expect(invalidFunctions.has('page.rsc.func')).toEqual(true);
+
+			expect(mockedWarn).toHaveBeenCalledTimes(1);
+			expect(mockedWarn).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/Prerendered file already exists for nested\/page.rsc/
+				)
+			);
+			mockedWarn.mockRestore();
+		});
+
+		test('fails with missing file', async () => {
+			const mockedWarn = vi
+				.spyOn(console, 'warn')
+				.mockImplementation(() => null);
+
+			const { functionsMap, invalidFunctions, prerenderedRoutes } =
+				await generateFunctionsMapFrom({
+					nested: {
+						'index.func': invalidFuncDir,
+						'index.rsc.func': invalidFuncDir,
+						'index.prerender-config.json': mockPrerenderConfigFile('index', {
+							vary: true,
+						}),
+						'index.prerender-fallback.html': '',
+						'index.rsc.prerender-config.json': mockPrerenderConfigFile(
+							'index.rsc',
+							{ rscType: true, vary: true }
+						),
+					},
+				});
+
+			expect(functionsMap.size).toEqual(0);
+
+			expect(prerenderedRoutes.size).toEqual(1);
+			expect(prerenderedRoutes.get('/nested/index.html')).toEqual({
+				headers: { vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+				overrides: ['/nested/index', '/nested'],
+			});
+
+			expect(invalidFunctions.size).toEqual(1);
+			expect(invalidFunctions.has('index.rsc.func')).toEqual(true);
+
+			expect(mockedWarn).toHaveBeenCalledTimes(1);
+			expect(mockedWarn).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/Could not find prerendered file for nested\/index.rsc.prerender-fallback.rsc/
+				)
+			);
+			mockedWarn.mockRestore();
+		});
+
+		test('fails with invalid config', async () => {
+			const mockedWarn = vi
+				.spyOn(console, 'warn')
+				.mockImplementation(() => null);
+
+			const { functionsMap, invalidFunctions, prerenderedRoutes } =
+				await generateFunctionsMapFrom({
+					nested: {
+						'index.func': invalidFuncDir,
+						'index.prerender-config.json': JSON.stringify({
+							type: 'Prerender',
+							fallback: { type: 'FileFsRef', fsPath: '' },
+						}),
+						'index.prerender-fallback.html': '',
+					},
+				});
+
+			expect(functionsMap.size).toEqual(0);
+			expect(prerenderedRoutes.size).toEqual(0);
+
+			expect(invalidFunctions.size).toEqual(1);
+			expect(invalidFunctions.has('index.func')).toEqual(true);
+
+			expect(mockedWarn).toHaveBeenCalledTimes(1);
+			expect(mockedWarn).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/Invalid prerender config for nested\/index.prerender-config.json/
+				)
+			);
+			mockedWarn.mockRestore();
+		});
+	});
+
 	// TODO: add tests that also test the functions map with the experimentalMinify flag
 });
 
@@ -148,12 +423,53 @@ const invalidFuncDir = {
 
 async function generateFunctionsMapFrom(
 	functions: DirectoryItems,
+	staticAssets: DirectoryItems = {},
 	experimentalMinify = false
 ) {
 	mockFs({
-		functions,
+		'.vercel': {
+			output: {
+				functions,
+				static: staticAssets,
+			},
+		},
 	});
-	const result = await generateFunctionsMap('functions', experimentalMinify);
+	const result = await generateFunctionsMap(
+		join('.vercel', 'output', 'functions'),
+		experimentalMinify
+	);
 	mockFs.restore();
 	return result;
+}
+
+/**
+ * Create a fake prerender config file for testing.
+ *
+ * @param path Path name for the file in the build output.
+ * @param args.rscType Whether the file should have the rsc file mime type header.
+ * @param args.vary Whether the file should have a vary header.
+ * @returns The stringified prerender config file contents.
+ */
+function mockPrerenderConfigFile(
+	path: string,
+	{ rscType, vary }: { rscType?: boolean; vary?: boolean } = {}
+): string {
+	const fsPath = path.endsWith('.rsc')
+		? `${path}.prerender-fallback.rsc`
+		: `${path}.prerender-fallback.html`;
+	const config: VercelPrerenderConfig = {
+		type: 'Prerender',
+		fallback: {
+			type: 'FileFsRef',
+			mode: 0,
+			fsPath,
+		},
+		initialHeaders: {
+			...(rscType && { 'content-type': 'text/x-component' }),
+			...(vary && {
+				vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+			}),
+		},
+	};
+	return JSON.stringify(config);
 }

--- a/tests/src/buildApplication/generateFunctionsMap.test.ts
+++ b/tests/src/buildApplication/generateFunctionsMap.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from 'vitest';
-import type { VercelPrerenderConfig } from '../../../src/buildApplication/generateFunctionsMap';
+import type { VercelPrerenderConfig } from '../../../src/buildApplication/fixPrerenderedRoutes';
 import { generateFunctionsMap } from '../../../src/buildApplication/generateFunctionsMap';
 import mockFs from 'mock-fs';
 import type { DirectoryItems } from 'mock-fs/lib/filesystem';

--- a/tests/src/buildApplication/processVercelOutput.test.ts
+++ b/tests/src/buildApplication/processVercelOutput.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest';
 import { processVercelOutput } from '../../../src/buildApplication/processVercelOutput';
+import type { PrerenderedFileData } from '../../../src/buildApplication/generateFunctionsMap';
 
 describe('processVercelOutput', () => {
 	test('should process the config and build output correctly', () => {
@@ -18,6 +19,7 @@ describe('processVercelOutput', () => {
 		const processed = processVercelOutput(
 			inputtedConfig,
 			['/static/test.png'],
+			new Map<string, PrerenderedFileData>(),
 			{
 				hydratedMiddleware: new Map([
 					['/middleware', { filepath: '/middleware/index.js', matchers: [] }],
@@ -86,6 +88,7 @@ describe('processVercelOutput', () => {
 		const processed = processVercelOutput(
 			inputtedConfig,
 			['/404.html', '/500.html', '/index.html', '/test.html'],
+			new Map<string, PrerenderedFileData>(),
 			{
 				hydratedMiddleware: new Map([]),
 				hydratedFunctions: new Map([
@@ -125,7 +128,7 @@ describe('processVercelOutput', () => {
 				[
 					'/404.html',
 					{
-						contentType: 'text/html; charset=utf-8',
+						headers: { 'content-type': 'text/html; charset=utf-8' },
 						path: '/404.html',
 						type: 'override',
 					},
@@ -133,7 +136,7 @@ describe('processVercelOutput', () => {
 				[
 					'/500.html',
 					{
-						contentType: 'text/html; charset=utf-8',
+						headers: { 'content-type': 'text/html; charset=utf-8' },
 						path: '/500.html',
 						type: 'override',
 					},
@@ -141,7 +144,7 @@ describe('processVercelOutput', () => {
 				[
 					'/index.html',
 					{
-						contentType: 'text/html; charset=utf-8',
+						headers: { 'content-type': 'text/html; charset=utf-8' },
 						path: '/index.html',
 						type: 'override',
 					},
@@ -163,7 +166,7 @@ describe('processVercelOutput', () => {
 				[
 					'/404',
 					{
-						contentType: 'text/html; charset=utf-8',
+						headers: { 'content-type': 'text/html; charset=utf-8' },
 						path: '/404.html',
 						type: 'override',
 					},
@@ -171,7 +174,7 @@ describe('processVercelOutput', () => {
 				[
 					'/500',
 					{
-						contentType: 'text/html; charset=utf-8',
+						headers: { 'content-type': 'text/html; charset=utf-8' },
 						path: '/500.html',
 						type: 'override',
 					},
@@ -179,7 +182,7 @@ describe('processVercelOutput', () => {
 				[
 					'/index',
 					{
-						contentType: 'text/html; charset=utf-8',
+						headers: { 'content-type': 'text/html; charset=utf-8' },
 						path: '/index.html',
 						type: 'override',
 					},
@@ -187,8 +190,212 @@ describe('processVercelOutput', () => {
 				[
 					'/',
 					{
-						contentType: 'text/html; charset=utf-8',
+						headers: { 'content-type': 'text/html; charset=utf-8' },
 						path: '/index.html',
+						type: 'override',
+					},
+				],
+			]),
+		});
+	});
+
+	test('applies prerendered routes to the outputted functions', () => {
+		const inputtedConfig: VercelConfig = {
+			version: 3,
+			routes: [],
+			overrides: {
+				'404.html': { path: '404', contentType: 'text/html; charset=utf-8' },
+				'500.html': { path: '500', contentType: 'text/html; charset=utf-8' },
+				'index.html': {
+					path: 'index',
+					contentType: 'text/html; charset=utf-8',
+				},
+			},
+		};
+
+		const processed = processVercelOutput(
+			inputtedConfig,
+			[
+				'/404.html',
+				'/500.html',
+				'/index.html',
+				'/index.rsc',
+				'/nested/(route-group)/foo.html',
+			],
+			new Map<string, PrerenderedFileData>([
+				[
+					'/index.html',
+					{
+						headers: {
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						overrides: ['/index', '/'],
+					},
+				],
+				[
+					'/index.rsc',
+					{
+						headers: {
+							'content-type': 'text/x-component',
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						overrides: [],
+					},
+				],
+				[
+					'/nested/(route-group)/foo.html',
+					{
+						headers: {
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						overrides: ['/nested/foo.html', '/nested/foo'],
+					},
+				],
+			]),
+			{
+				hydratedMiddleware: new Map([]),
+				hydratedFunctions: new Map([
+					['/page', { filepath: '/page/index.js', matchers: [] }],
+				]),
+			}
+		);
+
+		expect(processed).toEqual({
+			vercelConfig: {
+				version: 3,
+				routes: {
+					none: [],
+					filesystem: [],
+					miss: [],
+					rewrite: [],
+					resource: [],
+					hit: [],
+					error: [],
+				},
+				overrides: {
+					'404.html': {
+						contentType: 'text/html; charset=utf-8',
+						path: '404',
+					},
+					'500.html': {
+						contentType: 'text/html; charset=utf-8',
+						path: '500',
+					},
+					'index.html': {
+						contentType: 'text/html; charset=utf-8',
+						path: 'index',
+					},
+				},
+			},
+			vercelOutput: new Map([
+				[
+					'/404.html',
+					{
+						headers: { 'content-type': 'text/html; charset=utf-8' },
+						path: '/404.html',
+						type: 'override',
+					},
+				],
+				[
+					'/500.html',
+					{
+						headers: { 'content-type': 'text/html; charset=utf-8' },
+						path: '/500.html',
+						type: 'override',
+					},
+				],
+				[
+					'/index.html',
+					{
+						headers: {
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						path: '/index.html',
+						type: 'override',
+					},
+				],
+				[
+					'/index.rsc',
+					{
+						headers: {
+							'content-type': 'text/x-component',
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						path: '/index.rsc',
+						type: 'override',
+					},
+				],
+				[
+					'/nested/(route-group)/foo.html',
+					{
+						headers: {
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						path: '/nested/(route-group)/foo.html',
+						type: 'override',
+					},
+				],
+				[
+					'/page',
+					{
+						entrypoint: '/page/index.js',
+						matchers: [],
+						type: 'function',
+					},
+				],
+				[
+					'/404',
+					{
+						headers: { 'content-type': 'text/html; charset=utf-8' },
+						path: '/404.html',
+						type: 'override',
+					},
+				],
+				[
+					'/500',
+					{
+						headers: { 'content-type': 'text/html; charset=utf-8' },
+						path: '/500.html',
+						type: 'override',
+					},
+				],
+				[
+					'/index',
+					{
+						headers: {
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						path: '/index.html',
+						type: 'override',
+					},
+				],
+				[
+					'/',
+					{
+						headers: {
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						path: '/index.html',
+						type: 'override',
+					},
+				],
+				[
+					'/nested/foo.html',
+					{
+						headers: {
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						path: '/nested/(route-group)/foo.html',
+						type: 'override',
+					},
+				],
+				[
+					'/nested/foo',
+					{
+						headers: {
+							vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+						},
+						path: '/nested/(route-group)/foo.html',
 						type: 'override',
 					},
 				],

--- a/tests/src/utils/fs.test.ts
+++ b/tests/src/utils/fs.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll } from 'vitest';
 import {
+	copyFileWithDir,
 	normalizePath,
 	readJsonFile,
 	readPathsRecursively,
@@ -146,5 +147,36 @@ describe('readPathsRecursively', () => {
 		await expect(
 			readPathsRecursively('invalid-root/functions')
 		).resolves.toEqual([]);
+	});
+});
+
+describe('copyFileWithDir', () => {
+	test('should copy file to missing directory', async () => {
+		mockFs({
+			folder: {
+				'index.js': 'valid-file',
+			},
+		});
+
+		await expect(validateDir('new-folder')).resolves.toEqual(false);
+		await copyFileWithDir('folder/index.js', 'new-folder/index.js');
+		await expect(validateFile('new-folder/index.js')).resolves.toEqual(true);
+
+		mockFs.restore();
+	});
+
+	test('should copy file to existing directory', async () => {
+		mockFs({
+			folder: {
+				'index.js': 'valid-file',
+			},
+			'new-folder': {},
+		});
+
+		await expect(validateDir('new-folder')).resolves.toEqual(true);
+		await copyFileWithDir('folder/index.js', 'new-folder/index.js');
+		await expect(validateFile('new-folder/index.js')).resolves.toEqual(true);
+
+		mockFs.restore();
 	});
 });

--- a/vercel.types.d.ts
+++ b/vercel.types.d.ts
@@ -140,8 +140,8 @@ type ProcessedVercelConfig = Override<
 type BuildOutputStaticAsset = { type: 'static' };
 type BuildOutputStaticOverride = {
 	type: 'override';
-	path?: string;
-	contentType?: string;
+	path: string;
+	headers?: Record<string, string>;
 };
 type BuildOutputStaticItem = BuildOutputStaticAsset | BuildOutputStaticOverride;
 


### PR DESCRIPTION
This PR does the following before processing a directory for functions:
- Checks for any prerendered route configs.
- Checks if prerendered routes already exist in the static assets directory.
- Copies prerendered routes to the static assets directory.
- Returns a filtered list of paths to process that excludes the valid prerendered routes.
- Applies overrides to the build output for prerendered routes, like what would normally happen with static pages in the build output config.
- Adds tests for the new behaviour.