### PR TITLE
fix getPackageVersion and use it to discern use of dlx

### DIFF
--- a/.changeset/tender-rats-smash.md
+++ b/.changeset/tender-rats-smash.md
@@ -1,0 +1,17 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+fix getPackageVersion and use it to discern use of dlx
+
+fix the `getPackageVersion` function so that it doesn't wrongly produce `N/A` (thus
+improving the `-i|--info` results)
+
+the when running `vercel build`, use the function to discern if `dlx` should be added
+(for `yarn (berry)` and `pnpm` commands), ensuring that the vercel package is not
+unnecessarily re-fetched/installed
+
+> **Note**
+> Currently the aforementioned check (and build command) runs `next-on-pages-vercel-cli`
+> anyways that's a temporary solution, the changes here will also apply when we switch
+> back to the proper vercel cli package

--- a/src/buildApplication/buildVercelOutput.ts
+++ b/src/buildApplication/buildVercelOutput.ts
@@ -115,15 +115,18 @@ async function getVercelBuildChildProcess(
 	const pkgMngCMD = getPackageManagerSpawnCommand(pkgMng);
 	const isYarnBerry = pkgMng === 'yarn (berry)';
 	const isPnpm = pkgMngCMD.startsWith('pnpm');
+	let useDlx = false;
 
 	if (isYarnBerry || isPnpm) {
 		const vercelPackageIsInstalled = await isVercelPackageInstalled(pkgMng);
-		if (!vercelPackageIsInstalled) {
-			return spawn(pkgMngCMD, ['dlx', 'next-on-pages-vercel-cli', 'build']);
-		}
+		useDlx = !vercelPackageIsInstalled;
 	}
 
-	return spawn(pkgMngCMD, ['next-on-pages-vercel-cli', 'build']);
+	return spawn(pkgMngCMD, [
+		...(useDlx ? ['dlx'] : []),
+		'next-on-pages-vercel-cli',
+		'build',
+	]);
 }
 
 async function isVercelPackageInstalled(

--- a/src/buildApplication/packageManagerUtils.ts
+++ b/src/buildApplication/packageManagerUtils.ts
@@ -98,7 +98,7 @@ export function getPackageVersion(
 	try {
 		const command = getPackageManagerSpawnCommand(packageManager);
 		const commandOutput = execFileSync(
-			command,
+			command.startsWith('npx') ? 'npm' : command,
 			[
 				command === 'yarn' ? 'info' : 'list',
 				packageName,

--- a/src/buildApplication/packageManagerUtils.ts
+++ b/src/buildApplication/packageManagerUtils.ts
@@ -99,7 +99,12 @@ export function getPackageVersion(
 		const command = getPackageManagerSpawnCommand(packageManager);
 		const commandOutput = execFileSync(
 			command,
-			['list', packageName, '--json', '--depth=0'],
+			[
+				command === 'yarn' ? 'info' : 'list',
+				packageName,
+				'--json',
+				...(command === 'yarn' ? [] : ['--depth=0']),
+			],
 			{ stdio: 'pipe' }
 		)
 			.toString()
@@ -108,7 +113,10 @@ export function getPackageVersion(
 		const commandJsonOuput = JSON.parse(commandOutput);
 		const packageInfo =
 			packageManager === 'pnpm' ? commandJsonOuput[0] : commandJsonOuput;
-		const packageVersion = packageInfo?.dependencies[packageName]?.version;
+		const packageVersion =
+			command === 'yarn'
+				? packageInfo?.children?.Version
+				: packageInfo?.dependencies[packageName]?.version;
 		return packageVersion ?? null;
 	} catch {
 		return null;


### PR DESCRIPTION
fix the getPackageVersion (currently not correctly parsing packages using pnpm) and use it in the getVercelBuildChildProcess to decide if for yarn and pnpm we should include the dlx option

resolves #250
resolves #262


<details>
<summary>Manual testing results</summary>

### pnpm ✅
next-on-pages info:
![Screenshot 2023-05-19 at 10 02 48](https://github.com/cloudflare/next-on-pages/assets/61631103/ed2fed85-eb36-4afb-a33a-df3b5428faa1)

next-on-pages run with and without ""vercel"" cli, adds `dlx` when expected

___

### npm ✅
next-on-pages info:
![Screenshot 2023-05-19 at 10 20 17](https://github.com/cloudflare/next-on-pages/assets/61631103/f946fc17-babb-4ecf-bd5b-84eb3fc67804)

next-on-pages run with and without ""vercel"" cli (in any case `npx` works well)

___

### yarn ✅

next-on-pages info:
![Screenshot 2023-05-19 at 09 49 37](https://github.com/cloudflare/next-on-pages/assets/61631103/3ab7d921-1412-4cfb-a24a-666edb74ed46)

next-on-pages run with and without ""vercel"" cli, adds `dlx` when expected

</details>
