### PR TITLE
deduplicate Next.js manifests

### DIFF
--- a/.changeset/few-garlics-shout.md
+++ b/.changeset/few-garlics-shout.md
@@ -1,0 +1,11 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+deduplicate Next.js manifests
+
+Currently in our functions files we have end up having a number of Next.js internally used manifest objects duplicated.
+These manifests increase as the number of routes increases making the size effects of the duplication quite problematic for medium/large applications
+(for small applications the manifest duplication is not as problematic).
+
+This change removes such duplication by making sure that we only include each type of manifest once and share such javascript object across the various functions instead (significantly decreasing the output size of medium/large next-on-pages applications).

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -435,37 +435,33 @@ type ManifestStatementInfo = {
 function extractManifestStatementInfo(
 	statement: AST.StatementKind
 ): ManifestStatementInfo | null {
-	try {
-		if (
-			statement.type !== 'ExpressionStatement' ||
-			statement.expression.type !== 'AssignmentExpression' ||
-			statement.expression.left.type !== 'MemberExpression' ||
-			statement.expression.left.object.type !== 'Identifier' ||
-			statement.expression.left.object.name !== 'self' ||
-			statement.expression.left.property.type !== 'Identifier'
-		)
-			return null;
-
-		const nextJsManifests = [
-			'__RSC_SERVER_MANIFEST',
-			'__RSC_MANIFEST',
-			'__RSC_CSS_MANIFEST',
-			'__BUILD_MANIFEST',
-			'__REACT_LOADABLE_MANIFEST',
-			'__NEXT_FONT_MANIFEST',
-		];
-		if (!nextJsManifests.includes(statement.expression.left.property.name))
-			return null;
-
-		const { start, end } = statement as unknown as Node;
-		return {
-			manifestIdentifier: statement.expression.left.property.name,
-			start,
-			end,
-		};
-	} catch {
+	if (
+		statement.type !== 'ExpressionStatement' ||
+		statement.expression.type !== 'AssignmentExpression' ||
+		statement.expression.left.type !== 'MemberExpression' ||
+		statement.expression.left.object.type !== 'Identifier' ||
+		statement.expression.left.object.name !== 'self' ||
+		statement.expression.left.property.type !== 'Identifier'
+	)
 		return null;
-	}
+
+	const nextJsManifests = [
+		'__RSC_SERVER_MANIFEST',
+		'__RSC_MANIFEST',
+		'__RSC_CSS_MANIFEST',
+		'__BUILD_MANIFEST',
+		'__REACT_LOADABLE_MANIFEST',
+		'__NEXT_FONT_MANIFEST',
+	];
+	if (!nextJsManifests.includes(statement.expression.left.property.name))
+		return null;
+
+	const { start, end } = statement as unknown as Node;
+	return {
+		manifestIdentifier: statement.expression.left.property.name,
+		start,
+		end,
+	};
 }
 
 /**

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -149,33 +149,34 @@ async function processDirectoryRecursively(
 		setup.outputDir
 	);
 
-	await Promise.all(
-		functionFiles.map(async file => {
-			const filepath = join(dir, file);
-			if (await validateDir(filepath)) {
-				const dirResultsPromise = file.endsWith('.func')
-					? processFuncDirectory(setup, filepath)
-					: processDirectoryRecursively(setup, filepath);
-				const dirResults = await dirResultsPromise;
-				dirResults.invalidFunctions?.forEach(fn => invalidFunctions.add(fn));
-				dirResults.functionsMap?.forEach((value, key) =>
-					functionsMap.set(key, value)
-				);
-				dirResults.webpackChunks?.forEach((value, key) =>
-					webpackChunks.set(key, value)
-				);
-				dirResults.prerenderedRoutes?.forEach((value, key) =>
-					prerenderedRoutes.set(key, value)
-				);
-				dirResults.wasmIdentifiers?.forEach((value, key) =>
-					wasmIdentifiers.set(key, value)
-				);
-				dirResults.nextJsManifests?.forEach((value, key) =>
-					nextJsManifests.set(key, value)
-				);
-			}
-		})
-	);
+	// Note: the following could be implemented via `await Promise.all` since different directories are independent to each other
+	//       unfortunately this can cause large application to require unreasonably large memory to build, so we need to do a
+	//       simpler and slower loop with awaits instead
+	for (const file of functionFiles) {
+		const filepath = join(dir, file);
+		if (await validateDir(filepath)) {
+			const dirResultsPromise = file.endsWith('.func')
+				? processFuncDirectory(setup, filepath)
+				: processDirectoryRecursively(setup, filepath);
+			const dirResults = await dirResultsPromise;
+			dirResults.invalidFunctions?.forEach(fn => invalidFunctions.add(fn));
+			dirResults.functionsMap?.forEach((value, key) =>
+				functionsMap.set(key, value)
+			);
+			dirResults.webpackChunks?.forEach((value, key) =>
+				webpackChunks.set(key, value)
+			);
+			dirResults.prerenderedRoutes?.forEach((value, key) =>
+				prerenderedRoutes.set(key, value)
+			);
+			dirResults.wasmIdentifiers?.forEach((value, key) =>
+				wasmIdentifiers.set(key, value)
+			);
+			dirResults.nextJsManifests?.forEach((value, key) =>
+				nextJsManifests.set(key, value)
+			);
+		}
+	}
 
 	return {
 		invalidFunctions,

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -436,13 +436,15 @@ function extractManifestStatementInfo(
 	statement: AST.StatementKind
 ): ManifestStatementInfo | null {
 	try {
-		assert(statement.type === 'ExpressionStatement');
-		assert(statement.expression.type === 'AssignmentExpression');
-
-		assert(statement.expression.left.type === 'MemberExpression');
-		assert(statement.expression.left.object.type === 'Identifier');
-		assert(statement.expression.left.object.name === 'self');
-		assert(statement.expression.left.property.type === 'Identifier');
+		if (
+			statement.type !== 'ExpressionStatement' ||
+			statement.expression.type !== 'AssignmentExpression' ||
+			statement.expression.left.type !== 'MemberExpression' ||
+			statement.expression.left.object.type !== 'Identifier' ||
+			statement.expression.left.object.name !== 'self' ||
+			statement.expression.left.property.type !== 'Identifier'
+		)
+			return null;
 
 		const nextJsManifests = [
 			'__RSC_SERVER_MANIFEST',
@@ -452,7 +454,8 @@ function extractManifestStatementInfo(
 			'__REACT_LOADABLE_MANIFEST',
 			'__NEXT_FONT_MANIFEST',
 		];
-		assert(nextJsManifests.includes(statement.expression.left.property.name));
+		if (!nextJsManifests.includes(statement.expression.left.property.name))
+			return null;
 
 		const { start, end } = statement as unknown as Node;
 		return {

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -69,6 +69,11 @@ export async function generateFunctionsMap(
 		await copyWasmFiles(nextOnPagesDistDir, processingResults.wasmIdentifiers);
 	}
 
+	await createNextJsManifestFiles(
+		nextOnPagesDistDir,
+		processingResults.nextJsManifests
+	);
+
 	return processingResults;
 }
 
@@ -134,6 +139,7 @@ async function processDirectoryRecursively(
 	const webpackChunks = new Map<number, string>();
 	const prerenderedRoutes = new Map<string, PrerenderedFileData>();
 	const wasmIdentifiers = new Map<string, WasmModuleInfo>();
+	const nextJsManifests = new Map<string, string>();
 
 	const files = await readdir(dir);
 	const functionFiles = await fixPrerenderedRoutes(
@@ -164,6 +170,9 @@ async function processDirectoryRecursively(
 				dirResults.wasmIdentifiers?.forEach((value, key) =>
 					wasmIdentifiers.set(key, value)
 				);
+				dirResults.nextJsManifests?.forEach((value, key) =>
+					nextJsManifests.set(key, value)
+				);
 			}
 		})
 	);
@@ -174,6 +183,7 @@ async function processDirectoryRecursively(
 		webpackChunks,
 		prerenderedRoutes,
 		wasmIdentifiers,
+		nextJsManifests,
 	};
 }
 
@@ -255,9 +265,14 @@ async function processFuncDirectory(
 		wasmIdentifiers = funcWasmIdentifiers;
 	}
 
+	const { manifests: nextJsManifests, updatedContents } =
+		await extractNextJsManifests(functionFilePath, contents);
+	contents = updatedContents;
+
 	const newFilePath = join(setup.distFunctionsDir, `${relativePath}.js`);
 	await mkdir(dirname(newFilePath), { recursive: true });
-	const relativeChunksPath = getRelativeChunksPath(functionFilePath);
+	const relativeNextOnPagesDistPath =
+		getRelativeNextOnPagesDistPath(functionFilePath);
 	await build({
 		stdin: {
 			contents,
@@ -266,7 +281,7 @@ async function processFuncDirectory(
 		platform: 'neutral',
 		outfile: newFilePath,
 		bundle: true,
-		external: ['node:*', `${relativeChunksPath}/*`, '*.wasm'],
+		external: ['node:*', `${relativeNextOnPagesDistPath}/*`, '*.wasm'],
 		minify: true,
 		plugins: [nodeBuiltInModulesPlugin],
 	});
@@ -284,6 +299,7 @@ async function processFuncDirectory(
 		functionsMap,
 		webpackChunks,
 		wasmIdentifiers,
+		nextJsManifests,
 	};
 }
 
@@ -346,6 +362,92 @@ async function extractAndFixWasmRequires(
 	await writeFile(functionFilePath, updatedContents);
 
 	return { wasmIdentifiers, updatedContents };
+}
+
+/**
+ * Given the path of a function file and its content update the content so that it doesn't include Next.js manifests but imports them
+ * from the __next-on-pages-dist__/nextjs-manifests directory.
+ *
+ * Note: Such manifests are always the same for all functions so we need to share them across the various function files instead of costly duplicating them in each file.
+ *
+ * As a side effect this function also updates the file with the new content.
+ *
+ * @param functionFilePath file path of the function file
+ * @param originalFileContents the (original) contents of the file
+ * @returns the updated content and a map that maps manifest identifiers to the manifest's js object code.
+ */
+async function extractNextJsManifests(
+	functionFilePath: string,
+	originalFileContents: string
+): Promise<{
+	manifests: Map<string, string>;
+	updatedContents: string;
+}> {
+	const program = parse(originalFileContents, {
+		ecmaVersion: 'latest',
+		sourceType: 'module',
+	}) as unknown as AST.ProgramKind;
+
+	const manifestLocations: {
+		identifier: string;
+		start: number;
+		end: number;
+	}[] = program.body.map(getManifestStartEnd).filter(Boolean) as {
+		identifier: string;
+		start: number;
+		end: number;
+	}[];
+
+	let updatedContents = originalFileContents;
+
+	const manifests = new Map<string, string>();
+	manifestLocations.forEach(({ identifier, start, end }) => {
+		const originalManifestCode = originalFileContents.slice(start, end);
+		updatedContents = `${`import ${identifier} from "${'../'.repeat(
+			getFunctionNestingLevel(functionFilePath) - 1
+		)}../__next-on-pages-dist__/nextjs-manifests/${identifier}.js";`}${updatedContents}`;
+		updatedContents = updatedContents.replace(
+			originalManifestCode,
+			`self.${identifier}=${identifier};`
+		);
+		const manifest = originalManifestCode
+			.slice(`self.${identifier}=`.length)
+			.replace(/;$/, '');
+		manifests.set(identifier, manifest);
+	});
+
+	await writeFile(functionFilePath, updatedContents);
+
+	return { manifests, updatedContents };
+}
+
+function getManifestStartEnd(
+	statement: AST.StatementKind
+): { identifier: string; start: number; end: number } | null {
+	try {
+		assert(statement.type === 'ExpressionStatement');
+		assert(statement.expression.type === 'AssignmentExpression');
+
+		assert(statement.expression.left.type === 'MemberExpression');
+		assert(statement.expression.left.object.type === 'Identifier');
+		assert(statement.expression.left.object.name === 'self');
+		assert(statement.expression.left.property.type === 'Identifier');
+
+		const nextJsManifests = [
+			'__RSC_SERVER_MANIFEST',
+			'__RSC_MANIFEST',
+			'__RSC_CSS_MANIFEST',
+			'__BUILD_MANIFEST',
+			'__REACT_LOADABLE_MANIFEST',
+			'__NEXT_FONT_MANIFEST',
+		];
+		assert(nextJsManifests.includes(statement.expression.left.property.name));
+
+		const { start, end } = statement as unknown as Node;
+		return { identifier: statement.expression.left.property.name, start, end };
+	} catch {
+		return null;
+	}
 }
 
 /**
@@ -506,6 +608,7 @@ export type DirectoryProcessingResults = {
 	webpackChunks: Map<number, string>;
 	prerenderedRoutes: Map<string, PrerenderedFileData>;
 	wasmIdentifiers: Map<string, WasmModuleInfo>;
+	nextJsManifests: Map<string, string>;
 };
 
 /**
@@ -614,14 +717,16 @@ function getChunkIdentifier(chunkKey: number): string {
 	return `__chunk_${chunkKey}`;
 }
 
-function getRelativeChunksPath(functionPath: string): string {
+function getRelativeNextOnPagesDistPath(functionPath: string): string {
 	const functionNestingLevel = getFunctionNestingLevel(functionPath);
 	const accountForNestingPath = `../`.repeat(functionNestingLevel);
-	return `${accountForNestingPath}__next-on-pages-dist__/chunks`;
+	return `${accountForNestingPath}__next-on-pages-dist__`;
 }
 
 function getChunkImportFn(functionPath: string): (chunkKey: number) => string {
-	const relativeChunksPath = getRelativeChunksPath(functionPath);
+	const relativeChunksPath = `${getRelativeNextOnPagesDistPath(
+		functionPath
+	)}/chunks`;
 	return chunkKey => {
 		const chunkIdentifier = getChunkIdentifier(chunkKey);
 		const chunkPath = `${relativeChunksPath}/${chunkKey}.js`;
@@ -696,5 +801,24 @@ async function copyWasmFiles(
 	for (const { originalFileLocation, identifier } of wasmIdentifiers.values()) {
 		const newLocation = join(wasmDistDir, `${identifier}.wasm`);
 		await copyFile(originalFileLocation, newLocation);
+	}
+}
+
+/**
+ * Creates js files into the __next-on-pages-dist__/nextjs-manifest folder which export a default
+ * value containing a Next.js manifest object
+ *
+ * @param distDir the __next-on-pages-dist__ directory's path
+ * @param manifests map mapping next manifest identifiers to the manifest objects
+ */
+async function createNextJsManifestFiles(
+	distDir: string,
+	manifests: Map<string, string>
+): Promise<void> {
+	const manifestsDistDir = join(distDir, 'nextjs-manifests');
+	await mkdir(manifestsDistDir);
+	for (const [identifier, manifest] of manifests.entries()) {
+		const path = join(manifestsDistDir, `${identifier}.js`);
+		await writeFile(path, `export default ${manifest}`);
 	}
 }

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -69,10 +69,12 @@ export async function generateFunctionsMap(
 		await copyWasmFiles(nextOnPagesDistDir, processingResults.wasmIdentifiers);
 	}
 
-	await createNextJsManifestFiles(
-		nextOnPagesDistDir,
-		processingResults.nextJsManifests
-	);
+	if (processingResults.nextJsManifests.size) {
+		await createNextJsManifestFiles(
+			nextOnPagesDistDir,
+			processingResults.nextJsManifests
+		);
+	}
 
 	return processingResults;
 }

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -391,32 +391,26 @@ async function extractNextJsManifests(
 		sourceType: 'module',
 	}) as unknown as AST.ProgramKind;
 
-	const manifestLocations: {
-		identifier: string;
-		start: number;
-		end: number;
-	}[] = program.body.map(getManifestStartEnd).filter(Boolean) as {
-		identifier: string;
-		start: number;
-		end: number;
-	}[];
+	const manifestStatementInfos = program.body
+		.map(extractManifestStatementInfo)
+		.filter(Boolean) as ManifestStatementInfo[];
 
 	let updatedContents = originalFileContents;
 
 	const manifests = new Map<string, string>();
-	manifestLocations.forEach(({ identifier, start, end }) => {
+	manifestStatementInfos.forEach(({ manifestIdentifier, start, end }) => {
 		const originalManifestCode = originalFileContents.slice(start, end);
-		updatedContents = `${`import ${identifier} from "${'../'.repeat(
+		updatedContents = `${`import ${manifestIdentifier} from "${'../'.repeat(
 			getFunctionNestingLevel(functionFilePath) - 1
-		)}../__next-on-pages-dist__/nextjs-manifests/${identifier}.js";`}${updatedContents}`;
+		)}../__next-on-pages-dist__/nextjs-manifests/${manifestIdentifier}.js";`}${updatedContents}`;
 		updatedContents = updatedContents.replace(
 			originalManifestCode,
-			`self.${identifier}=${identifier};`
+			`self.${manifestIdentifier}=${manifestIdentifier};`
 		);
-		const manifest = originalManifestCode
-			.slice(`self.${identifier}=`.length)
+		const manifestContent = originalManifestCode
+			.slice(`self.${manifestIdentifier}=`.length)
 			.replace(/;$/, '');
-		manifests.set(identifier, manifest);
+		manifests.set(manifestIdentifier, manifestContent);
 	});
 
 	await writeFile(functionFilePath, updatedContents);
@@ -424,9 +418,23 @@ async function extractNextJsManifests(
 	return { manifests, updatedContents };
 }
 
-function getManifestStartEnd(
+type ManifestStatementInfo = {
+	manifestIdentifier: string;
+	start: number;
+	end: number;
+};
+
+/**
+ * Extracts statement manifest information (i.e. the manifest identifier and the start and end locations of the statement)
+ * from an AST statement representing the following format: "self.MANIFEST_NAME = { MANIFEST_CONTENT }"
+ * where MANIFEST_NAME is one of the name of the manifests that Next.js generates and MANIFEST_CONTENT is its content in js object form
+ *
+ * @param statement the target AST statement
+ * @returns information about the manifest statement if it follows the required format, null otherwise
+ */
+function extractManifestStatementInfo(
 	statement: AST.StatementKind
-): { identifier: string; start: number; end: number } | null {
+): ManifestStatementInfo | null {
 	try {
 		assert(statement.type === 'ExpressionStatement');
 		assert(statement.expression.type === 'AssignmentExpression');
@@ -447,7 +455,11 @@ function getManifestStartEnd(
 		assert(nextJsManifests.includes(statement.expression.left.property.name));
 
 		const { start, end } = statement as unknown as Node;
-		return { identifier: statement.expression.left.property.name, start, end };
+		return {
+			manifestIdentifier: statement.expression.left.property.name,
+			start,
+			end,
+		};
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
<details>

<summary>Results on a very small app</summary>

Before
![Screenshot 2023-06-28 at 16 37 44](https://github.com/cloudflare/next-on-pages/assets/61631103/54048691-d030-4a9b-b58d-d906c595ef72)

After
![Screenshot 2023-06-28 at 16 35 39](https://github.com/cloudflare/next-on-pages/assets/61631103/c6105c03-83d8-4676-a80b-f4272c133f30)

This doesn't seem to make a huge difference on small applications but I believe that the duplication of the manifest data in large applications can spin out of control

</details>

<details>

<summary>Results on a medium/small app</summary>

Before
![Screenshot 2023-06-28 at 16 53 13](https://github.com/cloudflare/next-on-pages/assets/61631103/9c18d6b3-8827-4571-be3d-12fb048141f3)

After
![Screenshot 2023-06-28 at 16 55 30](https://github.com/cloudflare/next-on-pages/assets/61631103/508740f6-288c-4a1c-b058-a4c172b9d332)

Here I think we do start seeing how much this can impact the overall app size 😄 

</details>

<details>

<summary>Results on a large app</summary>

After checking with the creator of #330 it seems like their application went from over 25MB to 9.8MB 🙂

Before
![248768424-e4b2dbee-df89-459c-8353-03a8adf4068f](https://github.com/cloudflare/next-on-pages/assets/61631103/681fe5a8-8518-4f1f-a8f4-2f1047880910)

After
![image](https://github.com/cloudflare/next-on-pages/assets/61631103/b06a2276-c7fe-4a08-b19e-bdaeedc5e47a)


I was hoping that the size of the app would reduce even further but this is still quite a sizeable improvement 🙂 

</details>

____

resolves #330 

