### PR TITLE
feat: wildcard option support in the build output config

### DIFF
--- a/.changeset/itchy-rings-behave.md
+++ b/.changeset/itchy-rings-behave.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Support the `wildcard` option in the Vercel build output config.

--- a/.changeset/itchy-rings-behave.md
+++ b/.changeset/itchy-rings-behave.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': minor
 ---
 
-Support the `wildcard` option in the Vercel build output config.
+Support for the `wildcard` option in the Vercel build output config.

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -28,7 +28,7 @@ Earlier and Later versions might be only partially supported, we don't fully kno
 | routes `locale`         | ✅      |
 | routes `middlewarePath` | ✅      |
 | images<sup>1</sup>      | 🔄      |
-| wildcard                | 🔄      |
+| wildcard                | ✅      |
 | overrides               | ✅      |
 | cache                   | ❌      |
 | crons                   | ❌      |

--- a/templates/_worker.js/handleRequest.ts
+++ b/templates/_worker.js/handleRequest.ts
@@ -16,7 +16,12 @@ export async function handleRequest(
 	config: ProcessedVercelConfig,
 	output: VercelBuildOutput
 ): Promise<Response> {
-	const matcher = new RoutesMatcher(config.routes, output, reqCtx);
+	const matcher = new RoutesMatcher(
+		config.routes,
+		output,
+		reqCtx,
+		config.wildcard
+	);
 	const match = await findMatch(matcher);
 
 	return generateResponse(reqCtx, match, output);

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -49,7 +49,7 @@ export class RoutesMatcher {
 	 * @param routes The processed Vercel build output config routes.
 	 * @param output Vercel build output.
 	 * @param reqCtx Request context object; request object, assets fetcher, and execution context.
-	 * @param wildcardMatch Wildcard options from the Vercel build output config.
+	 * @param wildcardConfig Wildcard options from the Vercel build output config.
 	 * @returns The matched set of path, status, headers, and search params.
 	 */
 	constructor(

--- a/tests/templates/requestTestData/i18n.ts
+++ b/tests/templates/requestTestData/i18n.ts
@@ -118,6 +118,7 @@ const rawVercelConfig: VercelConfig = {
 		},
 		{ src: '/.*', dest: '/en/500', status: 500 },
 	],
+	wildcard: [{ domain: 'example.es', value: '/es' }],
 	overrides: {
 		'en/gsp.html': { path: 'en/gsp', contentType: 'text/html; charset=utf-8' },
 		'fr/gsp.html': { path: 'fr/gsp', contentType: 'text/html; charset=utf-8' },
@@ -342,6 +343,19 @@ export const testSet: TestSet = {
 				headers: {
 					'content-type': 'text/html; charset=utf-8',
 					'x-matched-path': '/fr',
+				},
+			},
+		},
+		{
+			name: 'Vercel wildcard rewrites work: example.es -> /es',
+			paths: ['/'],
+			host: 'example.es',
+			expected: {
+				status: 200,
+				data: '<html>es</html>',
+				headers: {
+					'content-type': 'text/html; charset=utf-8',
+					'x-matched-path': '/es',
 				},
 			},
 		},


### PR DESCRIPTION
This PR does the following:
- Introduces support for the [`wildcard`](https://vercel.com/docs/build-output-api/v3/configuration#wildcard) option in the Vercel build output config.
- Applies wildcard matches to the route destination.
- Adds a test for the new functionality.
- Removes the `prevMatch` optional input for the `RoutesMatcher` constructor since it is never used.