### PR TITLE
update configs in no-unsupported-configs eslint rule

### DIFF
--- a/.changeset/pretty-icons-impress.md
+++ b/.changeset/pretty-icons-impress.md
@@ -2,4 +2,4 @@
 "eslint-plugin-next-on-pages": patch
 ---
 
-update no-unsuppoered-config rules (to match the latest supported configs table)
+update no-unsupported-config rules (to match the latest supported configs table)

--- a/.changeset/pretty-icons-impress.md
+++ b/.changeset/pretty-icons-impress.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-next-on-pages": patch
+---
+
+update no-unsuppoered-config rules (to match the latest supported configs table)

--- a/packages/eslint-plugin-next-on-pages/src/rules/no-unsupported-configs.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-unsupported-configs.ts
@@ -6,44 +6,64 @@ import { extractPaths } from '../utils/extract-paths';
 // Note: the rule now only checks for property name, it will probably need to also include case in which we do accept a property but not
 //       certain values for it
 
-/** configs that next-on-pages does support */
-const supportedConfigs: Readonly<Set<string>> = new Set([
-	'env',
-	'basePath',
-	'rewrites',
-	'redirects',
-	'headers',
-	'pageExtensions',
-	'webpack',
-	'generateBuildId',
-	'eslint',
-	'typescript',
-	'experimental/appDir',
-]);
+type Config = { name: string; support: '✅' | 'N/A' | '❌' | '🔄' };
 
-/** configs that next-on-pages does not support and likely never will */
-const indefinitelyUnsupportedConfigs: Readonly<Set<string>> = new Set([
-	'compress',
-	'serverRuntimeConfig',
-	'publicRuntimeConfig',
-	'httpAgentOptions',
-	'distDir',
-	'onDemandEntries',
-	'exportPathMap',
-	'devIndicators',
-]);
+// configs taken from https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/supported.md#nextconfigjs-properties
+// NOTE: to some we need to add the `experimental/` prefix and the Runtime Config is split into two
+const configs: Config[] = [
+	{ name: 'experimental/appDir', support: '✅' },
+	{ name: 'assetPrefix', support: '🔄' },
+	{ name: 'basePath', support: '✅' },
+	{ name: 'compress', support: 'N/A' },
+	{ name: 'devIndicators', support: '❌' },
+	{ name: 'distDir', support: 'N/A' },
+	{ name: 'env', support: '✅' },
+	{ name: 'eslint', support: '✅' },
+	{ name: 'exportPathMap', support: 'N/A' },
+	{ name: 'generateBuildId', support: '✅' },
+	{ name: 'generateEtags', support: '🔄' },
+	{ name: 'headers', support: '✅' },
+	{ name: 'httpAgentOptions', support: 'N/A' },
+	{ name: 'images', support: '✅' },
+	{ name: 'incrementalCacheHandlerPath', support: '🔄' },
+	{ name: 'experimental/mdxRs', support: '✅' },
+	{ name: 'onDemandEntries', support: 'N/A' },
+	{ name: 'output', support: 'N/A' },
+	{ name: 'pageExtensions', support: '✅' },
+	{ name: 'poweredByHeader', support: '🔄' },
+	{ name: 'productionBrowserSourceMaps', support: '🔄' },
+	{ name: 'reactStrictMode', support: '❌' },
+	{ name: 'redirects', support: '✅' },
+	{ name: 'rewrites', support: '✅' },
+	// Runtime Config
+	{ name: 'serverRuntimeConfig', support: '❌' },
+	{ name: 'publicRuntimeConfig', support: '❌' },
+	{ name: 'serverComponentsExternalPackages', support: 'N/A' },
+	{ name: 'trailingSlash', support: '✅' },
+	{ name: 'transpilePackages', support: '✅' },
+	{ name: 'experimental/turbo', support: '🔄' },
+	{ name: 'typedRoutes', support: '✅' },
+	{ name: 'typescript', support: '✅' },
+	{ name: 'experimental/urlImports', support: '✅' },
+	{ name: 'webpack', support: '✅' },
+	{ name: 'experimental/webVitalsAttribution', support: '✅' },
+];
 
-/** configs that next-on-pages does not support right now but likely will */
-const currentlyUnsupportedConfigs: Readonly<Set<string>> = new Set([
-	'assetPrefix',
-	'images',
-	'poweredByHeader',
-	'generateEtags',
-	'trailingSlash',
-	'reactStrictMode',
-	'i18n',
-	'experimental/turbo',
-]);
+function filterAndExtractConfigs(
+	support: Config['support'] | Config['support'][]
+): string[] {
+	const comparisonFn = (config: Config) =>
+		Array.isArray(support)
+			? support.includes(config.support)
+			: config.support === support;
+	return configs.filter(comparisonFn).map(config => config.name);
+}
+
+const supportedConfigs = new Set(filterAndExtractConfigs('✅'));
+const indefinitelyUnsupportedConfigs = new Set(
+	filterAndExtractConfigs(['❌', 'N/A'])
+);
+const currentlyUnsupportedConfigs = new Set(filterAndExtractConfigs('🔄'));
 
 /** nested Next.js configs that need to be explored
  * (For example 'experimental' because there are props such as 'experimental/appDir' and 'experimental/turbo')

--- a/packages/eslint-plugin-next-on-pages/src/rules/no-unsupported-configs.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-unsupported-configs.ts
@@ -184,7 +184,7 @@ function checkConfigPropsRecursively(
 
 		if (indefinitelyUnsupportedConfigs.has(fullPropName)) {
 			context.report({
-				message: `The "${fullPropName}" configuration is not supported by next-on-pages (and will likely never be).`,
+				message: `The "${fullPropName}" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).`,
 				node: prop.key,
 			});
 			return;

--- a/packages/eslint-plugin-next-on-pages/tests/rules/no-unsupported-configs.test.ts
+++ b/packages/eslint-plugin-next-on-pages/tests/rules/no-unsupported-configs.test.ts
@@ -37,11 +37,11 @@ describe('no-unsupported-configs', () => {
 					errors: [
 						{
 							message:
-								'The "compress" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "compress" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 						{
 							message:
-								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 					],
 				},
@@ -78,7 +78,7 @@ describe('no-unsupported-configs', () => {
 					errors: [
 						{
 							message:
-								'The "compress" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "compress" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 					],
 				},
@@ -110,7 +110,7 @@ describe('no-unsupported-configs', () => {
 					errors: [
 						{
 							message:
-								'The "distDir" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "distDir" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 					],
 				},
@@ -123,7 +123,7 @@ describe('no-unsupported-configs', () => {
     /** @type {import('next').NextConfig} */
     const nextConfig = {
       assetPrefix: 'test',
-      reactStrictMode: true,
+      incrementalCacheHandlerPath: true,
     }
 
     module.exports = nextConfig
@@ -148,7 +148,7 @@ describe('no-unsupported-configs', () => {
 						},
 						{
 							message:
-								'The "reactStrictMode" configuration is not currently supported by next-on-pages.',
+								'The "incrementalCacheHandlerPath" configuration is not currently supported by next-on-pages.',
 						},
 					],
 				},
@@ -219,7 +219,7 @@ describe('no-unsupported-configs', () => {
 					errors: [
 						{
 							message:
-								'The "compress" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "compress" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 						{
 							message:
@@ -227,15 +227,11 @@ describe('no-unsupported-configs', () => {
 						},
 						{
 							message:
-								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 						{
 							message:
 								'The "invalidTestConfig2" configuration is not recognized by next-on-pages (it might or might not be supported).',
-						},
-						{
-							message:
-								'The "trailingSlash" configuration is not currently supported by next-on-pages.',
 						},
 					],
 				},
@@ -248,7 +244,7 @@ describe('no-unsupported-configs', () => {
 					errors: [
 						{
 							message:
-								'The "compress" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "compress" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 						{
 							message:
@@ -256,7 +252,7 @@ describe('no-unsupported-configs', () => {
 						},
 						{
 							message:
-								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 						{
 							message:
@@ -273,15 +269,11 @@ describe('no-unsupported-configs', () => {
 					errors: [
 						{
 							message:
-								'The "compress" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "compress" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 						{
 							message:
-								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and will likely never be).',
-						},
-						{
-							message:
-								'The "trailingSlash" configuration is not currently supported by next-on-pages.',
+								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 					],
 				},
@@ -294,11 +286,11 @@ describe('no-unsupported-configs', () => {
 					errors: [
 						{
 							message:
-								'The "compress" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "compress" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 						{
 							message:
-								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and will likely never be).',
+								'The "serverRuntimeConfig" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
 						},
 					],
 				},


### PR DESCRIPTION
updating the eslint `no-unsupported-configs` rule based on the supported table updated in https://github.com/cloudflare/next-on-pages/pull/319