### PR TITLE
fix: avoid copying rsc funcs to output dir

### DIFF
--- a/.changeset/grumpy-seas-search.md
+++ b/.changeset/grumpy-seas-search.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Remove rsc functions from the worker output directory as we replace them with non-rsc variants in the config given to the router. This reduces the final bundle size.

--- a/src/buildApplication/processVercelOutput.ts
+++ b/src/buildApplication/processVercelOutput.ts
@@ -68,7 +68,7 @@ export function processVercelOutput(
 			entrypoint: value.replace(/\.rsc\.func\.js$/i, '.func.js'),
 		});
 
-		// Remove the RSC functions from the dist directory as they are not needed.
+		// Remove the RSC functions from the dist directory as they are not needed since we replace them with non-rsc variants for the runtime routing
 		if (/\.rsc\.func\.js$/i.test(value)) {
 			rmSync(value);
 		}

--- a/src/buildApplication/processVercelOutput.ts
+++ b/src/buildApplication/processVercelOutput.ts
@@ -27,7 +27,7 @@ export async function getVercelStaticAssets(): Promise<string[]> {
 		(await readPathsRecursively(dir))
 			.map(file => addLeadingSlash(normalizePath(relative(dir, file))))
 			// Filter out the worker script output directory contents as those are not valid static assets.
-			.filter(path => !/^\/?_worker\.js\//.test(path))
+			.filter(path => !/^\/_worker\.js\//.test(path))
 	);
 }
 

--- a/src/buildApplication/processVercelOutput.ts
+++ b/src/buildApplication/processVercelOutput.ts
@@ -1,4 +1,5 @@
 import { relative, resolve } from 'path';
+import { rmSync } from 'fs';
 import {
 	addLeadingSlash,
 	normalizePath,
@@ -22,8 +23,11 @@ export async function getVercelStaticAssets(): Promise<string[]> {
 		return [];
 	}
 
-	return (await readPathsRecursively(dir)).map(file =>
-		addLeadingSlash(normalizePath(relative(dir, file)))
+	return (
+		(await readPathsRecursively(dir))
+			.map(file => addLeadingSlash(normalizePath(relative(dir, file))))
+			// Filter out the worker script output directory contents as those are not valid static assets.
+			.filter(path => !/^\/?_worker\.js\//.test(path))
 	);
 }
 
@@ -63,6 +67,11 @@ export function processVercelOutput(
 			// `TypeError: Cannot read properties of undefined (reading 'default')`
 			entrypoint: value.replace(/\.rsc\.func\.js$/i, '.func.js'),
 		});
+
+		// Remove the RSC functions from the dist directory as they are not needed.
+		if (/\.rsc\.func\.js$/i.test(value)) {
+			rmSync(value);
+		}
 	});
 
 	// Apply the overrides from the build output config to the processed output map.


### PR DESCRIPTION
This PR does the following:
- Removes any copied rsc function files (`.rsc.func.js`) from the worker output directory (we do not use them during routing due to them being the same as non-rsc funcs)
- Filters the static assets list that we provide to the routing system to remove the contents of the `_worker.js` directory (this should never have happened in the first place).

This change is primarily to reduce the bundle size by removing files that we don't utilize.

The tiny app that I tested it with had 1 rsc function. The zipped (`tar -zcvf`) sizes were as follows:
- Before: 192451
- After: 179682
- Change: -12769

On my modified version of the [app dir playground](https://github.com/james-elicx/app-playground), the difference is very noticeable:
- Before: 1298780
- After: 858230
- Change: -440550
