### PR TITLE
Mitigate build loop in watch mode when using yarn (classic)

### DIFF
--- a/.changeset/empty-toys-notice.md
+++ b/.changeset/empty-toys-notice.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Added package.json to list of ignored files in watch mode to ensure compatibility with yarn (classic)

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ function setWatchMode(fn: () => void): void {
 			'pnpm-lock.yaml',
 			'.pnpm-store',
 			'_tmp_*',
+			'package.json',
 		],
 		ignoreInitial: true,
 	}).on('all', fn);


### PR DESCRIPTION

When using yarn (classic) as the package manager the build process ends up in an infinite loop when using watch mode.
`vercel` is added as a dev dependency when using this package manager. This results in the change in the package.json.

___

resolves #308  