### PR TITLE
Remove asserts from production code

### DIFF
--- a/packages/eslint-plugin-next-on-pages/src/rules/no-nodejs-runtime.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-nodejs-runtime.ts
@@ -1,33 +1,27 @@
 import type { Rule } from 'eslint';
-import assert, { AssertionError } from 'node:assert';
 
 const rule: Rule.RuleModule = {
 	create: context => {
 		return {
 			ExportNamedDeclaration: node => {
-				try {
-					const declaration = node.declaration;
-					assert(declaration?.type === 'VariableDeclaration');
-					assert(declaration.declarations.length === 1);
-					const actualDeclaration = declaration.declarations[0];
-					assert(actualDeclaration?.id.type === 'Identifier');
-					assert(actualDeclaration.id.name === 'runtime');
-					assert(actualDeclaration.init?.type === 'Literal');
-					assert(actualDeclaration.init?.value === 'nodejs');
-
+				const declaration = node.declaration;
+				if (
+					declaration?.type === 'VariableDeclaration' &&
+					declaration.declarations.length === 1 &&
+					declaration.declarations[0]?.id.type === 'Identifier' &&
+					declaration.declarations[0].id.name === 'runtime' &&
+					declaration.declarations[0].init?.type === 'Literal' &&
+					declaration.declarations[0].init?.value === 'nodejs'
+				) {
 					context.report({
 						message:
 							"The 'nodejs' runtime is not supported. Use 'edge' instead.",
-						node: actualDeclaration.init,
+						node: declaration.declarations[0].init,
 						fix: fixer =>
-							actualDeclaration.init
-								? fixer.replaceText(actualDeclaration.init, "'edge'")
+							declaration.declarations[0]?.init
+								? fixer.replaceText(declaration.declarations[0].init, "'edge'")
 								: null,
 					});
-				} catch (e) {
-					if (!(e instanceof AssertionError)) {
-						throw e;
-					}
 				}
 			},
 		};


### PR DESCRIPTION
@petebacondarwin I'm removing the `try`-`catch` `assert`s pattern I've been following

I've spent a bunch of time trying to think of how to not use `assert`s in a nice way but I've been struggling to find something I'd be happy with.

If I were to define many small/granular utility functions for AST nodes that would likely produce lots of functions which would just add lots of noise and wouldn't simply things too much (they would just make checks more readable).

If I were to define more chunky/specific utility functions they likely just one used once again, potentially adding noise without too much benefit, they would need to be alongside smaller `if`s which (could use or not more granular utility functions).
Chunky utility functions would also not provide great type safety and we'd be forced to do a bunch of casting (since they would only assert/infer the top level types without considering descendant nodes).

At the end I just ended up taking the existing code and replacing `assert`s with `if`s 😓 🤷 

Please have a look and let me know what you think, I'd totally welcome suggestions 🙏 