### PR TITLE
fix: `set-cookie` headers overriding instead of appending

### DIFF
--- a/.changeset/red-crabs-cross.md
+++ b/.changeset/red-crabs-cross.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix headers overriding when more than one is set, instead of appending.

--- a/templates/_worker.js/utils/http.ts
+++ b/templates/_worker.js/utils/http.ts
@@ -16,12 +16,16 @@ export function applyHeaders(
 	const entries =
 		source instanceof Headers ? source.entries() : Object.entries(source);
 	for (const [key, value] of entries) {
-		target.set(
-			key.toLowerCase(),
-			pcreMatch?.match
-				? applyPCREMatches(value, pcreMatch.match, pcreMatch.captureGroupKeys)
-				: value
-		);
+		const lowerKey = key.toLowerCase();
+		const newValue = pcreMatch?.match
+			? applyPCREMatches(value, pcreMatch.match, pcreMatch.captureGroupKeys)
+			: value;
+
+		if (lowerKey === 'set-cookie') {
+			target.append(lowerKey, newValue);
+		} else {
+			target.set(lowerKey, newValue);
+		}
 	}
 }
 

--- a/tests/templates/utils/http.test.ts
+++ b/tests/templates/utils/http.test.ts
@@ -42,6 +42,16 @@ describe('applyHeaders', () => {
 			other: 'path/to/index.html',
 		});
 	});
+
+	test('appends `set-cookie` headers instead of overriding', () => {
+		const headers = new Headers({ 'set-cookie': 'first-value' });
+		applyHeaders(headers, { 'set-cookie': 'second-value' });
+
+		expect([...headers.entries()]).toEqual([
+			['set-cookie', 'first-value'],
+			['set-cookie', 'second-value'],
+		]);
+	});
 });
 
 describe('isUrl', () => {


### PR DESCRIPTION
This PR does the following:
- Appends headers when they are for `set-cookie`, instead of overriding the existing value.
- Adds a test for the fix.

This change fixes a bug where multiple `set-cookie` headers would result in only the final one being applied. With this change, they are all applied and included.