### PR TITLE
fix: intercept routes being unintentionally stripped

### DIFF
--- a/.changeset/young-beers-buy.md
+++ b/.changeset/young-beers-buy.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Prevent the route group stripping regex from removing intercept routes.

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -10,7 +10,7 @@ import { normalizePath } from './fs';
  * @returns Path name with route groups stripped.
  */
 export function stripRouteGroups(path: string) {
-	return path.replace(/\/\(([^)]+)\)/g, '');
+	return path.replace(/\/\(([^).]+)\)/g, '');
 }
 
 /**

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -5,6 +5,9 @@ import { normalizePath } from './fs';
  *
  * The build output config does not rewrite requests to route groups, so we need to strip route
  * groups from the path name for file system matching.
+ * 
+ * Does not strip brackets containing `.` characters, as these are used for route intercepts.
+ * https://nextjs.org/docs/app/building-your-application/routing/intercepting-routes
  *
  * @param path Path name to strip route groups from.
  * @returns Path name with route groups stripped.

--- a/src/utils/routing.ts
+++ b/src/utils/routing.ts
@@ -5,7 +5,7 @@ import { normalizePath } from './fs';
  *
  * The build output config does not rewrite requests to route groups, so we need to strip route
  * groups from the path name for file system matching.
- * 
+ *
  * Does not strip brackets containing `.` characters, as these are used for route intercepts.
  * https://nextjs.org/docs/app/building-your-application/routing/intercepting-routes
  *

--- a/tests/src/utils/routing.test.ts
+++ b/tests/src/utils/routing.test.ts
@@ -16,7 +16,9 @@ describe('routing', () => {
 
 	test('stripRouteGroups does not strip intercepts', () => {
 		expect(stripRouteGroups('/(.)intercept')).toEqual('/(.)intercept');
-		expect(stripRouteGroups('/(..)(..)intercept')).toEqual('/(..)(..)intercept');
+		expect(stripRouteGroups('/(..)(..)intercept')).toEqual(
+			'/(..)(..)intercept'
+		);
 	});
 
 	test('stripIndexRoute', () => {

--- a/tests/src/utils/routing.test.ts
+++ b/tests/src/utils/routing.test.ts
@@ -16,6 +16,7 @@ describe('routing', () => {
 
 	test('stripRouteGroups does not strip intercepts', () => {
 		expect(stripRouteGroups('/(.)intercept')).toEqual('/(.)intercept');
+		expect(stripRouteGroups('/(..)(..)intercept')).toEqual('/(..)(..)intercept');
 	});
 
 	test('stripIndexRoute', () => {

--- a/tests/src/utils/routing.test.ts
+++ b/tests/src/utils/routing.test.ts
@@ -14,6 +14,10 @@ describe('routing', () => {
 		expect(stripRouteGroups('/(route-group)/path')).toEqual('/path');
 	});
 
+	test('stripRouteGroups does not strip intercepts', () => {
+		expect(stripRouteGroups('/(.)intercept')).toEqual('/(.)intercept');
+	});
+
 	test('stripIndexRoute', () => {
 		expect(stripIndexRoute('/index')).toEqual('/');
 		expect(stripIndexRoute('/path/index')).toEqual('/path');


### PR DESCRIPTION
This PR does the following:
- Fixes the regex used to strip route groups to not strip route intercepts.
- Adds a test for the bug fix.

Intercept routes use the format `/(.)path` which was being accidentally caught in the route group stripping, since route groups use `/(name)`. This PR changes that behaviour to exclude brackets that contain periods from matching the route group regex.

fixes #310