### PR TITLE
fix built-in node modules static imports

### DIFF
--- a/.changeset/lucky-toys-confess.md
+++ b/.changeset/lucky-toys-confess.md
@@ -1,0 +1,16 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+allow any node built-in module to be statically imported correctly
+
+currently only static imports from "node:buffer" work correctly, other
+imports, although supported by the workers runtime, aren't handled correctly
+(such as "node:events" and "node:util"), fix this by making sure we handle
+imports from any of the node built-in modules
+
+> **Note**
+> some node built-in modules supported by the workers runtime still cannot be
+> correctly imported (like "node:path" for example), but this is because they
+> seem to be not allowed by vercel/next itself (so it's something unrelated to
+> next-on-pages)

--- a/src/buildApplication/generateFunctionsMap.ts
+++ b/src/buildApplication/generateFunctionsMap.ts
@@ -653,7 +653,7 @@ function getFunctionNestingLevel(functionPath: string): number {
 }
 
 // Chunks can contain `require("node:*")`, this is not allowed and breaks at runtime
-// the following fixes this by updating the require to a standard esm import from node:*
+// the following fixes this by updating the require to a standard esm import from "node:*"
 export const nodeBuiltInModulesPlugin: Plugin = {
 	name: 'node:built-in:modules',
 	setup(build) {
@@ -670,7 +670,7 @@ export const nodeBuiltInModulesPlugin: Plugin = {
 		});
 
 		// we convert the imports we tagged with the node-built-in-modules namespace so that instead of `require("node:*")`
-		// they import from `export * from 'node:*;'`
+		// they import from `export * from "node:*";`
 		build.onLoad(
 			{ filter: /.*/, namespace: 'node-built-in-modules' },
 			({ path }) => {

--- a/src/buildApplication/generateFunctionsMap.ts
+++ b/src/buildApplication/generateFunctionsMap.ts
@@ -268,7 +268,7 @@ async function processFuncDirectory(
 		bundle: true,
 		external: ['node:*', `${relativeChunksPath}/*`, '*.wasm'],
 		minify: true,
-		plugins: [nodeBufferPlugin],
+		plugins: [nodeBuiltInModulesPlugin],
 	});
 	const formattedPathName = formatRoutePath(relativePath);
 	const normalizedFilePath = normalizePath(newFilePath);
@@ -478,7 +478,7 @@ async function buildWebpackChunkFiles(
 			bundle: true,
 			external: ['node:*'],
 			minify: true,
-			plugins: [nodeBufferPlugin],
+			plugins: [nodeBuiltInModulesPlugin],
 		});
 		const fileContents = await readFile(chunkFilePath, 'utf8');
 		const wasmChunkImports = Array.from(wasmIdentifiers.entries())
@@ -652,29 +652,34 @@ function getFunctionNestingLevel(functionPath: string): number {
 	return nestingLevel;
 }
 
-// Chunks can contain `require("node:buffer")`, this is not allowed and breaks at runtime
-// the following fixes this by updating the require to a standard esm import from node:buffer
-export const nodeBufferPlugin: Plugin = {
-	name: 'node:buffer',
+// Chunks can contain `require("node:*")`, this is not allowed and breaks at runtime
+// the following fixes this by updating the require to a standard esm import from node:*
+export const nodeBuiltInModulesPlugin: Plugin = {
+	name: 'node:built-in:modules',
 	setup(build) {
-		build.onResolve({ filter: /^node:buffer$/ }, ({ kind, path }) => {
-			// this plugin converts `require("node:buffer")` calls, those are the only ones that
-			// need updating (esm imports to "node:buffer" are totally valid), so here we tag with the
+		build.onResolve({ filter: /^node:/ }, ({ kind, path }) => {
+			// this plugin converts `require("node:*")` calls, those are the only ones that
+			// need updating (esm imports to "node:*" are totally valid), so here we tag with the
 			// node-buffer namespace only imports that are require calls
 			return kind === 'require-call'
 				? {
 						path,
-						namespace: 'node-buffer',
+						namespace: 'node-built-in-modules',
 				  }
 				: undefined;
 		});
 
-		// we convert the imports we tagged with the node-buffer namespace so that instead of `require("node:buffer")`
-		// they import from `export * from 'node:buffer;'`
-		build.onLoad({ filter: /.*/, namespace: 'node-buffer' }, () => ({
-			contents: `export * from 'node:buffer'`,
-			loader: 'js',
-		}));
+		// we convert the imports we tagged with the node-built-in-modules namespace so that instead of `require("node:*")`
+		// they import from `export * from 'node:*;'`
+		build.onLoad(
+			{ filter: /.*/, namespace: 'node-built-in-modules' },
+			({ path }) => {
+				return {
+					contents: `export * from '${path}'`,
+					loader: 'js',
+				};
+			}
+		);
 	},
 };
 


### PR DESCRIPTION
Blocked by #267 (but otherwise ready for reviewing)

___

Tested on this [api route](https://github.com/dario-piotrowicz/next-apps-for-testing/blob/a04ac505a506a38f0de5263f80637ea5dfc75cd9/apps/simple-pages-dir-13.4.2/pages/api/hello.js) see: https://a9b4b021.next-on-pages-test-5h3.pages.dev/api/hello

resolves #249
___

As mentioned in the changeset not all node built-in modules are supported but that's because of vercel/next itself so there isn't much we can do about it, I'll look into this and open an issue in their repo to allow such imports (but anyways the changes here will work untouched if/when they allow such imports)
