### PR TITLE
fix: middleware being invoked more than once in a phase

### DIFF
--- a/.changeset/spicy-pears-boil.md
+++ b/.changeset/spicy-pears-boil.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": patch
+---
+
+Fix middleware being invoked multiple times in a phase during routing when there is more than one config entry.

--- a/packages/next-on-pages/tests/_helpers/index.ts
+++ b/packages/next-on-pages/tests/_helpers/index.ts
@@ -27,7 +27,7 @@ export type TestCase = {
 		data: string;
 		headers?: Record<string, string>;
 		reqHeaders?: Record<string, string>;
-		mockConsole?: { error?: (string | Error)[] };
+		mockConsole?: { log?: string[]; error?: (string | Error)[] };
 	};
 };
 
@@ -41,7 +41,7 @@ export class MockAssetFetcher {
 		);
 	}
 
-	public fetch = (req: Request) => {
+	public fetch = async (req: Request) => {
 		const { pathname } = new URL(req.url);
 		const noExt = pathname.replace(/\.html$/, '');
 		const withExt = `${noExt.replace(/^\/$/, '/index')}.html`;
@@ -66,7 +66,7 @@ export class MockAssetFetcher {
 
 function createMockEntrypoint(file = 'unknown'): EdgeFunction {
 	return {
-		default: (request: Request) => {
+		default: async (request: Request) => {
 			const params = [...new URL(request.url).searchParams.entries()];
 
 			return Promise.resolve(
@@ -78,7 +78,7 @@ function createMockEntrypoint(file = 'unknown'): EdgeFunction {
 
 function createMockMiddlewareEntrypoint(file = '/'): EdgeFunction {
 	return {
-		default: (request: Request) => {
+		default: async (request: Request) => {
 			const url = new URL(request.url);
 			if (url.pathname !== file) {
 				return Promise.resolve(new Response(null, { status: 200 }));
@@ -134,6 +134,11 @@ function createMockMiddlewareEntrypoint(file = '/'): EdgeFunction {
 						'content-type': 'text/html',
 					}),
 				});
+			}
+
+			if (url.searchParams.has('log')) {
+				// eslint-disable-next-line no-console
+				console.log('Hello from middleware');
 			}
 
 			return new Response(null, {

--- a/packages/next-on-pages/tests/templates/handleRequest.test.ts
+++ b/packages/next-on-pages/tests/templates/handleRequest.test.ts
@@ -54,6 +54,9 @@ function runTestCase(
 			const mockedConsoleError = vi
 				.spyOn(console, 'error')
 				.mockImplementation(() => null);
+			const mockedConsoleLog = vi
+				.spyOn(console, 'log')
+				.mockImplementation(() => null);
 
 			const req = new Request(url, { method, headers });
 			const res = await handleRequest(
@@ -78,8 +81,14 @@ function runTestCase(
 			consoleErrorExp.forEach((val, i) => {
 				expect(mockedConsoleError.mock.calls[i]?.[0]).toEqual(val);
 			});
-
 			mockedConsoleError.mockRestore();
+
+			const consoleLogExp = expected.mockConsole?.log ?? [];
+			expect(mockedConsoleLog).toHaveBeenCalledTimes(consoleLogExp.length);
+			consoleLogExp.forEach((val, i) => {
+				expect(mockedConsoleLog.mock.calls[i]?.[0]).toEqual(val);
+			});
+			mockedConsoleLog.mockRestore();
 		}
 	});
 }
@@ -126,6 +135,6 @@ suite('router', () => {
 		middlewareTestSet,
 		trailingSlashTestSet,
 	].forEach(testSet => {
-		describe(testSet.name, () => runTestSet(testSet));
+		describe(testSet.name, async () => runTestSet(testSet));
 	});
 });

--- a/packages/next-on-pages/tests/templates/requestTestData/middleware.ts
+++ b/packages/next-on-pages/tests/templates/requestTestData/middleware.ts
@@ -13,6 +13,20 @@ const rawVercelConfig: VercelConfig = {
 			continue: true,
 			override: true,
 		},
+		{
+			continue: true,
+			src: '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/api(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?(.json)?[\\/#\\?]?$',
+			missing: [
+				{
+					type: 'header',
+					key: 'x-prerender-revalidate',
+					value: 'fbb77d6d4d2724d8afc1ba5be7461f98',
+				},
+			],
+			middlewarePath: 'middleware',
+			middlewareRawSrc: ['/:nextData(_next/data/[^/]{1,})?/api/:path*(.json)?'],
+			override: true,
+		},
 		{ handle: 'resource' },
 		{ src: '/.*', status: 404 },
 		{ handle: 'hit' },
@@ -168,6 +182,22 @@ export const testSet: TestSet = {
 				data: '<html>Hello from middleware</html>',
 				headers: {
 					'content-type': 'text/html',
+				},
+			},
+		},
+		{
+			name: 'middleware is only invoked once in a phase when the config contains two entries',
+			paths: ['/api/hello?log'],
+
+			expected: {
+				status: 200,
+				data: JSON.stringify({ file: '/api/hello', params: [['log', '']] }),
+				mockConsole: { log: ['Hello from middleware'] },
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+					'set-cookie': 'x-hello-from-middleware2=hello; Path=/',
+					'x-hello-from-middleware2': 'hello',
+					'x-matched-path': '/api/hello',
 				},
 			},
 		},


### PR DESCRIPTION
This PR does the following:
- Introduces an array to track which middleware has been invoked during each run of a phase.
- If a middleware is tried to be invoked more than once, it skips.
- Adds a test.

In the build output config, there are sometimes two records created for middleware in the `none` phase, both of which can be hit and then accidentally lead to multiple invocations. This PR introduces an array that tracks which middleware paths have been invoked when running a phase. If it tries to use one that has already been invoked, it will skip doing so, fixing the issue of multiple invocations.