### PR TITLE
fix: dynamic params not being derived correctly by next.js in some cases

### DIFF
--- a/.changeset/itchy-humans-tease.md
+++ b/.changeset/itchy-humans-tease.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix dynamic params not being derived correctly in some cases when running a page's function.

--- a/templates/_worker.js/utils/http.ts
+++ b/templates/_worker.js/utils/http.ts
@@ -40,6 +40,8 @@ export function isUrl(url: string): boolean {
  *
  * Only updates the a parameter if the target does not contain it, or the source value is not empty.
  *
+ * For params prefixed with `nxtP`, it also sets the param without the prefix if it does not exist.
+ *
  * @param target Target that search params will be applied to.
  * @param source Source search params to apply to the target.
  */
@@ -50,6 +52,11 @@ export function applySearchParams(
 	for (const [key, value] of source.entries()) {
 		if (!target.has(key) || !!value) {
 			target.set(key, value);
+
+			const paramMatch = /^nxtP(.+)$/.exec(key);
+			if (paramMatch?.[1] && !target.has(paramMatch[1])) {
+				target.set(paramMatch[1], value);
+			}
 		}
 	}
 }

--- a/tests/templates/requestTestData/i18n.ts
+++ b/tests/templates/requestTestData/i18n.ts
@@ -259,7 +259,10 @@ export const testSet: TestSet = {
 				status: 200,
 				data: JSON.stringify({
 					file: '/gsp/[slug]',
-					params: [['nxtPslug', 'test']],
+					params: [
+						['nxtPslug', 'test'],
+						['slug', 'test'],
+					],
 				}),
 				headers: {
 					'content-type': 'text/plain;charset=UTF-8',


### PR DESCRIPTION
This PR does the following:
- When a param prefixed by `nxtP` is encountered, it tries to apply the parameter without the prefix as well.
- Updates the relevant tests to reflect this.

During routing, the build output config rewrites dynamic routes to `/[id]?nxtPid=...`, where the value after `nxtP` is the name of the dynamic parameter. It appears that there is a bug where in certain cases, Next.js fails to derive the parameters from the search params when running a page's function, which it is normally able to do correctly.

I must admit that I am not sure why that happens or what causes it to fail to derive the dynamic params when the page's function is run, but it occurs in the reproduction in https://github.com/cloudflare/next-on-pages/issues/290#issuecomment-1578109221.

fixes #290