### PR TITLE
fix: non-index pages with trailing slash rewriting to `/index` for rsc requests

### DIFF
--- a/.changeset/smooth-pumpkins-press.md
+++ b/.changeset/smooth-pumpkins-press.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix non-index pages with trailing slash rewriting to /index for rsc requests.

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -275,7 +275,7 @@ export class RoutesMatcher {
 		// NOTE: Special handling for `/index` RSC routes. Sometimes the Vercel build output config
 		// has a record to rewrite `^/` to `/index.rsc`, however, this will hit requests to pages
 		// that aren't `/`. In this case, we should check that the previous path is `/`.
-		if (/\/index\.rsc$/i.test(this.path) && !/\/(?:index)?$/i.test(prevPath)) {
+		if (/\/index\.rsc$/i.test(this.path) && !/^\/(?:index)?$/i.test(prevPath)) {
 			this.path = prevPath;
 		}
 

--- a/tests/templates/requestTestData/basicEdgeAppDir.ts
+++ b/tests/templates/requestTestData/basicEdgeAppDir.ts
@@ -92,6 +92,8 @@ export const testSet: TestSet = {
 			api: { 'hello.func': createValidFuncDir('/api/hello') },
 			'index.func': createValidFuncDir('/index'),
 			'index.rsc.func': createValidFuncDir('/index.rsc'),
+			'alternative.func': createValidFuncDir('/alternative'),
+			'alternative.rsc.func': createValidFuncDir('/alternative.rsc'),
 		},
 		static: {
 			_next: {
@@ -232,6 +234,20 @@ export const testSet: TestSet = {
 				headers: {
 					'content-type': 'text/plain;charset=UTF-8',
 					'x-matched-path': '/',
+				},
+			},
+		},
+		{
+			name: "non-index page with trailing slash and rsc header doesn't redirect to /index",
+			paths: ['/alternative/'],
+			headers: { rsc: '1' },
+			expected: {
+				status: 200,
+				data: JSON.stringify({ file: '/alternative', params: [] }),
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+					'x-matched-path': '/alternative.rsc',
+					vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
 				},
 			},
 		},


### PR DESCRIPTION
This PR does the following:
- Alter the regex for the special handling of rewriting `^/` to `/index` to check that the index path is at the start of the pathname.
- Adds a test for the bug fix.

We previously added special handling for the build output config rule rewriting `^/` to `/index` when the `rsc` header is present as it was causing requests to `/non-index-path` to be rewritten. The handling involved verifying that the previous path before the rewrite was actually an index path. However, the regex wasn't checking that it started with the index path, only that one existed in the path, i.e. `*/` or `*/index`.

This meant that it would also match requests with a trailing slash by accident (e.g. `/non-index-path/`, so this change alters the regex to ensure that it is matching at the start of the path.

For reference, the config rule that this relates to:
```ts
{
  src: '^/',
  has: [{ type: 'header', key: 'rsc' }],
  dest: '/index.rsc',
  headers: {
    vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
  },
  continue: true,
  override: true,
}
```