### PR TITLE
feat: print build summary with info about the build

### DIFF
--- a/.changeset/silly-hornets-allow.md
+++ b/.changeset/silly-hornets-allow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": minor
+---
+
+Display a summary about the build at the end of the build process.

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -1,5 +1,5 @@
 import { exit } from 'process';
-import { resolve } from 'path';
+import { join, resolve } from 'path';
 import type { CliOptions } from '../cli';
 import { cliError, cliLog } from '../cli';
 import { getVercelConfig } from './getVercelConfig';
@@ -21,6 +21,7 @@ import {
 	getPackageVersion,
 } from './packageManagerUtils';
 import { gtr as versionGreaterThan, coerce } from 'semver';
+import { printBuildSummary, writeBuildInfo } from './buildSummary';
 
 /**
  * Builds the _worker.js with static assets implementing the Next.js application
@@ -111,6 +112,13 @@ async function prepareAndBuildWorker(
 		staticAssets,
 		generatedFunctionsMaps?.prerenderedRoutes,
 		generatedFunctionsMaps?.functionsMap
+	);
+
+	printBuildSummary(staticAssets, generatedFunctionsMaps);
+	await writeBuildInfo(
+		join('.vercel', 'output', 'static', '_worker.js'),
+		staticAssets,
+		generatedFunctionsMaps
 	);
 
 	await buildWorkerFile(

--- a/packages/next-on-pages/src/buildApplication/buildSummary.ts
+++ b/packages/next-on-pages/src/buildApplication/buildSummary.ts
@@ -13,7 +13,7 @@ import type { DirectoryProcessingResults } from './generateFunctionsMap';
  * @param items A map of items to process.
  * @returns A list of items to be used in the build summary.
  */
-function processItemsMap(items: Map<string, unknown>) {
+function processItemsMap(items: Map<string, unknown>): string[] {
 	return [...items.keys()]
 		.filter(path => !/\.rsc$/.test(path))
 		.map(path => addLeadingSlash(stripIndexRoute(path.replace(/\.html$/, ''))))
@@ -51,7 +51,7 @@ function addToSummary(
 	name: string,
 	rawItems: string[],
 	limit?: number
-) {
+): string {
 	if (rawItems.length === 0) return summary;
 
 	const items =
@@ -124,7 +124,7 @@ export async function writeBuildInfo(
 		prerenderedRoutes = new Map(),
 		wasmIdentifiers = new Map(),
 	}: Partial<DirectoryProcessingResults> = {}
-) {
+): Promise<void> {
 	const currentDir = resolve();
 	const filePath = join(outputDir, 'nop-build-info.json');
 

--- a/packages/next-on-pages/src/buildApplication/buildSummary.ts
+++ b/packages/next-on-pages/src/buildApplication/buildSummary.ts
@@ -1,0 +1,163 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+import { cliLog } from '../cli';
+import { addLeadingSlash, nextOnPagesVersion, stripIndexRoute } from '../utils';
+import type { DirectoryProcessingResults } from './generateFunctionsMap';
+
+/**
+ * Processes a map of items into a list that can be used in the build summary.
+ *
+ * Filters out `.rsc` files and strips `.html` from the end of the path, sorting the list
+ * alphabetically.
+ *
+ * @param items A map of items to process.
+ * @returns A list of items to be used in the build summary.
+ */
+function processItemsMap(items: Map<string, unknown>) {
+	return [...items.keys()]
+		.filter(path => !/\.rsc$/.test(path))
+		.map(path => addLeadingSlash(stripIndexRoute(path.replace(/\.html$/, ''))))
+		.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Returns a prefix to be used in the printed build summary for an item's index.
+ *
+ * @param total Total number of items.
+ * @param idx Current item index.
+ * @returns The prefix for the log message.
+ */
+function getItemPrefix(total: number, idx: number): string {
+	if (total === 1) return '-';
+	if (idx === 0) return '┌';
+	if (idx === total - 1) return '└';
+	return '├';
+}
+
+/**
+ * Adds a group of items to the build summary, limiting the number of items to be displayed if
+ * necessary.
+ *
+ * Formats the items with stylised prefixes and indentations.
+ *
+ * @param summary Current summary.
+ * @param name The name of the group of items.
+ * @param rawItems List of items to be added to the summary.
+ * @param limit Maximum number of items to be displayed.
+ * @returns The updated summary.
+ */
+function addToSummary(
+	summary: string,
+	name: string,
+	rawItems: string[],
+	limit?: number
+) {
+	if (rawItems.length === 0) return summary;
+
+	const items =
+		limit && rawItems.length > limit
+			? [
+					...rawItems.slice(0, limit - 1),
+					`... ${rawItems.length - limit - 1} more`,
+			  ]
+			: rawItems;
+
+	const formattedItems = items
+		.map((path, idx) => `  ${getItemPrefix(items.length, idx)} ${path}`)
+		.join('\n');
+
+	return `${summary}
+	
+${name} (${rawItems.length})
+${formattedItems}`;
+}
+
+/**
+ * Prints a build summary to the console.
+ *
+ * @param staticAssets List of static assets collected during the build.
+ * @param directoryProcessingResults Results of processing the output directory.
+ */
+export function printBuildSummary(
+	staticAssets: string[],
+	{
+		functionsMap = new Map(),
+		prerenderedRoutes = new Map(),
+		wasmIdentifiers = new Map(),
+	}: Partial<DirectoryProcessingResults> = {}
+): void {
+	const functions = processItemsMap(functionsMap);
+	const prerendered = processItemsMap(prerenderedRoutes);
+
+	let otherStatic = staticAssets
+		.filter(path => !prerenderedRoutes.has(path))
+		.sort((a, b) => a.localeCompare(b));
+
+	// Move the `/_next` and `/__next` assets to the end of the static assets list
+	otherStatic = [
+		...otherStatic.filter(path => !/^\/__?next/.test(path)),
+		...otherStatic.filter(path => /^\/__?next/.test(path)),
+	];
+
+	let summary = `Build Summary (@cloudflare/next-on-pages v${nextOnPagesVersion})`;
+	summary = addToSummary(summary, 'Edge Function Routes', functions);
+	summary = addToSummary(summary, 'Prerendered Routes', prerendered, 20);
+	summary = addToSummary(summary, 'Wasm Files', [...wasmIdentifiers.keys()]);
+	summary = addToSummary(summary, 'Other Static Assets', otherStatic, 5);
+
+	cliLog(summary, { spaced: true, skipDedent: true });
+}
+
+/**
+ * Writes information about the build to a specific directory.
+ *
+ * @param outputDir Output directory.
+ * @param staticAssets List of static assets collected during the build.
+ * @param directoryProcessingResults Results of processing the output directory.
+ */
+export async function writeBuildInfo(
+	outputDir: string,
+	staticAssets: string[],
+	{
+		invalidFunctions = new Set(),
+		functionsMap = new Map(),
+		prerenderedRoutes = new Map(),
+		wasmIdentifiers = new Map(),
+	}: Partial<DirectoryProcessingResults> = {}
+) {
+	const currentDir = resolve();
+	const filePath = join(outputDir, 'nop-build-info.json');
+
+	// Change wasm paths to be relative to avoid leaking file system structure or account username.
+	const desensitizedWasmIdentifiers = [...wasmIdentifiers.values()].map(
+		({ originalFileLocation, ...rest }) => ({
+			...rest,
+			originalFileLocation: relative(currentDir, originalFileLocation),
+		})
+	);
+
+	await mkdir(outputDir, { recursive: true });
+	await writeFile(
+		filePath,
+		JSON.stringify(
+			{
+				version: nextOnPagesVersion,
+				timestamp: Date.now(),
+				outputDir: relative(currentDir, outputDir),
+				buildFiles: {
+					invalidFunctions: [...invalidFunctions.values()],
+					edgeFunctions: [...functionsMap.keys()],
+					prerenderFunctionFallbackFiles: [...prerenderedRoutes.keys()],
+					wasmFiles: desensitizedWasmIdentifiers,
+					staticAssets: staticAssets.filter(
+						path => !prerenderedRoutes.has(path)
+					),
+				},
+			},
+			null,
+			2
+		)
+	);
+
+	cliLog(`Build info saved to '${relative(currentDir, filePath)}'`);
+}

--- a/packages/next-on-pages/src/cli.ts
+++ b/packages/next-on-pages/src/cli.ts
@@ -75,11 +75,6 @@ export function parseCliArgs() {
 	}
 }
 
-type LogOptions = {
-	fromVercelCli?: boolean;
-	spaced?: boolean;
-};
-
 /**
  * Prints the help message that users get when they provide the help option
  *
@@ -120,47 +115,41 @@ export function printCliHelpMessage(): void {
 	`);
 }
 
-export function cliLog(
-	message: string,
-	{ fromVercelCli, spaced }: LogOptions = {}
-): void {
+type LogOptions = {
+	fromVercelCli?: boolean;
+	spaced?: boolean;
+	skipDedent?: boolean;
+};
+
+export function cliLog(message: string, opts: LogOptions = {}): void {
 	// eslint-disable-next-line no-console
-	console.log(prepareCliMessage(message, { fromVercelCli, spaced }));
+	console.log(prepareCliMessage(message, opts));
 }
 
-export function cliSuccess(
-	message: string,
-	{ fromVercelCli, spaced }: LogOptions = {}
-): void {
+export function cliSuccess(message: string, opts: LogOptions = {}): void {
 	// eslint-disable-next-line no-console
 	console.log(
-		prepareCliMessage(message, {
-			fromVercelCli,
-			styleFormatter: chalk.green,
-			spaced,
-		})
+		prepareCliMessage(message, { ...opts, styleFormatter: chalk.green })
 	);
 }
 
 export function cliError(
 	message: string,
 	{
-		showReport: shouldReport,
+		showReport,
 		fromVercelCli,
-		spaced,
-	}: LogOptions & {
-		showReport?: boolean;
-	} = {}
+		...opts
+	}: LogOptions & { showReport?: boolean } = {}
 ): void {
 	// eslint-disable-next-line no-console
 	console.error(
 		prepareCliMessage(message, {
+			...opts,
 			fromVercelCli,
 			styleFormatter: chalk.red,
-			spaced,
 		})
 	);
-	if (shouldReport) {
+	if (showReport) {
 		cliError(
 			'Please report this at https://github.com/cloudflare/next-on-pages/issues.',
 			{ fromVercelCli }
@@ -168,17 +157,10 @@ export function cliError(
 	}
 }
 
-export function cliWarn(
-	message: string,
-	{ fromVercelCli, spaced }: LogOptions = {}
-): void {
+export function cliWarn(message: string, opts: LogOptions = {}): void {
 	// eslint-disable-next-line no-console
 	console.warn(
-		prepareCliMessage(message, {
-			fromVercelCli,
-			styleFormatter: chalk.yellow,
-			spaced,
-		})
+		prepareCliMessage(message, { ...opts, styleFormatter: chalk.yellow })
 	);
 }
 
@@ -194,12 +176,13 @@ function prepareCliMessage(
 		fromVercelCli,
 		styleFormatter,
 		spaced,
+		skipDedent,
 	}: LogOptions & {
 		styleFormatter?: ChalkInstance;
 	}
 ): string {
 	const prefix = fromVercelCli ? '▲ ' : '⚡️';
-	const preparedMessage = dedent(message)
+	const preparedMessage = (skipDedent ? message : dedent(message))
 		.split('\n')
 		.map(line => `${prefix} ${styleFormatter ? styleFormatter(line) : line}`)
 		.join('\n');


### PR DESCRIPTION
This PR does the following:
- Adds a `skipDedent` option for the CLI logging utilities, and cleans up the file a bit.
- Prints a summary of the build to the console.
- Writes a file containing information about the build that can be used for debugging.

The printed build summary contains the following:
- Edge runtime routes.
  - No limit.
- Prerendered routes.
  - Limit of 20 - there may be hundreds for statically generated dynamic routes.
  - Routes that generate Prerender functions are the ones considered prerendered routes (all static routes in the app directory, ISR routes in the pages directory).
- Wasm files.
  - No limit.
- Other static assets.
  - Limit of 5 - there can be lots and they're not as important to display.

The build info file that is written to the disk contains information about everything from directory processing and the static assets. Wasm paths are relativised so that the file can be shared without leaking a user's directory structure or account name. It is intended to be useful for debugging - a user can provide it so that we can know a lot more about their build output without them sharing source code or sensitive data (this is often a problem for people).

The file is created in the `_worker.js` directory for three reasons; it won't accidentally get committed to git, it won't be served to end-users, and it respects the output directory. It is important to note that the build info file is not bundled into the worker - I have confirmed this in the form data upload logs with Walshy.

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/c55f6456-f514-4de5-9ec7-1cdb7c8939be)

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/e292bf59-752f-4545-9f90-d76745e5e940)
