### PR TITLE
temp fix for chunk + manifest deduping in `--skip-build`

### DIFF
--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -51,7 +51,7 @@ export async function generateFunctionsMap(
 		outputDir,
 	};
 
-	// TODO: Remove need for no chunks directory check in refactor
+	// TODO: Remove need for no chunks directory check after https://github.com/cloudflare/next-on-pages/issues/371 is done
 	const chunksDirExists = await validateDir(processingSetup.distWebpackDir);
 
 	if (!disableChunksDedup && !chunksDirExists) {

--- a/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
+++ b/packages/next-on-pages/src/buildApplication/generateFunctionsMap.ts
@@ -465,7 +465,7 @@ function extractManifestStatementInfo(
 		statement.expression.left.object.name !== 'self' ||
 		statement.expression.left.property.type !== 'Identifier' ||
 		// only extract statements where the manifest is an object
-		// TODO: Remove need for this check in refactor
+		// TODO: Remove this check after https://github.com/cloudflare/next-on-pages/issues/371 is done
 		statement.expression.right.type !== 'ObjectExpression'
 	)
 		return null;


### PR DESCRIPTION
This is a temporary fix and should be resolved ASAP in a refactor of how the logic for processing the output works.

These two fixes are for errors thrown when using the `--skip-build` mode when deduplication has already taken place before.

Chunk deduping error that is fixed:
![image](https://github.com/cloudflare/next-on-pages/assets/10815538/70a9e62a-c41b-49f4-b59c-4fb0ca14d678)

Manifest deduping error that is fixed:
![image](https://github.com/cloudflare/next-on-pages/assets/10815538/fc5b5a1b-326a-4e06-ad16-ad695a6b27d0)
