### PR TITLE
properly build functions and chunks (so that they can have requires from 'node:buffer'

### DIFF
--- a/src/buildApplication/buildWorkerFile.ts
+++ b/src/buildApplication/buildWorkerFile.ts
@@ -1,5 +1,4 @@
 import { writeFile } from 'fs/promises';
-import type { Plugin } from 'esbuild';
 import { join } from 'path';
 import { build } from 'esbuild';
 import { tmpdir } from 'os';
@@ -76,34 +75,7 @@ export async function buildWorkerFile(
 		},
 		outfile: outputFile,
 		minify,
-		plugins: [nodeBufferPlugin],
 	});
 
 	cliSuccess(`Generated '${outputFile}'.`);
 }
-
-// Chunks can contain `require("node:buffer")`, this is not allowed and breaks at runtime
-// the following fixes this by updating the require to a standard esm import from node:buffer
-const nodeBufferPlugin: Plugin = {
-	name: 'node:buffer',
-	setup(build) {
-		build.onResolve({ filter: /^node:buffer$/ }, ({ kind, path }) => {
-			// this plugin converts `require("node:buffer")` calls, those are the only ones that
-			// need updating (esm imports to "node:buffer" are totally valid), so here we tag with the
-			// node-buffer namespace only imports that are require calls
-			return kind === 'require-call'
-				? {
-						path,
-						namespace: 'node-buffer',
-				  }
-				: undefined;
-		});
-
-		// we convert the imports we tagged with the node-buffer namespace so that instead of `require("node:buffer")`
-		// they import from `export * from 'node:buffer;'`
-		build.onLoad({ filter: /.*/, namespace: 'node-buffer' }, () => ({
-			contents: `export * from 'node:buffer'`,
-			loader: 'js',
-		}));
-	},
-};

--- a/tests/src/buildApplication/generateFunctionsMap.test.ts
+++ b/tests/src/buildApplication/generateFunctionsMap.test.ts
@@ -4,6 +4,19 @@ import mockFs from 'mock-fs';
 import type { DirectoryItems } from 'mock-fs/lib/filesystem';
 import { join } from 'path';
 import { mockPrerenderConfigFile } from '../../_helpers';
+import { writeFile } from 'fs/promises';
+
+function getEsBuildMock() {
+	const esbuildMock = {
+		build: (options: { stdin?: { contents: string }; outfile: string }) => {
+			const contents = options.stdin?.contents ?? 'built code';
+			writeFile(options.outfile, contents);
+		},
+	};
+	return esbuildMock;
+}
+
+vi.mock('esbuild', async () => getEsBuildMock());
 
 describe('generateFunctionsMap', async () => {
 	describe('with chunks deduplication disabled should correctly handle', () => {

--- a/tests/templates/handleRequest.test.ts
+++ b/tests/templates/handleRequest.test.ts
@@ -13,6 +13,7 @@ import type { TestCase, TestSet } from '../_helpers';
 import { createRouterTestData } from '../_helpers';
 import type { RequestContext } from '../../src/utils/requestContext';
 import { handleRequest } from '../../templates/_worker.js/handleRequest';
+import { writeFile } from 'fs/promises';
 
 /**
  * Runs a test case.
@@ -88,6 +89,15 @@ async function runTestSet({ config, files, testCases }: TestSet) {
 		runTestCase(reqCtx, vercelConfig, buildOutput, testCase)
 	);
 }
+
+vi.mock('esbuild', async () => {
+	return {
+		build: (options: { stdin?: { contents: string }; outfile: string }) => {
+			const contents = options.stdin?.contents ?? 'built code';
+			writeFile(options.outfile, contents);
+		},
+	};
+});
 
 suite('router', () => {
 	[


### PR DESCRIPTION
PS: not including any changeset here since this PR is fixing an issue introduced in the same release (so I think that it's actually part of the other changeset)