### PR TITLE
fix: prerendered json handling

### DIFF
--- a/.changeset/tricky-turtles-drum.md
+++ b/.changeset/tricky-turtles-drum.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix the prerendered route handling for generated JSON files.

--- a/src/buildApplication/fixPrerenderedRoutes.ts
+++ b/src/buildApplication/fixPrerenderedRoutes.ts
@@ -100,7 +100,7 @@ async function getRouteDest(
 		join(
 			dirName,
 			fallback.fsPath.replace(
-				/\.prerender-fallback(\.((rsc)|(body)|(json)))?/gi,
+				/\.prerender-fallback(?:\.(?:rsc|body|json))?/gi,
 				''
 			)
 		)

--- a/src/buildApplication/fixPrerenderedRoutes.ts
+++ b/src/buildApplication/fixPrerenderedRoutes.ts
@@ -83,6 +83,7 @@ async function getRoutePath(
  * // index.prerender-fallback.html -> index.html
  * // index.rsc.prerender-fallback.rsc -> index.rsc
  * // favicon.ico.prerender-fallback.body -> favicon.ico
+ * // 1.json.prerender-fallback.json -> 1.json
  * ```
  *
  * @param config.fallback Fallback file configuration.
@@ -98,7 +99,10 @@ async function getRouteDest(
 	const destRoute = normalizePath(
 		join(
 			dirName,
-			fallback.fsPath.replace(/\.prerender-fallback(?:\.rsc)?(?:\.body)?/gi, '')
+			fallback.fsPath.replace(
+				/\.prerender-fallback(\.((rsc)|(body)|(json)))?/gi,
+				''
+			)
 		)
 	);
 	const destFile = join(outputDir, 'static', destRoute);

--- a/src/buildApplication/fixPrerenderedRoutes.ts
+++ b/src/buildApplication/fixPrerenderedRoutes.ts
@@ -83,7 +83,7 @@ async function getRoutePath(
  * // index.prerender-fallback.html -> index.html
  * // index.rsc.prerender-fallback.rsc -> index.rsc
  * // favicon.ico.prerender-fallback.body -> favicon.ico
- * // 1.json.prerender-fallback.json -> 1.json
+ * // data.json.prerender-fallback.json -> data.json
  * ```
  *
  * @param config.fallback Fallback file configuration.

--- a/tests/_helpers/index.ts
+++ b/tests/_helpers/index.ts
@@ -270,7 +270,9 @@ export function mockPrerenderConfigFile(path: string, ext?: string): string {
 			fsPath,
 		},
 		initialHeaders: {
-			...(path.endsWith('.rsc') && { 'content-type': 'text/x-component' }),
+			...((path.endsWith('.rsc') || path.endsWith('.json')) && {
+				'content-type': 'text/x-component',
+			}),
 			...(path.endsWith('.ico') && { 'content-type': 'image/x-icon' }),
 			vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
 		},

--- a/tests/src/buildApplication/generateFunctionsMap.test.ts
+++ b/tests/src/buildApplication/generateFunctionsMap.test.ts
@@ -171,9 +171,19 @@ describe('generateFunctionsMap', async () => {
 			});
 		});
 
-		test('succeeds for prerendered favicon', async () => {
+		test('succeeds for prerendered favicon + json', async () => {
 			const { functionsMap, prerenderedRoutes } =
 				await generateFunctionsMapFrom({
+					_next: {
+						data: {
+							'1.json.func': invalidFuncDir,
+							'1.json.prerender-config.json': mockPrerenderConfigFile(
+								'1.json',
+								'json'
+							),
+							'1.json.prerender-fallback.json': '1.json',
+						},
+					},
 					'page.func': validFuncDir,
 					'page.rsc.func': validFuncDir,
 					'favicon.ico.func': invalidFuncDir,
@@ -188,10 +198,17 @@ describe('generateFunctionsMap', async () => {
 			expect(functionsMap.get('/page')).toMatch(/\/page\.func\.js$/);
 			expect(functionsMap.get('/page.rsc')).toMatch(/\/page\.rsc\.func\.js$/);
 
-			expect(prerenderedRoutes.size).toEqual(1);
+			expect(prerenderedRoutes.size).toEqual(2);
 			expect(prerenderedRoutes.get('/favicon.ico')).toEqual({
 				headers: {
 					'content-type': 'image/x-icon',
+					vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+				},
+				overrides: [],
+			});
+			expect(prerenderedRoutes.get('/_next/data/1.json')).toEqual({
+				headers: {
+					'content-type': 'text/x-component',
 					vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
 				},
 				overrides: [],

--- a/tests/src/buildApplication/generateFunctionsMap.test.ts
+++ b/tests/src/buildApplication/generateFunctionsMap.test.ts
@@ -174,16 +174,6 @@ describe('generateFunctionsMap', async () => {
 		test('succeeds for prerendered favicon + json', async () => {
 			const { functionsMap, prerenderedRoutes } =
 				await generateFunctionsMapFrom({
-					_next: {
-						data: {
-							'1.json.func': invalidFuncDir,
-							'1.json.prerender-config.json': mockPrerenderConfigFile(
-								'1.json',
-								'json'
-							),
-							'1.json.prerender-fallback.json': '1.json',
-						},
-					},
 					'page.func': validFuncDir,
 					'page.rsc.func': validFuncDir,
 					'favicon.ico.func': invalidFuncDir,
@@ -198,7 +188,7 @@ describe('generateFunctionsMap', async () => {
 			expect(functionsMap.get('/page')).toMatch(/\/page\.func\.js$/);
 			expect(functionsMap.get('/page.rsc')).toMatch(/\/page\.rsc\.func\.js$/);
 
-			expect(prerenderedRoutes.size).toEqual(2);
+			expect(prerenderedRoutes.size).toEqual(1);
 			expect(prerenderedRoutes.get('/favicon.ico')).toEqual({
 				headers: {
 					'content-type': 'image/x-icon',
@@ -206,7 +196,31 @@ describe('generateFunctionsMap', async () => {
 				},
 				overrides: [],
 			});
-			expect(prerenderedRoutes.get('/_next/data/1.json')).toEqual({
+		});
+
+		test('succeeds for prerendered json', async () => {
+			const { functionsMap, prerenderedRoutes } =
+				await generateFunctionsMapFrom({
+					_next: {
+						data: {
+							'data.json.func': invalidFuncDir,
+							'data.json.prerender-config.json': mockPrerenderConfigFile(
+								'data.json',
+								'json'
+							),
+							'data.json.prerender-fallback.json': 'data.json',
+						},
+					},
+					'page.func': validFuncDir,
+					'page.rsc.func': validFuncDir,
+				});
+
+			expect(functionsMap.size).toEqual(2);
+			expect(functionsMap.get('/page')).toMatch(/\/page\.func\.js$/);
+			expect(functionsMap.get('/page.rsc')).toMatch(/\/page\.rsc\.func\.js$/);
+
+			expect(prerenderedRoutes.size).toEqual(1);
+			expect(prerenderedRoutes.get('/_next/data/data.json')).toEqual({
 				headers: {
 					'content-type': 'text/x-component',
 					vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',

--- a/tests/src/buildApplication/generateFunctionsMap.test.ts
+++ b/tests/src/buildApplication/generateFunctionsMap.test.ts
@@ -171,7 +171,7 @@ describe('generateFunctionsMap', async () => {
 			});
 		});
 
-		test('succeeds for prerendered favicon + json', async () => {
+		test('succeeds for prerendered favicon', async () => {
 			const { functionsMap, prerenderedRoutes } =
 				await generateFunctionsMapFrom({
 					'page.func': validFuncDir,


### PR DESCRIPTION
Basically #238 but for prerendered JSON for pages in `_next/data/...`.

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/3aeb5c03-2ce6-4696-9f67-a030d7d42261)
![image](https://github.com/cloudflare/next-on-pages/assets/10815538/0f81576c-a988-444e-aa9e-8c638f55a980)
