### PR TITLE
feat: i18n locale redirects support

### DIFF
--- a/.changeset/six-squids-tickle.md
+++ b/.changeset/six-squids-tickle.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Support for the internationalization (`i18n`) option in `next.config.js`, and locale redirects.

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -25,7 +25,7 @@ Earlier and Later versions might be only partially supported, we don't fully kno
 | routes `status`         | ✅      |
 | routes `has`            | ✅      |
 | routes `missing`        | ✅      |
-| routes `locale`         | 🔄      |
+| routes `locale`         | ✅      |
 | routes `middlewarePath` | ✅      |
 | images<sup>1</sup>      | 🔄      |
 | wildcard                | 🔄      |
@@ -70,7 +70,7 @@ Earlier and Later versions might be only partially supported, we don't fully kno
 | URL imports                                | ✅      |
 | build indicator<sup>7</sup>                | ❌      |
 | Turbopack-specific options<sup>8</sup>     | ❌      |
-| internationalized (i18n) routing           | 🔄      |
+| internationalized (i18n) routing           | ✅      |
 
     - ✅: Supported
     - 🔄: Not currently supported, but it's probably possible and we may add support in the future

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -323,8 +323,8 @@ export class RoutesMatcher {
 			locale: { redirect: redirects, cookie: cookieName },
 		} = route;
 
-		const cookieValue = cookieName ? this.cookies[cookieName] ?? '' : '';
-		const cookieLocales = parseAcceptLanguage(cookieValue);
+		const cookieValue = cookieName && this.cookies[cookieName];
+		const cookieLocales = parseAcceptLanguage(cookieValue ?? '');
 
 		const headerLocales = parseAcceptLanguage(
 			this.reqCtx.request.headers.get('accept-language') ?? ''

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -43,9 +43,7 @@ export class RoutesMatcher {
 	 *
 	 * @param routes The processed Vercel build output config routes.
 	 * @param output Vercel build output.
-	 * @param assets Static assets fetcher.
-	 * @param ctx Execution context.
-	 * @param req Request object.
+	 * @param reqCtx Request context object; request object, assets fetcher, and execution context.
 	 * @param prevMatch The previous match from a routing phase to initialize the matcher with.
 	 * @returns The matched set of path, status, headers, and search params.
 	 */
@@ -405,7 +403,7 @@ export class RoutesMatcher {
 		if (
 			phase === 'hit' ||
 			isUrl(this.path) ||
-			(!shouldContinue && this.headers.normal.has('location'))
+			this.headers.normal.has('location')
 		) {
 			return 'done';
 		}

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -328,18 +328,15 @@ export class RoutesMatcher {
 		// Locales from the cookie take precedence over the header.
 		const locales = [...cookieLocales, ...headerLocales];
 
-		for (const locale of locales) {
-			const redirectValue = redirects[locale];
-			if (!redirectValue) continue;
+		const redirectLocales = locales.map(locale => redirects[locale]).filter(Boolean) as string[];
 
-			// If the path starts with the redirect, we should already be in the right place. Bail out.
-			if (this.path.startsWith(redirectValue)) {
-				return;
+		const redirectValue = redirectLocales[0];
+		if (redirectValue) {
+			const needsRedirecting = !this.path.startsWith(redirectValue);
+			if (needsRedirecting) {
+				this.headers.normal.set('location', redirectValue);
+				this.status = 307;
 			}
-
-			// Redirect found, set the location header and bail out.
-			this.headers.normal.set('location', redirectValue);
-			this.status = 307;
 			return;
 		}
 	}

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -36,6 +36,8 @@ export class RoutesMatcher {
 
 	/** Counter for how many times the function to check a phase has been called */
 	public checkPhaseCounter;
+	/** Locales found during routing */
+	public locales: Record<string, string> | undefined;
 
 	/**
 	 * Creates a new instance of a request matcher.
@@ -304,6 +306,9 @@ export class RoutesMatcher {
 	private applyLocaleRedirects(route: VercelSource): void {
 		if (!route.locale?.redirect) return;
 
+		if (!this.locales) this.locales = {};
+		Object.assign(this.locales, route.locale.redirect);
+
 		// Automatic locale detection is only supposed to occur at the root. However, the build output
 		// sometimes uses `/` as the regex instead of `^/$`. So, we should check if the `route.src` is
 		// equal to the path if it is not a regular expression, to determine if we are at the root.
@@ -318,17 +323,19 @@ export class RoutesMatcher {
 			locale: { redirect: redirects, cookie: cookieName },
 		} = route;
 
-		const cookieValue = cookieName ? this.cookies[cookieName] : '';
+		const cookieValue = cookieName ? this.cookies[cookieName] ?? '' : '';
 		const cookieLocales = parseAcceptLanguage(cookieValue);
 
 		const headerLocales = parseAcceptLanguage(
-			this.reqCtx.request.headers.get('accept-language')
+			this.reqCtx.request.headers.get('accept-language') ?? ''
 		);
 
 		// Locales from the cookie take precedence over the header.
 		const locales = [...cookieLocales, ...headerLocales];
 
-		const redirectLocales = locales.map(locale => redirects[locale]).filter(Boolean) as string[];
+		const redirectLocales = locales
+			.map(locale => redirects[locale])
+			.filter(Boolean) as string[];
 
 		const redirectValue = redirectLocales[0];
 		if (redirectValue) {
@@ -342,6 +349,37 @@ export class RoutesMatcher {
 	}
 
 	/**
+	 * Modifies the source route's `src` regex to be friendly with previously found locale's in the
+	 * `miss` phase.
+	 *
+	 * Sometimes, there is a source route with `src: '/{locale}'`, which rewrites all paths containing
+	 * the locale to `/`. This is problematic for matching, and should only do this if the path is
+	 * exactly the locale, i.e. `^/{locale}$`.
+	 *
+	 * @param route Build output config source route.
+	 * @param phase Current phase of the routing process.
+	 * @returns The route with the locale friendly regex.
+	 */
+	private getLocaleFriendlyRoute(
+		route: VercelSource,
+		phase: VercelPhase
+	): VercelSource {
+		if (
+			!this.locales ||
+			phase !== 'miss' ||
+			!/^\//.test(route.src) ||
+			!(route.src.slice(1) in this.locales)
+		) {
+			return route;
+		}
+
+		return {
+			...route,
+			src: `^${route.src}$`,
+		};
+	}
+
+	/**
 	 * Checks a route to see if it matches the current request.
 	 *
 	 * @param phase Current phase of the routing process.
@@ -350,8 +388,9 @@ export class RoutesMatcher {
 	 */
 	private async checkRoute(
 		phase: VercelPhase,
-		route: VercelSource
+		rawRoute: VercelSource
 	): Promise<CheckRouteStatus> {
+		const route = this.getLocaleFriendlyRoute(rawRoute, phase);
 		const routeMatch = this.checkRouteMatch(route, phase === 'error');
 
 		// If this route doesn't match, continue to the next one.

--- a/templates/_worker.js/utils/http.ts
+++ b/templates/_worker.js/utils/http.ts
@@ -99,7 +99,7 @@ export function parseAcceptLanguage(headerValue?: string | null): string[] {
 		.split(',')
 		.map(val => {
 			const [lang, qual] = val.split(';') as [string, string | undefined];
-			const quality = parseFloat((qual ?? 'q=1').replace(/q ?= ?/gi, ''));
+			const quality = parseFloat((qual ?? 'q=1').replace(/q *= */gi, ''));
 
 			return [lang.trim(), isNaN(quality) ? 1 : quality] as [string, number];
 		})

--- a/templates/_worker.js/utils/http.ts
+++ b/templates/_worker.js/utils/http.ts
@@ -95,7 +95,7 @@ export function createMutableResponse(resp: Response) {
  * @returns Array of locales sorted by quality.
  */
 export function parseAcceptLanguage(headerValue: string): string[] {
-	return (headerValue ?? '')
+	return headerValue
 		.split(',')
 		.map(val => {
 			const [lang, qual] = val.split(';') as [string, string | undefined];

--- a/templates/_worker.js/utils/http.ts
+++ b/templates/_worker.js/utils/http.ts
@@ -87,3 +87,23 @@ export function createRouteRequest(req: Request, path: string) {
 export function createMutableResponse(resp: Response) {
 	return new Response(resp.body, resp);
 }
+
+/**
+ * Parses the Accept-Language header value and returns an array of locales sorted by quality.
+ *
+ * @param headerValue Accept-Language header value.
+ * @returns Array of locales sorted by quality.
+ */
+export function parseAcceptLanguage(headerValue?: string | null): string[] {
+	return (headerValue ?? '')
+		.split(',')
+		.map(val => {
+			const [lang, qual] = val.split(';') as [string, string | undefined];
+			const quality = parseFloat((qual ?? 'q=1').replace(/q ?= ?/gi, ''));
+
+			return [lang.trim(), isNaN(quality) ? 1 : quality] as [string, number];
+		})
+		.sort((a, b) => b[1] - a[1])
+		.map(([locale]) => (locale === '*' || locale === '' ? [] : locale))
+		.flat();
+}

--- a/templates/_worker.js/utils/http.ts
+++ b/templates/_worker.js/utils/http.ts
@@ -94,7 +94,7 @@ export function createMutableResponse(resp: Response) {
  * @param headerValue Accept-Language header value.
  * @returns Array of locales sorted by quality.
  */
-export function parseAcceptLanguage(headerValue?: string | null): string[] {
+export function parseAcceptLanguage(headerValue: string): string[] {
 	return (headerValue ?? '')
 		.split(',')
 		.map(val => {

--- a/tests/templates/handleRequest.test.ts
+++ b/tests/templates/handleRequest.test.ts
@@ -5,6 +5,7 @@ import {
 	checkRouteMatchTestSet,
 	configRewritesRedirectsHeadersTestSet,
 	dynamicRoutesTestSet,
+	i18nTestSet,
 	infiniteLoopTestSet,
 	middlewareTestSet,
 } from './requestTestData';
@@ -95,6 +96,7 @@ suite('router', () => {
 		checkRouteMatchTestSet,
 		configRewritesRedirectsHeadersTestSet,
 		dynamicRoutesTestSet,
+		i18nTestSet,
 		infiniteLoopTestSet,
 		middlewareTestSet,
 	].forEach(testSet => {

--- a/tests/templates/requestTestData/basicEdgeAppDir.ts
+++ b/tests/templates/requestTestData/basicEdgeAppDir.ts
@@ -166,9 +166,9 @@ export const testSet: TestSet = {
 			},
 		},
 		{
-			name: 'trailing slash redirects to non-trailing slash',
+			name: 'trailing slash redirects (308) to non-trailing slash',
 			paths: ['/api/hello/'],
-			expected: { status: 307, data: '', headers: { location: '/api/hello' } },
+			expected: { status: 308, data: '', headers: { location: '/api/hello' } },
 		},
 		{
 			name: 'valid `_next/static` file returns the cache headers',

--- a/tests/templates/requestTestData/i18n.ts
+++ b/tests/templates/requestTestData/i18n.ts
@@ -1,0 +1,348 @@
+import type { TestSet } from '../../_helpers';
+import { createValidFuncDir } from '../../_helpers';
+
+// next.config.js internationalization (i18n); sub-path routing, and domain routing.
+
+const rawVercelConfig: VercelConfig = {
+	version: 3,
+	routes: [
+		{
+			src: '^(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))/$',
+			headers: { Location: '/$1' },
+			status: 308,
+			continue: true,
+		},
+		{
+			src: '/_next/__private/trace',
+			dest: '/404',
+			status: 404,
+			continue: true,
+		},
+		{
+			src: '^/(?!(?:_next/.*|en|fr|nl|es)(?:/.*|$))(.*)$',
+			dest: '$wildcard/$1',
+			continue: true,
+		},
+		{
+			src: '^//?(?:en|fr|nl|es)?/?$',
+			locale: {
+				redirect: { es: 'https://example.es/' },
+				cookie: 'NEXT_LOCALE',
+			},
+			continue: true,
+		},
+		{
+			src: '/',
+			locale: {
+				redirect: { en: '/', fr: '/fr', nl: '/nl', es: '/es' },
+				cookie: 'NEXT_LOCALE',
+			},
+			continue: true,
+		},
+		{ src: '^/$', dest: '/en', continue: true },
+		{
+			src: '^/(?!(?:_next/.*|en|fr|nl|es)(?:/.*|$))(.*)$',
+			dest: '/en/$1',
+			continue: true,
+		},
+		{
+			src: '/(?:en|fr|nl|es)?[/]?404/?',
+			status: 404,
+			continue: true,
+			missing: [{ type: 'header', key: 'x-prerender-revalidate' }],
+		},
+		{ src: '/(?:en|fr|nl|es)?[/]?500', status: 500, continue: true },
+		{ handle: 'filesystem' },
+		{ src: '/_next/data/(.*)', dest: '/_next/data/$1', check: true },
+		{ handle: 'resource' },
+		{ src: '/.*', status: 404 },
+		{ handle: 'miss' },
+		{
+			src: '/_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|image|media)/.+',
+			status: 404,
+			check: true,
+			dest: '$0',
+		},
+		{ src: '^//?(?:en|fr|nl|es)/(.*)', dest: '/$1', check: true },
+		{ handle: 'rewrite' },
+		{
+			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es)/gsp.json$',
+			dest: '/$nextLocale/gsp',
+		},
+		{
+			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es)/gsp/(?<nxtPslug>[^/]+?)\\.json$',
+			dest: '/$nextLocale/gsp/[slug]?nxtPslug=$nxtPslug',
+		},
+		{
+			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es)/gssp.json$',
+			dest: '/$nextLocale/gssp',
+		},
+		{ src: '/_next/data/(.*)', dest: '/404', status: 404 },
+		{
+			src: '^[/]?(?<nextLocale>en|fr|nl|es)?/gsp/(?<nxtPslug>[^/]+?)(?:/)?$',
+			dest: '/$nextLocale/gsp/[slug]?nxtPslug=$nxtPslug',
+		},
+		{ handle: 'hit' },
+		{
+			src: '/_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|image|media|_LMNvx1uNzgkLzYi9\\-YVv)/.+',
+			headers: { 'cache-control': 'public,max-age=31536000,immutable' },
+			continue: true,
+			important: true,
+		},
+		{
+			src: '/index',
+			headers: { 'x-matched-path': '/' },
+			continue: true,
+			important: true,
+		},
+		{
+			src: '/((?!index$).*)',
+			headers: { 'x-matched-path': '/$1' },
+			continue: true,
+			important: true,
+		},
+		{ handle: 'error' },
+		{
+			src: '/(?<nextLocale>en|fr|nl|es)(/.*|$)',
+			dest: '/$nextLocale/404',
+			status: 404,
+			caseSensitive: true,
+		},
+		{ src: '/.*', dest: '/en/404', status: 404 },
+		{
+			src: '/(?<nextLocale>en|fr|nl|es)(/.*|$)',
+			dest: '/$nextLocale/500',
+			status: 500,
+			caseSensitive: true,
+		},
+		{ src: '/.*', dest: '/en/500', status: 500 },
+	],
+	overrides: {
+		'en/gsp.html': { path: 'en/gsp', contentType: 'text/html; charset=utf-8' },
+		'fr/gsp.html': { path: 'fr/gsp', contentType: 'text/html; charset=utf-8' },
+		'nl/gsp.html': { path: 'nl/gsp', contentType: 'text/html; charset=utf-8' },
+		'en.html': { path: 'en', contentType: 'text/html; charset=utf-8' },
+		'en/404.html': { path: 'en/404', contentType: 'text/html; charset=utf-8' },
+		'en/500.html': { path: 'en/500', contentType: 'text/html; charset=utf-8' },
+		'fr.html': { path: 'fr', contentType: 'text/html; charset=utf-8' },
+		'fr/404.html': { path: 'fr/404', contentType: 'text/html; charset=utf-8' },
+		'fr/500.html': { path: 'fr/500', contentType: 'text/html; charset=utf-8' },
+		'nl.html': { path: 'nl', contentType: 'text/html; charset=utf-8' },
+		'nl/404.html': { path: 'nl/404', contentType: 'text/html; charset=utf-8' },
+		'nl/500.html': { path: 'nl/500', contentType: 'text/html; charset=utf-8' },
+		'es.html': { path: 'es', contentType: 'text/html; charset=utf-8' },
+		'es/404.html': { path: 'es/404', contentType: 'text/html; charset=utf-8' },
+		'es/500.html': { path: 'es/500', contentType: 'text/html; charset=utf-8' },
+	},
+};
+
+const locales = ['en', 'nl', 'fr', 'es'] as const;
+
+export const testSet: TestSet = {
+	name: 'routes using middleware',
+	config: rawVercelConfig,
+	files: {
+		functions: {
+			gsp: { '[slug].func': createValidFuncDir('/gsp/[slug]') },
+			'gssp.func': createValidFuncDir('/gssp'),
+		},
+		static: {
+			_next: {
+				static: { chunks: { 'index.js': 'index chunk file' } },
+				data: {
+					'_LMNvx1uNzgkLzYi9-YVv': locales.reduce(
+						(acc, locale) => ({
+							...acc,
+							[locale]: { 'gsp.json': JSON.stringify({ locale }) },
+						}),
+						{}
+					),
+				},
+			},
+			...locales.reduce(
+				(acc, locale) => ({
+					...acc,
+					[`${locale}.html`]: `<html>${locale}</html>`,
+					[locale]: {
+						'404.html': `<html>${locale}: 404</html>`,
+						'500.html': `<html>${locale}: 500</html>`,
+						'gsp.html': `<html>${locale}: gsp</html>`,
+					},
+				}),
+				{}
+			),
+		},
+	},
+	testCases: [
+		{
+			name: 'returns 404 for missing asset instead of infinite loop',
+			paths: ['/favicon.ico'],
+			expected: {
+				status: 404,
+				data: '<html>en: 404</html>',
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/en/404',
+				},
+			},
+		},
+		{
+			name: '/ matches default locale (en) page',
+			paths: ['/'],
+			expected: {
+				status: 200,
+				data: '<html>en</html>',
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/en',
+				},
+			},
+		},
+		...locales.map(locale => {
+			const path = `/${locale}`;
+			return {
+				name: `${path} matches ${path} static page for the correct locale`,
+				paths: [path],
+				expected: {
+					status: 200,
+					data: `<html>${locale}</html>`,
+					headers: {
+						'content-type': 'text/html; charset=utf-8',
+						'x-matched-path': `${path}`,
+					},
+				},
+			};
+		}),
+		...locales.map(locale => ({
+			name: `gets static locale (${locale}) page for generated \`_next/data\``,
+			paths: [`/_next/data/_LMNvx1uNzgkLzYi9-YVv/${locale}/gsp.json`],
+			expected: {
+				status: 200,
+				data: JSON.stringify({ locale }),
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+					'x-matched-path': `/_next/data/_LMNvx1uNzgkLzYi9-YVv/${locale}/gsp.json`,
+				},
+			},
+		})),
+		{
+			name: 'gets static file for valid `_next/static/...`',
+			paths: ['/_next/static/chunks/index.js'],
+			headers: { 'accept-language': 'fr' },
+			expected: {
+				status: 200,
+				data: 'index chunk file',
+				headers: {
+					'cache-control': 'public,max-age=31536000,immutable',
+					'content-type': 'text/plain;charset=UTF-8',
+					'x-matched-path': '/_next/static/chunks/index.js',
+				},
+			},
+		},
+		{
+			name: 'runs function for route (no specific locale for function)',
+			paths: locales.map(locale => `/${locale}/gssp`),
+			expected: {
+				status: 200,
+				data: JSON.stringify({ file: '/gssp', params: [] }),
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+					'x-matched-path': '/gssp',
+				},
+			},
+		},
+		{
+			name: 'runs function for dynamic route (no specific locale for function)',
+			paths: locales.map(locale => `/${locale}/gsp/test`),
+			expected: {
+				status: 200,
+				data: JSON.stringify({
+					file: '/gsp/[slug]',
+					params: [['nxtPslug', 'test']],
+				}),
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+					'x-matched-path': '/gsp/[slug]',
+				},
+			},
+		},
+		{
+			name: 'locale redirects to url with accept-language (es) header',
+			paths: ['/', '/en', '/fr', '/nl', '/es'],
+			headers: { 'accept-language': 'es' },
+			expected: {
+				status: 307,
+				data: '',
+				headers: { location: 'https://example.es/' },
+			},
+		},
+		{
+			name: 'locale redirects to url with cookie (es)',
+			paths: ['/', '/en', '/fr', '/nl', '/es'],
+			headers: { cookie: 'NEXT_LOCALE=es' },
+			expected: {
+				status: 307,
+				data: '',
+				headers: { location: 'https://example.es/' },
+			},
+		},
+		{
+			name: 'locale does not redirect with same accept-language (en) header',
+			paths: ['/'],
+			headers: { 'accept-language': 'en' },
+			expected: {
+				status: 200,
+				data: '<html>en</html>',
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/en',
+				},
+			},
+		},
+		{
+			name: 'locale does not redirect with same cookie (en)',
+			paths: ['/'],
+			headers: { cookie: 'NEXT_LOCALE=en' },
+			expected: {
+				status: 200,
+				data: '<html>en</html>',
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/en',
+				},
+			},
+		},
+		{
+			name: 'locale redirects to path with accept-language (fr) header',
+			paths: ['/'],
+			headers: { 'accept-language': 'fr' },
+			expected: {
+				status: 307,
+				data: '',
+				headers: { location: '/fr' },
+			},
+		},
+		{
+			name: 'locale redirects to path with cookie (fr)',
+			paths: ['/'],
+			headers: { cookie: 'NEXT_LOCALE=fr' },
+			expected: {
+				status: 307,
+				data: '',
+				headers: { location: '/fr' },
+			},
+		},
+		{
+			name: 'does not redirect when path starts with locale',
+			paths: ['/fr'],
+			expected: {
+				status: 200,
+				data: '<html>fr</html>',
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/fr',
+				},
+			},
+		},
+	],
+};

--- a/tests/templates/requestTestData/i18n.ts
+++ b/tests/templates/requestTestData/i18n.ts
@@ -63,6 +63,7 @@ const rawVercelConfig: VercelConfig = {
 			check: true,
 			dest: '$0',
 		},
+		{ src: '/en', dest: '/', check: true },
 		{ src: '^//?(?:en|fr|nl|es)/(.*)', dest: '/$1', check: true },
 		{ handle: 'rewrite' },
 		{
@@ -241,7 +242,7 @@ export const testSet: TestSet = {
 		},
 		{
 			name: 'runs function for route (no specific locale for function)',
-			paths: locales.map(locale => `/${locale}/gssp`),
+			paths: ['/gssp', ...locales.map(locale => `/${locale}/gssp`)],
 			expected: {
 				status: 200,
 				data: JSON.stringify({ file: '/gssp', params: [] }),
@@ -253,7 +254,7 @@ export const testSet: TestSet = {
 		},
 		{
 			name: 'runs function for dynamic route (no specific locale for function)',
-			paths: locales.map(locale => `/${locale}/gsp/test`),
+			paths: ['/gsp/test', ...locales.map(locale => `/${locale}/gsp/test`)],
 			expected: {
 				status: 200,
 				data: JSON.stringify({

--- a/tests/templates/requestTestData/index.ts
+++ b/tests/templates/requestTestData/index.ts
@@ -3,5 +3,6 @@ export { testSet as basicStaticAppDirTestSet } from './basicStaticAppDir';
 export { testSet as checkRouteMatchTestSet } from './checkRouteMatch';
 export { testSet as configRewritesRedirectsHeadersTestSet } from './configRewritesRedirectsHeaders';
 export { testSet as dynamicRoutesTestSet } from './dynamicRoutes';
+export { testSet as i18nTestSet } from './i18n';
 export { testSet as infiniteLoopTestSet } from './infiniteLoop';
 export { testSet as middlewareTestSet } from './middleware';

--- a/tests/templates/requestTestData/middleware.ts
+++ b/tests/templates/requestTestData/middleware.ts
@@ -93,7 +93,6 @@ export const testSet: TestSet = {
 				data: '',
 				headers: {
 					location: 'http://localhost/somewhere-else?redirect=',
-					'x-matched-path': '/api/hello',
 				},
 			},
 		},

--- a/tests/templates/utils/http.test.ts
+++ b/tests/templates/utils/http.test.ts
@@ -99,15 +99,25 @@ describe('createRouteRequest', () => {
 describe('parseAcceptLanguage', () => {
 	test('extract the locales and sort by quality when present', () => {
 		[
-			['', []],
-			['en', ['en']],
-			['en-US,en', ['en-US', 'en']],
-			['en-US,en;q=0.9,es;q=0.8', ['en-US', 'en', 'es']],
-			['en-US,fr;q=0.7,en;q=0.9,es;q=0.8', ['en-US', 'en', 'es', 'fr']],
-			['fr;q=0.7,en;q=0.9,en-US,es;q=0.8', ['en-US', 'en', 'es', 'fr']],
-			['fr;q = 0.7,en;q =0.9,en-US,es;q= 0.8', ['en-US', 'en', 'es', 'fr']],
-		].forEach(([input, output]) => {
-			expect(parseAcceptLanguage(input as string)).toEqual(output);
+			{ header: '', expected: [] },
+			{ header: 'en', expected: ['en'] },
+			{ header: 'en-US,en', expected: ['en-US', 'en'] },
+			{ header: 'en-US,en;q=0.9,es;q=0.8', expected: ['en-US', 'en', 'es'] },
+			{
+				header: 'en-US,fr;q=0.7,en;q=0.9,es;q=0.8',
+				expected: ['en-US', 'en', 'es', 'fr'],
+			},
+			{
+				header: 'fr;q=0.7,en;q=0.9,en-US,es;q=0.8',
+				expected: ['en-US', 'en', 'es', 'fr'],
+			},
+			{
+				header: 'fr;q = 0.7,en;q =0.9,en-US,es;q= 0.8',
+				expected: ['en-US', 'en', 'es', 'fr'],
+			},
+		].forEach(({ header, expected }) => {
+			const result = parseAcceptLanguage(header);
+			expect(result).toEqual(expected);
 		});
 	});
 });

--- a/tests/templates/utils/http.test.ts
+++ b/tests/templates/utils/http.test.ts
@@ -5,6 +5,7 @@ import {
 	applySearchParams,
 	createRouteRequest,
 	isUrl,
+	parseAcceptLanguage,
 } from '../../../templates/_worker.js/utils';
 
 describe('applyHeaders', () => {
@@ -92,5 +93,21 @@ describe('createRouteRequest', () => {
 		const request = createRouteRequest(prevReq, '/index.html');
 
 		expect(new URL(request.url).pathname).toEqual('/');
+	});
+});
+
+describe('parseAcceptLanguage', () => {
+	test('extract the locales and sort by quality when present', () => {
+		[
+			['', []],
+			['en', ['en']],
+			['en-US,en', ['en-US', 'en']],
+			['en-US,en;q=0.9,es;q=0.8', ['en-US', 'en', 'es']],
+			['en-US,fr;q=0.7,en;q=0.9,es;q=0.8', ['en-US', 'en', 'es', 'fr']],
+			['fr;q=0.7,en;q=0.9,en-US,es;q=0.8', ['en-US', 'en', 'es', 'fr']],
+			['fr;q = 0.7,en;q =0.9,en-US,es;q= 0.8', ['en-US', 'en', 'es', 'fr']],
+		].forEach(([input, output]) => {
+			expect(parseAcceptLanguage(input as string)).toEqual(output);
+		});
 	});
 });


### PR DESCRIPTION
This PR does the following:
- Fixes an issue where redirects weren't breaking out of routing at the right point.
- Adds a utility function for parsing the `accept-language` header value.
- Introduces support for the source route `locale` option and the `next.config.js` option for `i18n`.
- Adds tests for the new functionality.

It is somewhat of a continuation of https://github.com/cloudflare/next-on-pages/pull/222 as that fixed a major blocker for i18n.

So, there is a little quirk with how the locale redirects have to be handled. There are two different types of ways internationalization works. These are sub-path routing and domain routing. The build output config `route.src` value for sub-path routing is simply `/`, which causes issues.

The Next.js [docs](https://nextjs.org/docs/pages/building-your-application/routing/internationalization#automatic-locale-detection) state that automatic locale detection occurs when a user visits the root of the website, which would mean that the regex should be `^/$`, except it isn't. Therefore, we have to add custom behaviour to check whether the `route.src` is a regex, and if it isn't, check that it is equal to the current path before determining whether we should apply the locale redirects.

Sub-path routing entry:
```
{
	src: '/',
	locale: {
		redirect: { en: '/', fr: '/fr', nl: '/nl', es: '/es' },
		cookie: 'NEXT_LOCALE',
	},
	continue: true,
}
```

Domain routing entry:
```
{
	src: '^//?(?:en|fr|nl|es)?/?$',
	locale: {
		redirect: { es: 'https://example.es/' },
		cookie: 'NEXT_LOCALE',
	},
	continue: true,
}
```

As you can see, the two values for `route.src` are very different. I find this to be rather bizarre behaviour, and to me, it looks like the Vercel build output isn't generating the correct matching patterns. Anyway, so to address the quirks, I have done what I detailed above.

Also tested it using [test apps](https://github.com/dario-piotrowicz/next-apps-for-testing) for plain Next.js i18n, next-translate, and next-i18n. The test app shouldn't actually matter anyway, because they all use next.config.js i18n under the hood, which is what this PR introduces better support for.

closes #28
closes #37
closes #157