### PR TITLE
fix: query params not appending with the same key

### DIFF
--- a/.changeset/neat-terms-boil.md
+++ b/.changeset/neat-terms-boil.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix multiple search params with the same key not being preserved

--- a/packages/next-on-pages/templates/_worker.js/utils/http.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/http.ts
@@ -64,7 +64,10 @@ export function applySearchParams(
 		if (paramMatch?.[1]) {
 			target.set(key, value);
 			target.set(paramMatch[1], value);
-		} else if (!target.has(key) || (target.get(key) !== value && !!value)) {
+		} else if (
+			!target.has(key) ||
+			(!!value && !target.getAll(key).includes(value))
+		) {
 			target.append(key, value);
 		}
 	}

--- a/packages/next-on-pages/templates/_worker.js/utils/http.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/http.ts
@@ -45,7 +45,7 @@ export function isUrl(url: string): boolean {
 /**
  * Merges search params from one URLSearchParams object to another.
  *
- * Only updates the a parameter if the target does not contain it, or the source value is not empty.
+ * Only appends the parameter if the target does not contain it, or if the value is different and not undefined.
  *
  * For params prefixed with `nxtP`, it also sets the param without the prefix if it does not exist.
  * The `nxtP` prefix indicates that it is for Next.js dynamic route parameters. In some cases,
@@ -60,13 +60,13 @@ export function applySearchParams(
 	source: URLSearchParams,
 ) {
 	for (const [key, value] of source.entries()) {
-		if (!target.has(key) || !!value) {
-			target.set(key, value);
+		if (!target.has(key) || (target.get(key) !== value && !!value)) {
+			target.append(key, value);
+		}
 
-			const paramMatch = /^nxtP(.+)$/.exec(key);
-			if (paramMatch?.[1] && !target.has(paramMatch[1])) {
-				target.set(paramMatch[1], value);
-			}
+		const paramMatch = /^nxtP(.+)$/.exec(key);
+		if (paramMatch?.[1]) {
+			target.set(paramMatch[1], value);
 		}
 	}
 }

--- a/packages/next-on-pages/templates/_worker.js/utils/http.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/http.ts
@@ -60,13 +60,12 @@ export function applySearchParams(
 	source: URLSearchParams,
 ) {
 	for (const [key, value] of source.entries()) {
-		if (!target.has(key) || (target.get(key) !== value && !!value)) {
-			target.append(key, value);
-		}
-
 		const paramMatch = /^nxtP(.+)$/.exec(key);
 		if (paramMatch?.[1]) {
+			target.set(key, value);
 			target.set(paramMatch[1], value);
+		} else if (!target.has(key) || (target.get(key) !== value && !!value)) {
+			target.append(key, value);
 		}
 	}
 }

--- a/packages/next-on-pages/tests/templates/utils/http.test.ts
+++ b/packages/next-on-pages/tests/templates/utils/http.test.ts
@@ -101,6 +101,23 @@ describe('applySearchParams', () => {
 		);
 	});
 
+	test('multiple query params with the same key must be unique values', () => {
+		const source = new URL('http://localhost/page?foo=bar&foo=baz&foo=baz');
+		const target = new URL('http://localhost/page?other=value&foo=baz');
+
+		expect([...source.searchParams.entries()].length).toEqual(3);
+		expect([...target.searchParams.entries()].length).toEqual(2);
+
+		applySearchParams(target.searchParams, source.searchParams);
+
+		expect([...source.searchParams.entries()].length).toEqual(3);
+		expect([...target.searchParams.entries()].length).toEqual(3);
+
+		expect(target.toString()).toEqual(
+			'http://localhost/page?other=value&foo=baz&foo=bar',
+		);
+	});
+
 	test('Next.js page params (nxtP) always override', () => {
 		const source = new URL('http://localhost/page?nxtPfoo=bar');
 		const target = new URL(

--- a/packages/next-on-pages/tests/templates/utils/http.test.ts
+++ b/packages/next-on-pages/tests/templates/utils/http.test.ts
@@ -81,6 +81,25 @@ describe('applySearchParams', () => {
 			'http://localhost/page?other=value&foo=bar',
 		);
 	});
+
+	test('allows multiple query params with the same key', () => {
+		const source = new URL('http://localhost/page?foo=bar');
+		const target = new URL(
+			'http://localhost/page?other=value&foo=baz&foo=test',
+		);
+
+		expect([...source.searchParams.entries()].length).toEqual(1);
+		expect([...target.searchParams.entries()].length).toEqual(3);
+
+		applySearchParams(target.searchParams, source.searchParams);
+
+		expect([...source.searchParams.entries()].length).toEqual(1);
+		expect([...target.searchParams.entries()].length).toEqual(4);
+
+		expect(target.toString()).toEqual(
+			'http://localhost/page?other=value&foo=bar&foo=baz&foo=test',
+		);
+	});
 });
 
 describe('createRouteRequest', () => {

--- a/packages/next-on-pages/tests/templates/utils/http.test.ts
+++ b/packages/next-on-pages/tests/templates/utils/http.test.ts
@@ -97,7 +97,26 @@ describe('applySearchParams', () => {
 		expect([...target.searchParams.entries()].length).toEqual(4);
 
 		expect(target.toString()).toEqual(
-			'http://localhost/page?other=value&foo=bar&foo=baz&foo=test',
+			'http://localhost/page?other=value&foo=baz&foo=test&foo=bar',
+		);
+	});
+
+	test('Next.js page params (nxtP) always override', () => {
+		const source = new URL('http://localhost/page?nxtPfoo=bar');
+		const target = new URL(
+			'http://localhost/page?other=value&foo=baz&foo=test',
+		);
+
+		expect([...source.searchParams.entries()].length).toEqual(1);
+		expect([...target.searchParams.entries()].length).toEqual(3);
+
+		applySearchParams(target.searchParams, source.searchParams);
+
+		expect([...source.searchParams.entries()].length).toEqual(1);
+		expect([...target.searchParams.entries()].length).toEqual(3);
+
+		expect(target.toString()).toEqual(
+			'http://localhost/page?other=value&foo=bar&nxtPfoo=bar',
 		);
 	});
 });


### PR DESCRIPTION
This PR does the following:
- Changes the `applySearchParams` function to append on unique key-value combos, instead of overriding them.
- Ensures that internal Next.js search params from matches in the build output config always override so routes function properly.

From what I understand, this is common behaviour and is how it should have been implemented originally. 