### PR TITLE
fix: i18n locale index request not matching for ssr'd index route

### DIFF
--- a/.changeset/four-clouds-travel.md
+++ b/.changeset/four-clouds-travel.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix i18n locale index routes not matching for SSR'd index pages.

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -399,7 +399,9 @@ export class RoutesMatcher {
 			return route;
 		}
 
-		if (/^\//.test(route.src) && route.src.slice(1) in this.locales) {
+		const isLocaleIndex =
+			/^\//.test(route.src) && route.src.slice(1) in this.locales;
+		if (isLocaleIndex) {
 			return { ...route, src: `^${route.src}$` };
 		}
 

--- a/templates/_worker.js/routes-matcher.ts
+++ b/templates/_worker.js/routes-matcher.ts
@@ -1,6 +1,6 @@
 import { parse } from 'cookie';
 import type { MatchPCREResult } from './utils';
-import { parseAcceptLanguage } from './utils';
+import { isLocaleTrailingSlashRegex, parseAcceptLanguage } from './utils';
 import {
 	applyHeaders,
 	applyPCREMatches,
@@ -405,14 +405,7 @@ export class RoutesMatcher {
 			return { ...route, src: `^${route.src}$` };
 		}
 
-		const trailingSlashRegex = /^\^\/\/\?\(\?:([a-zA-Z|]+)\)\/\(\.\*\)$/;
-		const trailingSlashMatch = trailingSlashRegex.exec(route.src);
-		if (
-			trailingSlashMatch?.[1]
-				?.split('|')
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				?.every(locale => locale in this.locales!)
-		) {
+		if (isLocaleTrailingSlashRegex(route.src, this.locales)) {
 			return { ...route, src: route.src.replace(/\/\(\.\*\)$/, '(?:/(.*))?$') };
 		}
 

--- a/templates/_worker.js/utils/routing.ts
+++ b/templates/_worker.js/utils/routing.ts
@@ -103,3 +103,28 @@ export async function runOrFetchBuildOutputItem(
 
 	return createMutableResponse(resp);
 }
+
+/**
+ * Checks if a source route's matcher uses the regex format for locales with a trailing slash, where
+ * the locales specified are known.
+ *
+ * Determines whether a matcher is in the format of `^//?(?:en|fr|nl)/(.*)`.
+ *
+ * @param src Source route `src` regex value.
+ * @param locales Known available locales.
+ * @returns Whether the source route matches the regex for a locale with a trailing slash.
+ */
+export function isLocaleTrailingSlashRegex(
+	src: string,
+	locales: Record<string, string>
+) {
+	const prefix = '^//?(?:';
+	const suffix = ')/(.*)';
+
+	if (!src.startsWith(prefix) || !src.endsWith(suffix)) {
+		return false;
+	}
+
+	const foundLocales = src.slice(prefix.length, -suffix.length).split('|');
+	return foundLocales.every(locale => locale in locales);
+}

--- a/tests/templates/requestTestData/i18n.ts
+++ b/tests/templates/requestTestData/i18n.ts
@@ -233,7 +233,7 @@ export const testSet: TestSet = {
 					data: JSON.stringify({ file: '/index', params: [] }),
 					headers: {
 						'content-type': 'text/plain;charset=UTF-8',
-						'x-matched-path': `/`,
+						'x-matched-path': '/',
 					},
 				},
 			};

--- a/tests/templates/requestTestData/i18n.ts
+++ b/tests/templates/requestTestData/i18n.ts
@@ -19,12 +19,12 @@ const rawVercelConfig: VercelConfig = {
 			continue: true,
 		},
 		{
-			src: '^/(?!(?:_next/.*|en|fr|nl|es)(?:/.*|$))(.*)$',
+			src: '^/(?!(?:_next/.*|en|fr|nl|es|de)(?:/.*|$))(.*)$',
 			dest: '$wildcard/$1',
 			continue: true,
 		},
 		{
-			src: '^//?(?:en|fr|nl|es)?/?$',
+			src: '^//?(?:en|fr|nl|es|de)?/?$',
 			locale: {
 				redirect: { es: 'https://example.es/' },
 				cookie: 'NEXT_LOCALE',
@@ -34,24 +34,24 @@ const rawVercelConfig: VercelConfig = {
 		{
 			src: '/',
 			locale: {
-				redirect: { en: '/', fr: '/fr', nl: '/nl', es: '/es' },
+				redirect: { en: '/', fr: '/fr', nl: '/nl', es: '/es', de: '/de' },
 				cookie: 'NEXT_LOCALE',
 			},
 			continue: true,
 		},
 		{ src: '^/$', dest: '/en', continue: true },
 		{
-			src: '^/(?!(?:_next/.*|en|fr|nl|es)(?:/.*|$))(.*)$',
+			src: '^/(?!(?:_next/.*|en|fr|nl|es|de)(?:/.*|$))(.*)$',
 			dest: '/en/$1',
 			continue: true,
 		},
 		{
-			src: '/(?:en|fr|nl|es)?[/]?404/?',
+			src: '/(?:en|fr|nl|es|de)?[/]?404/?',
 			status: 404,
 			continue: true,
 			missing: [{ type: 'header', key: 'x-prerender-revalidate' }],
 		},
-		{ src: '/(?:en|fr|nl|es)?[/]?500', status: 500, continue: true },
+		{ src: '/(?:en|fr|nl|es|de)?[/]?500', status: 500, continue: true },
 		{ handle: 'filesystem' },
 		{ src: '/_next/data/(.*)', dest: '/_next/data/$1', check: true },
 		{ handle: 'resource' },
@@ -64,23 +64,23 @@ const rawVercelConfig: VercelConfig = {
 			dest: '$0',
 		},
 		{ src: '/en', dest: '/', check: true },
-		{ src: '^//?(?:en|fr|nl|es)/(.*)', dest: '/$1', check: true },
+		{ src: '^//?(?:en|fr|nl|es|de)/(.*)', dest: '/$1', check: true },
 		{ handle: 'rewrite' },
 		{
-			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es)/gsp.json$',
+			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es|de)/gsp.json$',
 			dest: '/$nextLocale/gsp',
 		},
 		{
-			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es)/gsp/(?<nxtPslug>[^/]+?)\\.json$',
+			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es|de)/gsp/(?<nxtPslug>[^/]+?)\\.json$',
 			dest: '/$nextLocale/gsp/[slug]?nxtPslug=$nxtPslug',
 		},
 		{
-			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es)/gssp.json$',
+			src: '^/_next/data/_LMNvx1uNzgkLzYi9\\-YVv/(?<nextLocale>en|fr|nl|es|de)/gssp.json$',
 			dest: '/$nextLocale/gssp',
 		},
 		{ src: '/_next/data/(.*)', dest: '/404', status: 404 },
 		{
-			src: '^[/]?(?<nextLocale>en|fr|nl|es)?/gsp/(?<nxtPslug>[^/]+?)(?:/)?$',
+			src: '^[/]?(?<nextLocale>en|fr|nl|es|de)?/gsp/(?<nxtPslug>[^/]+?)(?:/)?$',
 			dest: '/$nextLocale/gsp/[slug]?nxtPslug=$nxtPslug',
 		},
 		{ handle: 'hit' },
@@ -104,14 +104,14 @@ const rawVercelConfig: VercelConfig = {
 		},
 		{ handle: 'error' },
 		{
-			src: '/(?<nextLocale>en|fr|nl|es)(/.*|$)',
+			src: '/(?<nextLocale>en|fr|nl|es|de)(/.*|$)',
 			dest: '/$nextLocale/404',
 			status: 404,
 			caseSensitive: true,
 		},
 		{ src: '/.*', dest: '/en/404', status: 404 },
 		{
-			src: '/(?<nextLocale>en|fr|nl|es)(/.*|$)',
+			src: '/(?<nextLocale>en|fr|nl|es|de)(/.*|$)',
 			dest: '/$nextLocale/500',
 			status: 500,
 			caseSensitive: true,
@@ -135,10 +135,14 @@ const rawVercelConfig: VercelConfig = {
 		'es.html': { path: 'es', contentType: 'text/html; charset=utf-8' },
 		'es/404.html': { path: 'es/404', contentType: 'text/html; charset=utf-8' },
 		'es/500.html': { path: 'es/500', contentType: 'text/html; charset=utf-8' },
+		'de/404.html': { path: 'de/404', contentType: 'text/html; charset=utf-8' },
+		'de/500.html': { path: 'de/500', contentType: 'text/html; charset=utf-8' },
 	},
 };
 
-const locales = ['en', 'nl', 'fr', 'es'] as const;
+const staticLocales = ['en', 'fr', 'nl', 'es'] as const;
+const nonStaticLocales = ['de'] as const;
+const locales = [...staticLocales, ...nonStaticLocales] as const;
 
 export const testSet: TestSet = {
 	name: 'routes using middleware',
@@ -147,6 +151,7 @@ export const testSet: TestSet = {
 		functions: {
 			gsp: { '[slug].func': createValidFuncDir('/gsp/[slug]') },
 			'gssp.func': createValidFuncDir('/gssp'),
+			'index.func': createValidFuncDir('/index'),
 		},
 		static: {
 			_next: {
@@ -164,7 +169,10 @@ export const testSet: TestSet = {
 			...locales.reduce(
 				(acc, locale) => ({
 					...acc,
-					[`${locale}.html`]: `<html>${locale}</html>`,
+					// @ts-expect-error - static locales is a subset of locales so this is fine
+					...(staticLocales.includes(locale)
+						? { [`${locale}.html`]: `<html>${locale}</html>` }
+						: {}),
 					[locale]: {
 						'404.html': `<html>${locale}: 404</html>`,
 						'500.html': `<html>${locale}: 500</html>`,
@@ -200,7 +208,7 @@ export const testSet: TestSet = {
 				},
 			},
 		},
-		...locales.map(locale => {
+		...staticLocales.map(locale => {
 			const path = `/${locale}`;
 			return {
 				name: `${path} matches ${path} static page for the correct locale`,
@@ -211,6 +219,21 @@ export const testSet: TestSet = {
 					headers: {
 						'content-type': 'text/html; charset=utf-8',
 						'x-matched-path': `${path}`,
+					},
+				},
+			};
+		}),
+		...nonStaticLocales.map(locale => {
+			const path = `/${locale}`;
+			return {
+				name: `${path} matches /index function as it is not statically generated`,
+				paths: [path],
+				expected: {
+					status: 200,
+					data: JSON.stringify({ file: '/index', params: [] }),
+					headers: {
+						'content-type': 'text/plain;charset=UTF-8',
+						'x-matched-path': `/`,
 					},
 				},
 			};

--- a/tests/templates/requestTestData/i18n.ts
+++ b/tests/templates/requestTestData/i18n.ts
@@ -169,8 +169,7 @@ export const testSet: TestSet = {
 			...locales.reduce(
 				(acc, locale) => ({
 					...acc,
-					// @ts-expect-error - static locales is a subset of locales so this is fine
-					...(staticLocales.includes(locale)
+					...(staticLocales.includes(locale as (typeof staticLocales)[number])
 						? { [`${locale}.html`]: `<html>${locale}</html>` }
 						: {}),
 					[locale]: {


### PR DESCRIPTION
This PR does the following:
- Introduces yet another hack for i18n to make it work properly.
- Ensures that requests to i18n index routes (e.g. `/nl`) can be rewritten to `/` in the `miss` phase by modifying the relevant source route's regex.
- Adds a test for the bug fix.

As we know from before, the build output config is rather iffy when it comes to `next.config.js` internationalization. The support for it appears to be half-baked. This PR adds another hack to resolve another regex issue for i18n in the build output config. At the moment, our support for statically generated index routes works fine, however, it appears that there is an issue when you use an SSR'd index route that generates an edge function.

In the `miss` phase, there is a source route as follows that is designed to rewrite any requests from `/{locale}/...` to `/...`.
```ts
{
  "src": "^//?(?:en|fr|nl)/(.*)",
  "dest": "/$1",
  "check": true
}
```
The problem with this regex is that it does not hit requests to `/{locale}`. It only hits when there is a trailing slash present, but it should always hit since this is the `miss` phase. When it fails to find a file to use for a path with i18n, it should be checking it without the locale present. In the case of requests to `/{locale}`, it should then check for a file for `/` if it can't find one.

Therefore, this hack modifies the regex to make the `/(.*)` optional.

`^//?(?:en|fr|nl)/(.*)` -> `^//?(?:en|fr|nl)(?:/(.*))?$`

Ugh. Supporting `next.config.js` i18n isn't that nice.

Fixes the issue encountered in the reproduction in https://github.com/cloudflare/next-on-pages/issues/37#issuecomment-1591894407