### PR TITLE
fix: image resizing returning weird response

### DIFF
--- a/packages/next-on-pages/templates/_worker.js/index.ts
+++ b/packages/next-on-pages/templates/_worker.js/index.ts
@@ -24,7 +24,11 @@ export default {
 			async () => {
 				const url = new URL(request.url);
 				if (url.pathname.startsWith('/_next/image')) {
-					return handleImageResizingRequest(request, __CONFIG__.images);
+					return handleImageResizingRequest(request, {
+						buildOutput: __BUILD_OUTPUT__,
+						assetsFetcher: env.ASSETS,
+						imagesConfig: __CONFIG__.images,
+					});
 				}
 
 				const adjustedRequest = adjustRequestForVercel(request);

--- a/packages/next-on-pages/tests/templates/utils/images.test.ts
+++ b/packages/next-on-pages/tests/templates/utils/images.test.ts
@@ -126,6 +126,7 @@ describe('getResizingProperties', () => {
 
 			const result = getResizingProperties(req, baseConfig);
 			expect(result).toEqual({
+				isRelative: true,
 				imageUrl: new URL('https://localhost/images/1.jpg'),
 				options: { format: undefined, width: 640, quality: 75 },
 			});
@@ -146,6 +147,7 @@ describe('getResizingProperties', () => {
 
 			const result = getResizingProperties(req, config);
 			expect(result).toEqual({
+				isRelative: true,
 				imageUrl: new URL('https://localhost/images/1.svg'),
 				options: { format: undefined, width: 640, quality: 75 },
 			});
@@ -158,6 +160,7 @@ describe('getResizingProperties', () => {
 
 			const result = getResizingProperties(req, config);
 			expect(result).toEqual({
+				isRelative: true,
 				imageUrl: new URL('https://localhost/images/1.svg'),
 				options: { format: undefined, width: 640, quality: 75 },
 			});
@@ -182,6 +185,7 @@ describe('getResizingProperties', () => {
 
 			const result = getResizingProperties(req, baseConfig);
 			expect(result).toEqual({
+				isRelative: false,
 				imageUrl: new URL('https://example.com/image.jpg'),
 				options: { format: undefined, width: 640, quality: 75 },
 			});
@@ -195,6 +199,7 @@ describe('getResizingProperties', () => {
 
 			const result = getResizingProperties(req, baseConfig);
 			expect(result).toEqual({
+				isRelative: false,
 				imageUrl: new URL('https://via.placeholder.com/image.jpg'),
 				options: { format: undefined, width: 640, quality: 75 },
 			});
@@ -208,6 +213,7 @@ describe('getResizingProperties', () => {
 
 			const result = getResizingProperties(req, baseConfig);
 			expect(result).toEqual({
+				isRelative: true,
 				imageUrl: new URL('https://localhost/images/1.jpg'),
 				options: { format: 'webp', width: 640, quality: 75 },
 			});
@@ -221,6 +227,7 @@ describe('getResizingProperties', () => {
 
 			const result = getResizingProperties(req, baseConfig);
 			expect(result).toEqual({
+				isRelative: true,
 				imageUrl: new URL('https://localhost/images/1.jpg'),
 				options: { format: 'avif', width: 640, quality: 75 },
 			});
@@ -247,5 +254,25 @@ describe('formatResp', () => {
 		expect(newResp.headers.get('Content-Disposition')).toEqual(
 			'inline; filename="1.jpg"'
 		);
+	});
+
+	test('uses cache ttl from config when no cache header is present', () => {
+		const config = baseConfig;
+		const imageUrl = new URL('https://localhost/images/1.jpg');
+
+		const newResp = formatResp(new Response(), imageUrl, config);
+		expect(newResp.headers.get('Cache-Control')).toEqual('public, max-age=60');
+	});
+
+	test('does not override the cache header when one is present', () => {
+		const config = baseConfig;
+		const imageUrl = new URL('https://localhost/images/1.jpg');
+
+		const newResp = formatResp(
+			new Response(null, { headers: { 'cache-control': 'test-value' } }),
+			imageUrl,
+			config
+		);
+		expect(newResp.headers.get('Cache-Control')).toEqual('test-value');
 	});
 });


### PR DESCRIPTION
This PR fixes a weird issue where every other refresh in the browser would not show the image.

The actual fix is making the response mutable and applying the headers to it, instead of creating a new response with the new headers from the resp body. Why? I don't know - I assume something on the response object being weird. Don't ask me why this fixes it, but it does.

Oh, and this PR also includes an unrelated change to fetch relative assets in the build output through the assets fetcher instead of a fetch request.

and the other thing this pr does is also respect the expected cache-control response header behaviour of falling back to the minimumcachettl config value

https://e572d143.image-resizing-test.pages.dev/