### PR TITLE
fix: middleware returns 404 with `new NextResponse` on invalid route

### DIFF
--- a/.changeset/rude-hotels-raise.md
+++ b/.changeset/rude-hotels-raise.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": patch
+---
+
+Fix middleware returning `new NextResponse` resulting in 404 for routes that don't exist in the build output.

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -537,11 +537,12 @@ export class RoutesMatcher {
 			}
 		}
 
-		// In the `hit` phase or for external urls/redirects, return the match.
+		// In the `hit` phase or for external urls/redirects/middleware responses, return the match.
 		if (
 			phase === 'hit' ||
 			isUrl(this.path) ||
-			this.headers.normal.has('location')
+			this.headers.normal.has('location') ||
+			!!this.body
 		) {
 			return 'done';
 		}

--- a/packages/next-on-pages/tests/_helpers/index.ts
+++ b/packages/next-on-pages/tests/_helpers/index.ts
@@ -80,7 +80,7 @@ function createMockMiddlewareEntrypoint(file = '/'): EdgeFunction {
 	return {
 		default: async (request: Request) => {
 			const url = new URL(request.url);
-			if (url.pathname !== file) {
+			if (!url.pathname.startsWith(file)) {
 				return Promise.resolve(new Response(null, { status: 200 }));
 			}
 
@@ -130,6 +130,15 @@ function createMockMiddlewareEntrypoint(file = '/'): EdgeFunction {
 			if (url.searchParams.has('returns')) {
 				return new Response('<html>Hello from middleware</html>', {
 					status: 401,
+					headers: new Headers({
+						'content-type': 'text/html',
+					}),
+				});
+			}
+
+			if (url.searchParams.has('returns200')) {
+				return new Response('Hello, World!', {
+					status: 200,
 					headers: new Headers({
 						'content-type': 'text/html',
 					}),

--- a/packages/next-on-pages/tests/templates/requestTestData/middleware.ts
+++ b/packages/next-on-pages/tests/templates/requestTestData/middleware.ts
@@ -201,5 +201,16 @@ export const testSet: TestSet = {
 				},
 			},
 		},
+		{
+			name: 'middleware route returns custom response when returning a new NextResponse on an invalid route',
+			paths: ['/api/hello/invalid-route?returns200'],
+			expected: {
+				status: 200,
+				data: 'Hello, World!',
+				headers: {
+					'content-type': 'text/html',
+				},
+			},
+		},
 	],
 };


### PR DESCRIPTION
This PR does the following:
- Ensures we bail out of routing when a middleware response is present

Previously, we added a fix to bail out of routing when running a middleware returned a response. However, this change didn't account for when the request was to a route that doesn't exist in the build output. This fix ensures that it always bails out when a user returns `new NextResponse`, regardless of if the target route is in the build output. This is the correct behaviour that should have happened before 🙈

fixes #341