### PR TITLE
fix: prevent infinite loops during routing edge case

### DIFF
--- a/.changeset/unlucky-chicken-join.md
+++ b/.changeset/unlucky-chicken-join.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Prevent infinite loops from occuring when checking phases during routing.

--- a/tests/templates/handleRequest.test.ts
+++ b/tests/templates/handleRequest.test.ts
@@ -5,6 +5,7 @@ import {
 	checkRouteMatchTestSet,
 	configRewritesRedirectsHeadersTestSet,
 	dynamicRoutesTestSet,
+	infiniteLoopTestSet,
 	middlewareTestSet,
 } from './requestTestData';
 import type { TestCase, TestSet } from '../_helpers';
@@ -94,6 +95,7 @@ suite('router', () => {
 		checkRouteMatchTestSet,
 		configRewritesRedirectsHeadersTestSet,
 		dynamicRoutesTestSet,
+		infiniteLoopTestSet,
 		middlewareTestSet,
 	].forEach(testSet => {
 		describe(testSet.name, () => runTestSet(testSet));

--- a/tests/templates/requestTestData/index.ts
+++ b/tests/templates/requestTestData/index.ts
@@ -3,4 +3,5 @@ export { testSet as basicStaticAppDirTestSet } from './basicStaticAppDir';
 export { testSet as checkRouteMatchTestSet } from './checkRouteMatch';
 export { testSet as configRewritesRedirectsHeadersTestSet } from './configRewritesRedirectsHeaders';
 export { testSet as dynamicRoutesTestSet } from './dynamicRoutes';
+export { testSet as infiniteLoopTestSet } from './infiniteLoop';
 export { testSet as middlewareTestSet } from './middleware';

--- a/tests/templates/requestTestData/infiniteLoop.ts
+++ b/tests/templates/requestTestData/infiniteLoop.ts
@@ -1,0 +1,82 @@
+import type { TestSet } from '../../_helpers';
+import { createValidFuncDir } from '../../_helpers';
+
+// runaway phase checking, aka infinitely looping through phases.
+
+const rawVercelConfig: VercelConfig = {
+	version: 3,
+	routes: [
+		{ src: '^/invalid$', dest: '/invalid/new', status: 404 },
+		{ handle: 'filesystem' },
+		{ src: '^/infinite$', dest: '/infinite/new' },
+		{ handle: 'miss' },
+		{ src: '^/invalid/new$', dest: '/invalid', check: true },
+		{ src: '^/infinite/new$', dest: '/infinite', check: true },
+		{ handle: 'hit' },
+		{
+			src: '/((?!index$).*)',
+			headers: { 'x-matched-path': '/$1' },
+			continue: true,
+			important: true,
+		},
+		{ handle: 'error' },
+		{ src: '/.*', dest: '/404', status: 404 },
+		{ src: '/.*', dest: '/500', status: 500 },
+	],
+	overrides: {
+		'404.html': { path: '404', contentType: 'text/html; charset=utf-8' },
+		'500.html': { path: '500', contentType: 'text/html; charset=utf-8' },
+	},
+};
+
+export const testSet: TestSet = {
+	name: 'infinite loop during route matching',
+	config: rawVercelConfig,
+	files: {
+		functions: { api: { 'hello.func': createValidFuncDir('/api/hello') } },
+		static: { '404.html': '<html>404</html>', '500.html': '<html>500</html>' },
+	},
+	testCases: [
+		{
+			name: 'regular route is processed normally',
+			paths: ['/api/hello'],
+			expected: {
+				status: 200,
+				data: JSON.stringify({ file: '/api/hello', params: [] }),
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+					'x-matched-path': '/api/hello',
+				},
+			},
+		},
+		{
+			name: 'invalid asset with contradicting `miss` and `none` returns 404',
+			paths: ['/invalid'],
+			expected: {
+				status: 404,
+				data: '<html>404</html>',
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/404',
+				},
+			},
+		},
+		{
+			name: 'infinite phase checking returns 500 and logs an error',
+			paths: ['/infinite'],
+			expected: {
+				status: 500,
+				data: '<html>500</html>',
+				mockConsole: {
+					error: [
+						'Routing encountered an infinite loop while checking /infinite',
+					],
+				},
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/500',
+				},
+			},
+		},
+	],
+};


### PR DESCRIPTION
This PR does the following:
- Introduces a counter for keeping track of how many times the `checkPhase` function is called for each run of the route matcher.
  - Returns a 500 error after the counter exceeds 50 loops - this indicates infinite looping.
- Changes the `check: true` behaviour for the `miss` phase.
  - If the path is not in the build output, it enters the `filesystem` phase as the `none` phase may cause infinite loops with i18n.
  - If a path is in the build output, it resets the status code if it was previously set to 404, and continues with routing like normal.
- Unintentionally introduces basic i18n support.


With i18n, there is a rule in the `none` phase that maps a request from `/*` to `/{default-locale}/*`. At the same time, there is a rule in the `miss` phase to map requests to `/{locale}/*` to `/*`. Because of this, when we encounter `check: true` in the `miss` phase, we need to change the default behaviour to act as detailed above.

Although infinite loops when checking phases *shouldn't* happen, this edge case proves it's possible, hence why the counter has been introduced.

Anyway, onto the exciting part! This fix unintentionally introduces basic support for internationalized routing with the `i18n` option in `next.config.js`! There is still some additional work to do to get full i18n support, so I'm not doing this PR as an i18n one - that'll come when I finish the other bits for i18n and write tests.