### PR TITLE
fix: middleware not returning response with `new NextResponse`

### DIFF
--- a/.changeset/serious-cobras-run.md
+++ b/.changeset/serious-cobras-run.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix middleware not returning a response with `new NextResponse` and when there is no `x-middleware-next` header present.

--- a/templates/_worker.js/handleRequest.ts
+++ b/templates/_worker.js/handleRequest.ts
@@ -49,6 +49,7 @@ async function findMatch(
 		status: matcher.status,
 		headers: matcher.headers,
 		searchParams: matcher.searchParams,
+		body: matcher.body,
 	};
 }
 
@@ -61,7 +62,7 @@ async function findMatch(
  */
 async function generateResponse(
 	reqCtx: RequestContext,
-	{ path = '/404', status, headers, searchParams }: MatchedSet,
+	{ path = '/404', status, headers, searchParams, body }: MatchedSet,
 	output: VercelBuildOutput
 ): Promise<Response> {
 	// Redirect user to external URL for redirects.
@@ -76,12 +77,16 @@ async function generateResponse(
 		return new Response(null, { status, headers: headers.normal });
 	}
 
-	let resp = await runOrFetchBuildOutputItem(output[path], reqCtx, {
-		path,
-		status,
-		headers,
-		searchParams,
-	});
+	let resp =
+		body !== undefined
+			? // If we have a response body from matching, use it instead.
+			  new Response(body, { status })
+			: await runOrFetchBuildOutputItem(output[path], reqCtx, {
+					path,
+					status,
+					headers,
+					searchParams,
+			  });
 
 	const newHeaders = headers.normal;
 	applyHeaders(newHeaders, resp.headers);

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -33,6 +33,8 @@ export class RoutesMatcher {
 	public headers: { normal: Headers; important: Headers };
 	/** Search params for the response object */
 	public searchParams: URLSearchParams;
+	/** Custom response body from middleware */
+	public body: BodyInit | undefined | null;
 
 	/** Counter for how many times the function to check a phase has been called */
 	public checkPhaseCounter;
@@ -165,6 +167,17 @@ export class RoutesMatcher {
 			resp.headers.delete(rewriteKey);
 		}
 
+		const nextKey = 'x-middleware-next';
+		const nextHeader = resp.headers.get(nextKey);
+		if (nextHeader) {
+			resp.headers.delete(nextKey);
+		} else if (!rewriteHeader && !resp.headers.has('location')) {
+			// We should set the final response body and status to the middleware's if it does not want
+			// to continue and did not rewrite/redirect the URL.
+			this.body = resp.body;
+			this.status = resp.status;
+		}
+
 		applyHeaders(this.headers.normal, resp.headers);
 	}
 
@@ -192,8 +205,8 @@ export class RoutesMatcher {
 			status: this.status,
 		});
 
-		if (resp.status >= 400) {
-			// The middleware function errored. Set the status and bail out.
+		if (resp.status === 500) {
+			// The middleware function threw an error. Set the status and bail out.
 			this.status = resp.status;
 			return false;
 		}
@@ -407,6 +420,8 @@ export class RoutesMatcher {
 		// Call and process the middleware if this is a middleware route.
 		const success = await this.runRouteMiddleware(route.middlewarePath);
 		if (!success) return 'error';
+		// If the middleware set a response body, we are done.
+		if (this.body !== undefined) return 'done';
 
 		// Update final headers with the ones from this route.
 		this.applyRouteHeaders(route, srcMatch, captureGroupKeys);

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -167,10 +167,10 @@ export class RoutesMatcher {
 			resp.headers.delete(rewriteKey);
 		}
 
-		const nextKey = 'x-middleware-next';
-		const nextHeader = resp.headers.get(nextKey);
-		if (nextHeader) {
-			resp.headers.delete(nextKey);
+		const middlewareNextKey = 'x-middleware-next';
+		const middlewareNextHeader = resp.headers.get(middlewareNextKey);
+		if (middlewareNextHeader) {
+			resp.headers.delete(middlewareNextKey);
 		} else if (!rewriteHeader && !resp.headers.has('location')) {
 			// We should set the final response body and status to the middleware's if it does not want
 			// to continue and did not rewrite/redirect the URL.

--- a/templates/_worker.js/utils/routing.ts
+++ b/templates/_worker.js/utils/routing.ts
@@ -11,6 +11,7 @@ export type MatchedSet = {
 	status: number | undefined;
 	headers: { normal: Headers; important: Headers };
 	searchParams: URLSearchParams;
+	body: BodyInit | undefined | null;
 };
 
 /**
@@ -59,7 +60,7 @@ export function getNextPhase(phase: VercelPhase): VercelHandleValue {
 export async function runOrFetchBuildOutputItem(
 	item: VercelBuildOutputItem | undefined,
 	{ request, assetsFetcher, ctx }: RequestContext,
-	{ path, searchParams }: MatchedSet
+	{ path, searchParams }: Omit<MatchedSet, 'body'>
 ) {
 	let resp: Response | undefined = undefined;
 

--- a/tests/_helpers/index.ts
+++ b/tests/_helpers/index.ts
@@ -127,6 +127,15 @@ function createMockMiddlewareEntrypoint(file = '/'): EdgeFunction {
 				});
 			}
 
+			if (url.searchParams.has('returns')) {
+				return new Response('<html>Hello from middleware</html>', {
+					status: 401,
+					headers: new Headers({
+						'content-type': 'text/html',
+					}),
+				});
+			}
+
 			return new Response(null, {
 				status: 200,
 				headers: new Headers({

--- a/tests/templates/requestTestData/middleware.ts
+++ b/tests/templates/requestTestData/middleware.ts
@@ -1,7 +1,7 @@
 import type { TestSet } from '../../_helpers';
 import { createValidFuncDir } from '../../_helpers';
 
-// routes using middleware: redirect, rewrite, set headers, set cookies, override request headers.
+// routes using middleware: redirect, rewrite, set headers, set cookies, override request headers, return new NextResponse.
 
 const rawVercelConfig: VercelConfig = {
 	version: 3,
@@ -81,7 +81,6 @@ export const testSet: TestSet = {
 				headers: {
 					'content-type': 'text/plain;charset=UTF-8',
 					'x-matched-path': '/api/hello',
-					'x-middleware-next': '1',
 				},
 			},
 		},
@@ -119,7 +118,6 @@ export const testSet: TestSet = {
 					'x-matched-path': '/api/hello',
 					'set-cookie': 'x-hello-from-middleware2=hello; Path=/',
 					'x-hello-from-middleware2': 'hello',
-					'x-middleware-next': '1',
 				},
 			},
 		},
@@ -141,7 +139,6 @@ export const testSet: TestSet = {
 					'x-matched-path': '/api/hello',
 					'set-cookie': 'x-hello-from-middleware2=hello; Path=/',
 					'x-hello-from-middleware2': 'hello',
-					'x-middleware-next': '1',
 				},
 				reqHeaders: {
 					'not-overriden': 'should not be overriden',
@@ -161,6 +158,17 @@ export const testSet: TestSet = {
 					'x-matched-path': '/500',
 				},
 				mockConsole: { error: [new Error('Middleware error')] },
+			},
+		},
+		{
+			name: 'middleware route returns custom response when returning a new NextResponse',
+			paths: ['/api/hello?returns'],
+			expected: {
+				status: 401,
+				data: '<html>Hello from middleware</html>',
+				headers: {
+					'content-type': 'text/html',
+				},
 			},
 		},
 	],


### PR DESCRIPTION
This PR does the following:
- Modifies the middleware handling to check for the `x-middleware-next` header and act as follows:
  - If the header exists, remove it and continue as normal.
  - If the header does not exist, and there was no rewrite or location header, this means the middleware response should be the final response we return to the client.
    - Therefore, update the final response body and status.
- Changes the middleware error check to only be for status 500 which is what occurs when an error is thrown in a middleware func.
- Checks if a response body was set during middleware processing and if so, bails out of routing and also uses it when returning a response to the client.
- Adds a test for the new logic.

fixes https://github.com/cloudflare/next-on-pages/issues/283