### PR TITLE
add caching to github workflows

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -21,7 +21,25 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Install Dependencies
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Modify package.json version

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -35,7 +35,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -35,7 +35,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/configs-docs-scraping.yml
+++ b/.github/workflows/configs-docs-scraping.yml
@@ -12,21 +12,46 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+
       - name: Setup Node.js 16.x
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - name: Install NPM Dependencies
+
+      - name: Get current node version
+        id: node-version
+        run: |
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
+
       - name: Run Checker
         id: run-checker
         working-directory: internal-packages/docs-scraper
         run: GH_ACTION=true npm run check-docs
+
       - name: Generate table
         id: generate-table
         if: steps.run-checker.outputs.result == 'out-of-date'
         working-directory: internal-packages/docs-scraper
         run: GH_ACTION=true npm run generate-configs-table
+
       - name: Create or update issue
         if: steps.run-checker.outputs.result == 'out-of-date'
         working-directory: internal-packages/docs-scraper

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -18,11 +18,27 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.13
-          cache: 'npm' # cache ~/.npm in case 'npm ci' needs to run
 
-      - name: Install NPM Dependencies
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
-
       - name: Modify package.json version
         run: node .github/version-script.js PR=${{ github.event.number }}
 

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -33,7 +33,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -33,7 +33,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           path: ./turbo-cache
           key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
-          restore-key: |
+          restore-keys: |
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
             cache-turbo-${{ github.base_ref }}-
             cache-turbo

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -37,7 +37,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -60,8 +60,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -71,7 +71,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -94,8 +94,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -105,7 +105,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -128,8 +128,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -139,7 +139,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -162,8 +162,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -173,7 +173,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -196,8 +196,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -207,7 +207,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,6 +44,18 @@ jobs:
         name: Install NPM Dependencies
         run: npm ci
 
+      # TODO: use turbo for prettier:check
+      # - name: Cache turbo
+      #   id: turbo-cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ./turbo-cache
+      #     key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+      #     restore-key: |
+      #       cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
+      #       cache-turbo-${{ github.base_ref }}-
+      #       cache-turbo
+
       - name: Check formatting
         run: npm run prettier:check
   linting:
@@ -78,8 +90,19 @@ jobs:
         name: Install NPM Dependencies
         run: npm ci
 
+      - name: Cache turbo
+        id: turbo-cache
+        uses: actions/cache@v3
+        with:
+          path: ./turbo-cache
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.base_ref }}-
+            cache-turbo
+
       - name: Check linting
-        run: npm run lint
+        run: npm run lint -- --cache-dir ./turbo-cache
   types:
     name: Types
     runs-on: ubuntu-latest
@@ -112,8 +135,19 @@ jobs:
         name: Install NPM Dependencies
         run: npm ci
 
+      - name: Cache turbo
+        id: turbo-cache
+        uses: actions/cache@v3
+        with:
+          path: ./turbo-cache
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.base_ref }}-
+            cache-turbo
+
       - name: Check types
-        run: npm run types-check
+        run: npm run types-check -- --cache-dir ./turbo-cache
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -146,8 +180,19 @@ jobs:
         name: Install NPM Dependencies
         run: npm ci
 
+      - name: Cache turbo
+        id: turbo-cache
+        uses: actions/cache@v3
+        with:
+          path: ./turbo-cache
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.base_ref }}-
+            cache-turbo
+
       - name: Build
-        run: npm run build
+        run: npm run build -- --cache-dir ./turbo-cache
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -180,8 +225,19 @@ jobs:
         name: Install NPM Dependencies
         run: npm ci
 
+      - name: Cache turbo
+        id: turbo-cache
+        uses: actions/cache@v3
+        with:
+          path: ./turbo-cache
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.base_ref }}-
+            cache-turbo
+
       - name: Run unit tests
-        run: npm run test:unit
+        run: npm run test:unit -- --cache-dir ./turbo-cache
   e2e-tests:
     name: e2e tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,8 +49,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
           restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
             cache-turbo-${{ github.base_ref }}-
             cache-turbo
@@ -94,8 +95,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
           restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
             cache-turbo-${{ github.base_ref }}-
             cache-turbo
@@ -139,8 +141,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
           restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
             cache-turbo-${{ github.base_ref }}-
             cache-turbo
@@ -184,8 +187,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
           restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
             cache-turbo-${{ github.base_ref }}-
             cache-turbo
@@ -229,8 +233,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
           restore-keys: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
             cache-turbo-${{ github.base_ref }}-
             cache-turbo

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,7 @@ jobs:
         name: Install NPM Dependencies
         run: npm ci
 
-      # TODO: use turbo for prettier:check
+      # TODO: use turbo for the prettier check
       # - name: Cache turbo
       #   id: turbo-cache
       #   uses: actions/cache@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,7 +29,7 @@ jobs:
           node_version=$(node -v)
           echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
-        # Attempt to cache all the node_modules directories based on the node version and package lock.
+        # Attempt to cache all the node_modules directories based on the node version and package lock
       - name: Cache node_modules
         id: npm-cache
         uses: actions/cache@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -83,7 +85,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -129,7 +133,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -175,7 +181,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -221,7 +229,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
@@ -267,7 +277,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
           restore-keys: |
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
@@ -95,7 +95,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
           restore-keys: |
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
@@ -141,7 +141,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
           restore-keys: |
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
@@ -187,7 +187,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
           restore-keys: |
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
@@ -233,7 +233,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.jon }}
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
           restore-keys: |
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
             cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,7 @@ jobs:
         name: Install NPM Dependencies
         run: npm ci
 
-      # TODO: use turbo for the prettier check
+      # TODO: use turbo for prettier:check
       # - name: Cache turbo
       #   id: turbo-cache
       #   uses: actions/cache@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,25 @@ jobs:
         with:
           node-version: 16.13.x
 
-      - name: Install
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Check formatting
@@ -39,7 +57,25 @@ jobs:
         with:
           node-version: 16.13.x
 
-      - name: Install
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Check linting
@@ -55,7 +91,25 @@ jobs:
         with:
           node-version: 16.13.x
 
-      - name: Install
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Check types
@@ -71,7 +125,25 @@ jobs:
         with:
           node-version: 16.13.x
 
-      - name: Install
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Build
@@ -87,7 +159,25 @@ jobs:
         with:
           node-version: 16.13.x
 
-      - name: Install
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Run unit tests
@@ -103,7 +193,25 @@ jobs:
         with:
           node-version: 18.x
 
-      - name: Install
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Run e2e tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,20 +44,19 @@ jobs:
         name: Install NPM Dependencies
         run: npm ci
 
-      # TODO: use turbo for prettier:check
-      # - name: Cache turbo
-      #   id: turbo-cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ./turbo-cache
-      #     key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
-      #     restore-key: |
-      #       cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
-      #       cache-turbo-${{ github.base_ref }}-
-      #       cache-turbo
+      - name: Cache turbo
+        id: turbo-cache
+        uses: actions/cache@v3
+        with:
+          path: ./turbo-cache
+          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-key: |
+            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.base_ref }}-
+            cache-turbo
 
       - name: Check formatting
-        run: npm run prettier:check
+        run: npm run prettier:check -- --cache-dir ./turbo-cache
   linting:
     name: Linting
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,12 +49,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
+          key: cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
-            cache-turbo-${{ github.base_ref }}-
-            cache-turbo
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}
 
       - name: Check formatting
         run: npm run prettier:check -- --cache-dir ./turbo-cache
@@ -95,12 +95,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
+          key: cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
-            cache-turbo-${{ github.base_ref }}-
-            cache-turbo
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}
 
       - name: Check linting
         run: npm run lint -- --cache-dir ./turbo-cache
@@ -141,12 +141,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
+          key: cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
-            cache-turbo-${{ github.base_ref }}-
-            cache-turbo
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}
 
       - name: Check types
         run: npm run types-check -- --cache-dir ./turbo-cache
@@ -187,12 +187,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
+          key: cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
-            cache-turbo-${{ github.base_ref }}-
-            cache-turbo
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}
 
       - name: Build
         run: npm run build -- --cache-dir ./turbo-cache
@@ -233,12 +233,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./turbo-cache
-          key: cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}-${{ github.job }}
+          key: cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
-            cache-turbo-${{ github.base_ref }}-${{ github.ref_name }}-
-            cache-turbo-${{ github.base_ref }}-
-            cache-turbo
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-${{ github.sha }}
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-${{ github.ref_name }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}-${{ github.base_ref }}-
+            cache-turbo-${{ github.workflow }}-${{ github.job }}
 
       - name: Run unit tests
         run: npm run test:unit -- --cache-dir ./turbo-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,25 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Install Dependencies
+      - name: Get current node version
+        id: node-version
+        run: |
+         node_version=$(node -v)
+         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+
+        # Attempt to cache all the node_modules directories based on the node version and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
+        with:
+          key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,9 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          path: |
+            **/node_modules
+            !/pages-e2e/workspaces/**/node_modules
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Get current node version
         id: node-version
         run: |
-         node_version=$(node -v)
-         echo "node_version=$node_version" >> $GITHUB_OUTPUT
+          node_version=$(node -v)
+          echo "node_version=$node_version" >> $GITHUB_OUTPUT
 
         # Attempt to cache all the node_modules directories based on the node version and package lock.
       - name: Cache node_modules
@@ -35,7 +35,7 @@ jobs:
           cache-name: cache-node-modules-${{ steps.node-version.outputs.node_version }}
         with:
           key: ${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          path: "**/node_modules"
+          path: '**/node_modules'
 
       # If the cache missed then install using `npm ci` to follow package lock exactly
       - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}

--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,7 @@ dist
 
 # Turobrepo
 .turbo/
+turbo-cache
 
 # pages-e2e
 /pages-e2e/workspaces

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
 		"pages-e2e/features/*"
 	],
 	"scripts": {
-		"prettier": "npx prettier --ignore-path .prettierignore --ignore-path .gitignore .",
-		"prettier:check": "npm run prettier -- --check",
-		"prettier:fix": "npm run prettier -- --write",
+		"prettier": "prettier --ignore-path .prettierignore --ignore-path .gitignore .",
+		"prettier__check": "npm run prettier -- --check",
+		"prettier:check": "FORCE_COLOR=1 turbo run prettier__check",
+		"prettier__fix": "npm run prettier -- --write",
+		"prettier:fix": "FORCE_COLOR=1 turbo prettier__fix",
 		"lint": "FORCE_COLOR=1 turbo lint",
 		"types-check": "FORCE_COLOR=1 turbo types-check",
 		"build": "FORCE_COLOR=1 turbo build",

--- a/turbo.json
+++ b/turbo.json
@@ -15,8 +15,7 @@
 		},
 		"types-check": {},
 		"test:unit": {
-			"persistent": true,
-			"cache": false
+			"persistent": true
 		},
 		"publish": {}
 	}

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,8 @@
 			"outputs": ["dist/**"]
 		},
 		"lint": {},
-		"prettier:fix": {
+		"//#prettier__check": {},
+		"//#prettier__fix": {
 			"cache": false
 		},
 		"types-check": {},


### PR DESCRIPTION
resolves #367 

| Before | with npm caching | with npm and turbo caching<br/>(with all full turbo) |
|--------|--------|-------|
| [![Screenshot 2023-07-05 at 13 51 11](https://github.com/cloudflare/next-on-pages/assets/61631103/4045da67-b169-4ef2-8866-22c200dc28c4)](https://github.com/cloudflare/next-on-pages/actions/runs/5456442488) | [![Screenshot 2023-07-05 at 13 53 12](https://github.com/cloudflare/next-on-pages/assets/61631103/c7e7cbf4-9a4c-4f93-b636-68a4a6e6bc8c)](https://github.com/cloudflare/next-on-pages/actions/runs/5464461977) | [![Screenshot 2023-07-05 at 18 04 23](https://github.com/cloudflare/next-on-pages/assets/61631103/26755f84-f3eb-4a67-8890-40c38f79037f)](https://github.com/cloudflare/next-on-pages/actions/runs/5466966647) |

Notes:
 - The Turbo caching doesn't seem to make a huge difference here, but I guess it would help scaling better
 - The e2e tests don't use turbo nor caching so those are going to be the biggest bottleneck here, but even if they are we still get a fast feedback loop for the other checks, I think we could also set up turbo and caching for the e2es but maybe it could be more valuable not to (so that we can test for example fresh installs which would conflict with caching) (maybe we could turbo/cache the e2es for PRs and not for releases?)