### PR TITLE
Avoid "deduping" webpack chunks used by a single function

### DIFF
--- a/.changeset/wicked-radios-yawn.md
+++ b/.changeset/wicked-radios-yawn.md
@@ -1,0 +1,13 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+avoid extracting chunks when unnecessary
+
+As part of our lazy loading implementation (see https://github.com/cloudflare/next-on-pages/blob/main/docs/technical/lazy-loading.md)
+we extract chunks that are used by different routes into separate functions and import those functions in the route files, this allows
+us not to duplicate chunks code.
+
+This change here makes sure that only the chunks that are actually used by multiple routes get extracted as there isn't a real benefit
+in extracting into separate files chunks that are used by single routes, on the contrary it actually adds overhead and increases
+the number of files produced, which for large next-on-pages applications might be problematic.


### PR DESCRIPTION
Result on [app-playground-edge](https://github.com/dario-piotrowicz/next-apps-for-testing/tree/master/apps/app-playground-edge):

<p align="center">

| Before | After |
|--------|--------|
| ![Screenshot 2023-06-29 at 13 22 01](https://github.com/cloudflare/next-on-pages/assets/61631103/614246f1-6350-4dd0-8cf0-a10562b2ebc1) | ![Screenshot 2023-06-29 at 13 24 36](https://github.com/cloudflare/next-on-pages/assets/61631103/6d947373-60ff-42df-8391-4b7f07e7066c)

</p>

Not a huge saving in size but the the reduction of files needed could be important for large applications (I think it can potentially solve https://github.com/cloudflare/workers-sdk/issues/3391)
