### PR TITLE
fix: non-dynamic trailing slash matching when using `trailingSlash`

### DIFF
--- a/.changeset/rich-shirts-shake.md
+++ b/.changeset/rich-shirts-shake.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix non-dynamic trailing slash pages not matching when using `trailingSlash: true`.

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -504,9 +504,9 @@ export class RoutesMatcher {
 		if (
 			phase === 'rewrite' &&
 			!pathExistsInOutput &&
-			/^\/(.+)\/$/.test(this.path)
+			this.path.endsWith('/')
 		) {
-			const newPath = this.path.replace(/^\/(.+)\/$/, '/$1');
+			const newPath = this.path.replace(/\/$/, '')
 			pathExistsInOutput = newPath in this.output;
 			if (pathExistsInOutput) {
 				this.path = newPath;

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -506,8 +506,11 @@ export class RoutesMatcher {
 			!pathExistsInOutput &&
 			/^\/(.+)\/$/.test(this.path)
 		) {
-			this.path = this.path.replace(/\/(.+)\//, '/$1');
-			pathExistsInOutput = this.path in this.output;
+			const newPath = this.path.replace(/^\/(.+)\/$/, '/$1');
+			pathExistsInOutput = newPath in this.output;
+			if (pathExistsInOutput) {
+				this.path = newPath;
+			}
 		}
 
 		// In the `miss` phase, set status to 404 if no path was found and it isn't an error code.

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -496,7 +496,19 @@ export class RoutesMatcher {
 			return 'done';
 		}
 
-		const pathExistsInOutput = this.path in this.output;
+		let pathExistsInOutput = this.path in this.output;
+
+		// If a path with a trailing slash entered the `rewrite` phase and didn't find a match, it might
+		// be due to the `trailingSlash` setting in `next.config.js`. Therefore, we should remove the
+		// trailing slash and check again before entering the next phase.
+		if (
+			phase === 'rewrite' &&
+			!pathExistsInOutput &&
+			/^\/(.+)\/$/.test(this.path)
+		) {
+			this.path = this.path.replace(/\/(.+)\//, '/$1');
+			pathExistsInOutput = this.path in this.output;
+		}
 
 		// In the `miss` phase, set status to 404 if no path was found and it isn't an error code.
 		if (phase === 'miss' && !pathExistsInOutput) {

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -501,12 +501,8 @@ export class RoutesMatcher {
 		// If a path with a trailing slash entered the `rewrite` phase and didn't find a match, it might
 		// be due to the `trailingSlash` setting in `next.config.js`. Therefore, we should remove the
 		// trailing slash and check again before entering the next phase.
-		if (
-			phase === 'rewrite' &&
-			!pathExistsInOutput &&
-			this.path.endsWith('/')
-		) {
-			const newPath = this.path.replace(/\/$/, '')
+		if (phase === 'rewrite' && !pathExistsInOutput && this.path.endsWith('/')) {
+			const newPath = this.path.replace(/\/$/, '');
 			pathExistsInOutput = newPath in this.output;
 			if (pathExistsInOutput) {
 				this.path = newPath;

--- a/tests/_helpers/index.ts
+++ b/tests/_helpers/index.ts
@@ -275,6 +275,8 @@ export function mockPrerenderConfigFile(path: string, ext?: string): string {
 			...((path.endsWith('.rsc') || path.endsWith('.json')) && {
 				'content-type': 'text/x-component',
 			}),
+			...(path.endsWith('.txt') && { 'content-type': 'text/plain' }),
+			...(path.endsWith('.xml') && { 'content-type': 'application/xml' }),
 			...(path.endsWith('.ico') && { 'content-type': 'image/x-icon' }),
 			vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
 		},

--- a/tests/templates/handleRequest.test.ts
+++ b/tests/templates/handleRequest.test.ts
@@ -8,6 +8,7 @@ import {
 	i18nTestSet,
 	infiniteLoopTestSet,
 	middlewareTestSet,
+	trailingSlashTestSet,
 } from './requestTestData';
 import type { TestCase, TestSet } from '../_helpers';
 import { createRouterTestData } from '../_helpers';
@@ -113,6 +114,7 @@ suite('router', () => {
 		i18nTestSet,
 		infiniteLoopTestSet,
 		middlewareTestSet,
+		trailingSlashTestSet,
 	].forEach(testSet => {
 		describe(testSet.name, () => runTestSet(testSet));
 	});

--- a/tests/templates/requestTestData/index.ts
+++ b/tests/templates/requestTestData/index.ts
@@ -6,3 +6,4 @@ export { testSet as dynamicRoutesTestSet } from './dynamicRoutes';
 export { testSet as i18nTestSet } from './i18n';
 export { testSet as infiniteLoopTestSet } from './infiniteLoop';
 export { testSet as middlewareTestSet } from './middleware';
+export { testSet as trailingSlashTestSet } from './trailingSlash';

--- a/tests/templates/requestTestData/trailingSlash.ts
+++ b/tests/templates/requestTestData/trailingSlash.ts
@@ -30,7 +30,7 @@ const rawVercelConfig: VercelConfig = {
 		{ handle: 'resource' },
 		{ src: '/.*', status: 404 },
 		{ handle: 'rewrite' },
-		{ src: '^/(?<nxtPlang>[^/]+?)(?:/)?$', dest: '/[lang]?nxtPlang=$nxtPlang' },
+		{ src: '^/(?<lang>[^/]+?)(?:/)?$', dest: '/[lang]?lang=$lang' },
 		{ handle: 'hit' },
 		{
 			src: '/index',
@@ -87,7 +87,7 @@ export const testSet: TestSet = {
 			paths: ['/en/'],
 			expected: {
 				status: 200,
-				data: JSON.stringify({ file: '/[lang]', params: [['nxtPlang', 'en']] }),
+				data: JSON.stringify({ file: '/[lang]', params: [['lang', 'en']] }),
 				headers: {
 					'content-type': 'text/plain;charset=UTF-8',
 					'x-matched-path': '/[lang]',

--- a/tests/templates/requestTestData/trailingSlash.ts
+++ b/tests/templates/requestTestData/trailingSlash.ts
@@ -1,0 +1,146 @@
+import type { TestSet } from '../../_helpers';
+import { mockPrerenderConfigFile } from '../../_helpers';
+import { createValidFuncDir } from '../../_helpers';
+
+// `trailingSlash` option in `next.config.js` is `true`.
+
+const rawVercelConfig: VercelConfig = {
+	version: 3,
+	routes: [
+		{
+			src: '^(?:/((?!\\.well-known(?:/.*)?)(?:[^/]+/)*[^/]+\\.\\w+))/$',
+			headers: { Location: '/$1' },
+			status: 308,
+			missing: [{ type: 'header', key: 'x-nextjs-data' }],
+			continue: true,
+		},
+		{
+			src: '^(?:/((?!\\.well-known(?:/.*)?)(?:[^/]+/)*[^/\\.]+))$',
+			headers: { Location: '/$1/' },
+			status: 308,
+			continue: true,
+		},
+		{
+			src: '/404/?',
+			status: 404,
+			continue: true,
+			missing: [{ type: 'header', key: 'x-prerender-revalidate' }],
+		},
+		{ src: '/500', status: 500, continue: true },
+		{ handle: 'resource' },
+		{ src: '/.*', status: 404 },
+		{ handle: 'rewrite' },
+		{ src: '^/(?<nxtPlang>[^/]+?)(?:/)?$', dest: '/[lang]?nxtPlang=$nxtPlang' },
+		{ handle: 'hit' },
+		{
+			src: '/index',
+			headers: { 'x-matched-path': '/' },
+			continue: true,
+			important: true,
+		},
+		{
+			src: '/((?!index$).*)',
+			headers: { 'x-matched-path': '/$1' },
+			continue: true,
+			important: true,
+		},
+		{ handle: 'error' },
+		{ src: '/.*', dest: '/404', status: 404 },
+		{ src: '/.*', dest: '/500', status: 500 },
+	],
+	overrides: {
+		'404.html': { path: '404', contentType: 'text/html; charset=utf-8' },
+		'500.html': { path: '500', contentType: 'text/html; charset=utf-8' },
+	},
+};
+
+export const testSet: TestSet = {
+	name: 'basic edge runtime app dir routes',
+	config: rawVercelConfig,
+	files: {
+		functions: {
+			api: { 'hello.func': createValidFuncDir('/api/hello') },
+			'[lang].func': createValidFuncDir('/[lang]'),
+			'robots.txt.prerender-config.json': mockPrerenderConfigFile(
+				'robots.txt',
+				'body'
+			),
+			'robots.txt.prerender-fallback.body': 'robots.txt fallback',
+		},
+		static: {
+			'404.html': '<html>404</html>',
+			'500.html': '<html>500</html>',
+		},
+	},
+	testCases: [
+		{
+			name: 'non-trailing slash redirects to trailing slash',
+			paths: ['/en'],
+			expected: {
+				status: 308,
+				data: '',
+				headers: { location: '/en/' },
+			},
+		},
+		{
+			name: 'dynamic page with trailing slash matches',
+			paths: ['/en/'],
+			expected: {
+				status: 200,
+				data: JSON.stringify({ file: '/[lang]', params: [['nxtPlang', 'en']] }),
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+					'x-matched-path': '/[lang]',
+				},
+			},
+		},
+		{
+			name: 'non-trailing slash non-dynamic page redirects to trailing slash',
+			paths: ['/api/hello'],
+			expected: {
+				status: 308,
+				data: '',
+				headers: {
+					location: '/api/hello/',
+				},
+			},
+		},
+		{
+			name: 'non-dynamic page with trailing slash matches',
+			paths: ['/api/hello/'],
+			expected: {
+				status: 200,
+				data: JSON.stringify({ file: '/api/hello', params: [] }),
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+					'x-matched-path': '/api/hello',
+				},
+			},
+		},
+		{
+			name: 'invalid page 404s',
+			paths: ['/invalid/route/'],
+			expected: {
+				status: 404,
+				data: '<html>404</html>',
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/404',
+				},
+			},
+		},
+		{
+			name: 'non-dynamic prerendered route matches',
+			paths: ['/robots.txt'],
+			expected: {
+				status: 200,
+				data: 'robots.txt fallback',
+				headers: {
+					'content-type': 'text/plain',
+					'x-matched-path': '/robots.txt',
+					vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+				},
+			},
+		},
+	],
+};


### PR DESCRIPTION
This PR does the following:
- In the `rewrite` phase, if no path is found in the build output, check if there is a trailing slash. If so, remove it and check the build output again.
- Adds tests for the new functionality.

When using `trailingSlash: true` in `next.config.js`, it redirects requests to include a trailing slash. However, it doesn't always rewrite the paths in the build output config to let them match. For dynamic routes, there are rewrites present in the `rewrite` phase that account for the trailing slash. However, with non-dynamic routes, there typically isn't a rewrite to take care of them. So, if we weren't able to match a rewrite and there's a trailing slash, we should manually remove it and check if the file system contains the route.

Tested using the reproduction in https://github.com/cloudflare/next-on-pages/issues/257
That issue is not about trailing slashes, and therefore I am not marking it as being fixed by this PR, but it's a problem that I noticed when trying out their reproduction.