### PR TITLE
improve bundled assets handling

### DIFF
--- a/.changeset/clean-experts-tap.md
+++ b/.changeset/clean-experts-tap.md
@@ -1,0 +1,21 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+bundle assets produced by the Vercel build and make them accessible via fetch
+
+Vercel/Next can allow access binary assets bundled with their edge functions in the following manner:
+
+```
+const font = fetch(new URL('../../assets/asset-x', import.meta.url)).then(
+  (res) => res.arrayBuffer(),
+);
+```
+
+As you can see in this `@vercel/og` example:
+https://vercel.com/docs/concepts/functions/edge-functions/og-image-generation/og-image-examples#using-a-custom-font
+
+This sort of access to bindings is necessary for the `@vercel/og` package to work and might be used in other packages
+as well, so it is something that we need to support.
+We do so by making sure that we properly bind the assets found in the Vercel build output into our worker
+and that fetches to such assets (using blob urls) are correctly handled (this requires us to patch the global `fetch` function)

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -92,7 +92,7 @@ export async function generateFunctionsMap(
 	if (processingResults.bundledAssetsInfo.size) {
 		await copyBundledAssetFiles(
 			nextOnPagesDistDir,
-			processingResults.bundledAssetsInfo
+			processingResults.bundledAssetsInfo,
 		);
 	}
 
@@ -204,7 +204,7 @@ async function processDirectoryRecursively(
 				nextJsManifests.set(key, value),
 			);
 			dirResults.bundledAssetsInfo?.forEach((value, key) =>
-				bundledAssetsInfo.set(key, value)
+				bundledAssetsInfo.set(key, value),
 			);
 		}
 	}
@@ -233,12 +233,12 @@ type FunctionConfig = {
 
 async function processFuncDirectory(
 	setup: ProcessingSetup,
-	directoryFilepath: string
+	directoryFilepath: string,
 ): Promise<Partial<DirectoryProcessingResults>> {
 	const relativePath = relative(setup.functionsDir, directoryFilepath);
 
 	const functionConfig = await readJsonFile<FunctionConfig>(
-		join(directoryFilepath, '.vc-config.json')
+		join(directoryFilepath, '.vc-config.json'),
 	);
 
 	if (functionConfig?.runtime !== 'edge') {
@@ -966,7 +966,7 @@ async function collectChunksConsumersInfosFromFuncDirectory(
  */
 async function copyBundledAssetFiles(
 	distDir: string,
-	bundledAssetsInfo: Map<string, BundledAssetInfo>
+	bundledAssetsInfo: Map<string, BundledAssetInfo>,
 ): Promise<void> {
 	const assetsDir = join(distDir, 'assets');
 	await mkdir(assetsDir);

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -89,6 +89,13 @@ export async function generateFunctionsMap(
 		);
 	}
 
+	if (processingResults.bundledAssetsInfo.size) {
+		await copyBundledAssetFiles(
+			nextOnPagesDistDir,
+			processingResults.bundledAssetsInfo
+		);
+	}
+
 	return processingResults;
 }
 
@@ -139,6 +146,11 @@ async function tryToFixInvalidFunctions({
 	}
 }
 
+type BundledAssetInfo = {
+	filename: string;
+	originalFileLocation: string;
+};
+
 type WasmModuleInfo = {
 	identifier: string;
 	importPath: string;
@@ -155,6 +167,7 @@ async function processDirectoryRecursively(
 	const prerenderedRoutes = new Map<string, PrerenderedFileData>();
 	const wasmIdentifiers = new Map<string, WasmModuleInfo>();
 	const nextJsManifests = new Map<string, string>();
+	const bundledAssetsInfo = new Map<string, BundledAssetInfo>();
 
 	const files = await readdir(dir);
 	const functionFiles = await fixPrerenderedRoutes(
@@ -190,6 +203,9 @@ async function processDirectoryRecursively(
 			dirResults.nextJsManifests?.forEach((value, key) =>
 				nextJsManifests.set(key, value),
 			);
+			dirResults.bundledAssetsInfo?.forEach((value, key) =>
+				bundledAssetsInfo.set(key, value)
+			);
 		}
 	}
 
@@ -200,6 +216,7 @@ async function processDirectoryRecursively(
 		prerenderedRoutes,
 		wasmIdentifiers,
 		nextJsManifests,
+		bundledAssetsInfo,
 	};
 }
 
@@ -216,12 +233,12 @@ type FunctionConfig = {
 
 async function processFuncDirectory(
 	setup: ProcessingSetup,
-	filepath: string,
+	directoryFilepath: string
 ): Promise<Partial<DirectoryProcessingResults>> {
-	const relativePath = relative(setup.functionsDir, filepath);
+	const relativePath = relative(setup.functionsDir, directoryFilepath);
 
 	const functionConfig = await readJsonFile<FunctionConfig>(
-		join(filepath, '.vc-config.json'),
+		join(directoryFilepath, '.vc-config.json')
 	);
 
 	if (functionConfig?.runtime !== 'edge') {
@@ -239,7 +256,7 @@ async function processFuncDirectory(
 		functionConfig.entrypoint = 'index.js';
 	}
 
-	const functionFilePath = join(filepath, functionConfig.entrypoint);
+	const functionFilePath = join(directoryFilepath, functionConfig.entrypoint);
 	if (!(await validateFile(functionFilePath))) {
 		if (isMiddleware) {
 			// We sometimes encounter an uncompiled `middleware.js` with no compiled `index.js` outside of a base path.
@@ -291,6 +308,21 @@ async function processFuncDirectory(
 	contents = wasmExtractionResult.updatedContents;
 	wasmIdentifiers = wasmExtractionResult.wasmIdentifiers;
 
+	const bundledAssetsInfo = new Map<string, BundledAssetInfo>();
+
+	try {
+		const assetsDir = join(directoryFilepath, 'assets');
+		const files = await readdir(assetsDir);
+		files.forEach(file => {
+			bundledAssetsInfo.set(file, {
+				filename: file,
+				originalFileLocation: join(assetsDir, file),
+			});
+		});
+	} catch {
+		/* empty */
+	}
+
 	const newFilePath = join(setup.distFunctionsDir, `${relativePath}.js`);
 	await mkdir(dirname(newFilePath), { recursive: true });
 	const relativeNextOnPagesDistPath =
@@ -322,6 +354,7 @@ async function processFuncDirectory(
 		webpackChunks,
 		wasmIdentifiers,
 		nextJsManifests,
+		bundledAssetsInfo,
 	};
 }
 
@@ -635,6 +668,7 @@ export type DirectoryProcessingResults = {
 	prerenderedRoutes: Map<string, PrerenderedFileData>;
 	wasmIdentifiers: Map<string, WasmModuleInfo>;
 	nextJsManifests: Map<string, string>;
+	bundledAssetsInfo: Map<string, BundledAssetInfo>;
 };
 
 /**
@@ -921,4 +955,23 @@ async function collectChunksConsumersInfosFromFuncDirectory(
 	});
 
 	return chunksConsumersInfos;
+}
+
+/**
+ * Copies bundled asset files into the __next-on-pages-dist__/assets folder as binary files (so that they can be
+ * fetched as binaries)
+ *
+ * @param distDir the __next-on-pages-dist__ directory's path
+ * @param bundledAssetsInfo map containing all the bundled assets files info collected during the build process
+ */
+async function copyBundledAssetFiles(
+	distDir: string,
+	bundledAssetsInfo: Map<string, BundledAssetInfo>
+): Promise<void> {
+	const assetsDir = join(distDir, 'assets');
+	await mkdir(assetsDir);
+	for (const { filename, originalFileLocation } of bundledAssetsInfo.values()) {
+		const newLocation = join(assetsDir, `${filename}.bin`);
+		await copyFile(originalFileLocation, newLocation);
+	}
 }

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -310,8 +310,9 @@ async function processFuncDirectory(
 
 	const bundledAssetsInfo = new Map<string, BundledAssetInfo>();
 
-	try {
-		const assetsDir = join(directoryFilepath, 'assets');
+	const assetsDir = join(directoryFilepath, 'assets');
+	const assetsDirExists = await validateDir(join(directoryFilepath, 'assets'));
+	if (assetsDirExists) {
 		const files = await readdir(assetsDir);
 		files.forEach(file => {
 			bundledAssetsInfo.set(file, {
@@ -319,8 +320,6 @@ async function processFuncDirectory(
 				originalFileLocation: join(assetsDir, file),
 			});
 		});
-	} catch {
-		/* empty */
 	}
 
 	const newFilePath = join(setup.distFunctionsDir, `${relativePath}.js`);

--- a/packages/next-on-pages/src/buildApplication/generateGlobalJs.ts
+++ b/packages/next-on-pages/src/buildApplication/generateGlobalJs.ts
@@ -6,6 +6,11 @@
  */
 export function generateGlobalJs(): string {
 	return `
+		import('node:buffer').then(({ Buffer }) => {
+			globalThis.Buffer = Buffer;
+		})
+		.catch(() => null);
+
 		const __ENV_ALS_PROMISE__ = import('node:async_hooks').then(({ AsyncLocalStorage }) => {
 			globalThis.AsyncLocalStorage = AsyncLocalStorage;
 

--- a/packages/next-on-pages/templates/_worker.js/index.ts
+++ b/packages/next-on-pages/templates/_worker.js/index.ts
@@ -1,5 +1,9 @@
 import { handleRequest } from './handleRequest';
-import { adjustRequestForVercel, handleImageResizingRequest } from './utils';
+import {
+	adjustRequestForVercel,
+	handleImageResizingRequest,
+	patchFetchToAllowBundledAssets,
+} from './utils';
 import type { AsyncLocalStorage } from 'node:async_hooks';
 
 declare const __NODE_ENV__: string;
@@ -12,6 +16,7 @@ declare const __ENV_ALS_PROMISE__: Promise<null | AsyncLocalStorage<unknown>>;
 
 export default {
 	async fetch(request, env, ctx) {
+		patchFetchToAllowBundledAssets();
 		const envAsyncLocalStorage = await __ENV_ALS_PROMISE__;
 		if (!envAsyncLocalStorage) {
 			return new Response(

--- a/packages/next-on-pages/templates/_worker.js/index.ts
+++ b/packages/next-on-pages/templates/_worker.js/index.ts
@@ -14,9 +14,10 @@ declare const __BUILD_OUTPUT__: VercelBuildOutput;
 
 declare const __ENV_ALS_PROMISE__: Promise<null | AsyncLocalStorage<unknown>>;
 
+patchFetchToAllowBundledAssets();
+
 export default {
 	async fetch(request, env, ctx) {
-		patchFetchToAllowBundledAssets();
 		const envAsyncLocalStorage = await __ENV_ALS_PROMISE__;
 		if (!envAsyncLocalStorage) {
 			return new Response(

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -1,0 +1,40 @@
+export function patchFetchToAllowBundledAssets(): void {
+	const flagSymbol = Symbol.for('next-on-pages bundled assets fetch patch');
+
+	const alreadyPatched = (
+		globalThis.fetch as unknown as { [flagSymbol]: boolean }
+	)[flagSymbol];
+	if (alreadyPatched) {
+		return;
+	}
+
+	applyPatch();
+
+	(globalThis.fetch as unknown as { [flagSymbol]: boolean })[flagSymbol] = true;
+}
+
+function applyPatch() {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = async (...args) => {
+		const request = new Request(...args);
+
+		if (request.url.startsWith('blob:')) {
+			try {
+				const url = new URL(request.url);
+				const binaryContent = (
+					await import(`./__next-on-pages-dist__/assets/${url.pathname}.bin`)
+				).default;
+
+				return {
+					arrayBuffer() {
+						return binaryContent;
+					},
+				} as Response;
+			} catch {
+				/* empty, let's just fallback to the original fetch */
+			}
+		}
+
+		return originalFetch(request);
+	};
+}

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -25,11 +25,21 @@ function applyPatch() {
 					await import(`./__next-on-pages-dist__/assets/${url.pathname}.bin`)
 				).default;
 
-				return {
+				// Note: we can't generate a real Response object here because this fetch might be called
+				//       at the top level of a dynamically imported module, and such cases produce the following
+				//       error:
+				//           Some functionality, such as asynchronous I/O, timeouts, and generating random values,
+				//           can only be performed while handling a request
+				//       this is a somewhat known workerd behavior (currently kept for security and performance reasons)
+				//
+				//       if the above issue/constraint were to change we should replace the following with a real Response object
+				const resp = {
 					arrayBuffer() {
 						return binaryContent;
 					},
 				} as Response;
+
+				return resp;
 			} catch {
 				/* empty, let's just fallback to the original fetch */
 			}

--- a/packages/next-on-pages/templates/_worker.js/utils/index.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/index.ts
@@ -4,3 +4,4 @@ export * from './http';
 export * from './pcre';
 export * from './routing';
 export * from './images';
+export * from './fetch';

--- a/packages/next-on-pages/tests/src/buildApplication/generateGlobalJs.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/generateGlobalJs.test.ts
@@ -17,6 +17,15 @@ describe('generateGlobalJs', async () => {
 			);
 		});
 
+		test('should make the Buffer globally available', async () => {
+			/*
+				Note: we need Buffer in the global scope
+					as it is sometimes used by Next under the hood
+			*/
+			const globalJs = generateGlobalJs();
+			expect(globalJs).toContain('globalThis.Buffer = Buffer');
+		});
+
 		test('create an AsyncLocalStorage and set it as a proxy to process.env', async () => {
 			const globalJs = generateGlobalJs();
 			expect(globalJs).toContain(


### PR DESCRIPTION
This PR allows us to handle vercel asset fetches such as the one present in this example: https://vercel.com/docs/concepts/functions/edge-functions/og-image-generation/og-image-examples#using-a-custom-font

Which makes it possible to use `@vercel/og` 🚀 😄 

Result:
[simple-wasm-pages-13.3.1](https://github.com/dario-piotrowicz/next-apps-for-testing/tree/master/apps/simple-wasm-pages-13.3.1) deployed at: https://a9aeda25.next-on-pages-test-5h3.pages.dev

resolves #39 