### PR TITLE
Apply minor npm improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `@cloudflare/next-on-pages` is a CLI tool that you can use to build and develop [Next.js](https://nextjs.org/) applications so that they can run on the [Cloudflare Pages](https://pages.cloudflare.com/) platform (and integrate with Cloudflare's various other [product offerings](https://developers.cloudflare.com/pages/platform/functions/bindings/), such as KV, D1, R2, and Durable Objects).
 
-This tool is a best-effort library implemented by the Cloudflare team and the community. As such, most, but not all, Next.js features are supported. See the [Supported Versions and Features document](./docs/supported.md) for more details.
+This tool is a best-effort library implemented by the Cloudflare team and the community. As such, most, but not all, Next.js features are supported. See the [Supported Versions and Features document](https://github.com/cloudflare/next-on-pages/blob/main/docs/supported.md) for more details.
 
 ## Quick Start
 
@@ -38,7 +38,7 @@ export const runtime = 'edge';
 
 &NewLine;
 
-For more examples of this and for Next.js versions prior to v13.3.1, take a look at our [examples document](/docs/examples.md). Additionally, ensure that your application is not using any [unsupported APIs](https://nextjs.org/docs/app/api-reference/edge#unsupported-apis) or [features](./docs/supported.md).
+For more examples of this and for Next.js versions prior to v13.3.1, take a look at our [examples document](https://github.com/cloudflare/next-on-pages/blob/main/docs/examples.md). Additionally, ensure that your application is not using any [unsupported APIs](https://nextjs.org/docs/app/api-reference/edge#unsupported-apis) or [features](https://github.com/cloudflare/next-on-pages/blob/main/docs/supported.md).
 
 ### 3. Deploy your application to Cloudflare Pages
 
@@ -98,11 +98,11 @@ npx wrangler pages dev .vercel/output/static --compatibility-flag=nodejs_compat
 
 ## Examples
 
-To see some examples on how to use Next.js features with `@cloudflare/next-on-pages`, see the [Examples document](./docs/examples.md).
+To see some examples on how to use Next.js features with `@cloudflare/next-on-pages`, see the [Examples document](https://github.com/cloudflare/next-on-pages/blob/main/docs/examples.md).
 
 ## Contributing
 
-If you want to contribute to this project please refer to the [Contributing document](./docs/contributing.md).
+If you want to contribute to this project please refer to the [Contributing document](https://github.com/cloudflare/next-on-pages/blob/main/docs/contributing.md).
 
 ## References
 
@@ -116,6 +116,6 @@ Extra references you might be interested in:
 
   Cloudflare guide on how to create and deploy a Next.js application. The application can be either static (and deployed as simple static assets) or dynamic using the edge runtime (using `@cloudflare/next-on-pages`).
 
-- [Technical Documentation](./docs/technical)
+- [Technical Documentation](https://github.com/cloudflare/next-on-pages/blob/main/docs/technical)
 
   Explanations and insights into how `@cloudflare/next-on-pages` works, design decisions behind different aspects, and how it handles different Next.js features.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,21 @@
 		"dist",
 		"templates"
 	],
+	"keywords": [
+		"cloudflare",
+		"cloudflare pages",
+		"edge",
+		"nextjs"
+	],
+	"license": "MIT",
+	"homepage": "https://github.com/cloudflare/next-on-pages#readme",
+	"bugs": {
+		"url": "https://github.com/cloudflare/next-on-pages/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cloudflare/next-on-pages.git"
+	},
 	"dependencies": {
 		"acorn": "^8.8.0",
 		"ast-types": "^0.14.2",


### PR DESCRIPTION
### This PR:

- __converts all relative urls in the README to be absolute urls since relative urls in the npm site result in 404s__
alternatively for fixing the above we could include the `doc` folder in the package as well, but that would increase the package side and number of files... so I'd imagine using absolute urls is preferred? 🤷\
another alternative would be to have a standard gh readme and an npm readme, I think that it wouldn't be too bad having a minimalistic README on npm, but it would require some extra login in the packaging process\
(Please let me know if you prefer one of the other alternatives I'd be equally fine with all of them)
- __Adds missing fields in the package.json related to info displayed on npm__


___

For reference see the current npm next-on-pages page here: https://www.npmjs.com/package/@cloudflare/next-on-pages

   
<details>

<summary>Example of why a minimalistic npm README could be useful</summary>

For example we have some styling that works nicely on gh but on npm can produce slightly weird results, like the heading we use, it shows the raw html in the search bar:

![Screenshot 2023-06-07 at 14 15 01](https://github.com/cloudflare/next-on-pages/assets/61631103/d9df09bd-f458-4f0c-adef-0ec58b8ff867)

</details>