### PR TITLE
refactor fetch patching and add missing user-agent header setting

### DIFF
--- a/.changeset/tame-goats-perform.md
+++ b/.changeset/tame-goats-perform.md
@@ -1,0 +1,12 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+add user-agent header to outgoing fetch requests
+
+mimic Next.js' behavior of setting (if not already present) a `user-agent` header set to `Next.js Middleware`
+see: https://github.com/vercel/next.js/blob/6705c803021d3bdea7fec20e5d98f6899e49836d/packages/next/src/server/web/sandbox/context.ts#L318-L320
+
+this helps making next-on-pages more consistent with Next.js on Vercel
+(it and can solve issues in which such header is necessary, as for example when making Github rest api calls,
+see: https://github.com/cloudflare/next-on-pages/issues/376#issuecomment-1628416988)

--- a/packages/next-on-pages/templates/_worker.js/index.ts
+++ b/packages/next-on-pages/templates/_worker.js/index.ts
@@ -2,7 +2,7 @@ import { handleRequest } from './handleRequest';
 import {
 	adjustRequestForVercel,
 	handleImageResizingRequest,
-	patchFetchToAllowBundledAssets,
+	patchFetch,
 } from './utils';
 import type { AsyncLocalStorage } from 'node:async_hooks';
 
@@ -14,7 +14,7 @@ declare const __BUILD_OUTPUT__: VercelBuildOutput;
 
 declare const __ENV_ALS_PROMISE__: Promise<null | AsyncLocalStorage<unknown>>;
 
-patchFetchToAllowBundledAssets();
+patchFetch();
 
 export default {
 	async fetch(request, env, ctx) {

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -86,7 +86,7 @@ async function handleInlineAssetRequest(request: Request) {
 
 			// Note: clone is necessary so that body does work
 			resp.clone = (): Response => {
-				return { ...resp };
+				return { ...resp } as Response;
 			};
 
 			return resp;

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -86,7 +86,7 @@ async function handleInlineAssetRequest(request: Request) {
 
 			// Note: clone is necessary so that body does work
 			resp.clone = (): Response => {
-				return resp;
+				return { ...resp };
 			};
 
 			return resp;

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -65,13 +65,9 @@ async function handleInlineAssetRequest(request: Request) {
 				get body(): ReadableStream<unknown> | null {
 					return new ReadableStream({
 						start(controller) {
-							return pump();
-							function pump() {
-								const b = Buffer.from(binaryContent);
-								controller.enqueue(b);
-								controller.close();
-								return pump();
-							}
+							const b = Buffer.from(binaryContent);
+							controller.enqueue(b);
+							controller.close();
 						},
 					});
 				},

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -1,79 +1,121 @@
-export function patchFetchToAllowBundledAssets(): void {
-	const flagSymbol = Symbol.for('next-on-pages bundled assets fetch patch');
+/**
+ * Patches the global fetch in ways necessary for Next.js (/next-on-pages) applications
+ * to work
+ */
+export function patchFetch(): void {
+	const alreadyPatched = (globalThis.fetch as Fetch)[patchFlagSymbol];
 
-	const alreadyPatched = (
-		globalThis.fetch as unknown as { [flagSymbol]: boolean }
-	)[flagSymbol];
-	if (alreadyPatched) {
-		return;
-	}
+	if (alreadyPatched) return;
 
 	applyPatch();
 
-	(globalThis.fetch as unknown as { [flagSymbol]: boolean })[flagSymbol] = true;
+	(globalThis.fetch as Fetch)[patchFlagSymbol] = true;
 }
 
 function applyPatch() {
 	const originalFetch = globalThis.fetch;
+
 	globalThis.fetch = async (...args) => {
 		const request = new Request(...args);
 
-		if (request.url.startsWith('blob:')) {
-			try {
-				const url = new URL(request.url);
-				const binaryContent = (
-					await import(`./__next-on-pages-dist__/assets/${url.pathname}.bin`)
-				).default;
-
-				// Note: we can't generate a real Response object here because this fetch might be called
-				//       at the top level of a dynamically imported module, and such cases produce the following
-				//       error:
-				//           Some functionality, such as asynchronous I/O, timeouts, and generating random values,
-				//           can only be performed while handling a request
-				//       this is a somewhat known workerd behavior (currently kept for security and performance reasons)
-				//
-				//       if the above issue/constraint were to change we should replace the following with a real Response object
-				const resp = {
-					async arrayBuffer() {
-						return binaryContent;
-					},
-					get body(): ReadableStream<unknown> | null {
-						return new ReadableStream({
-							start(controller) {
-								return pump();
-								function pump() {
-									const b = Buffer.from(binaryContent);
-									controller.enqueue(b);
-									controller.close();
-									return pump();
-								}
-							},
-						});
-					},
-					async text() {
-						const b = Buffer.from(binaryContent);
-						return b.toString();
-					},
-					async json() {
-						const b = Buffer.from(binaryContent);
-						return JSON.stringify(b.toString());
-					},
-					async blob() {
-						return new Blob(binaryContent);
-					},
-				} as Response;
-
-				// Note: clone is necessary so that body does work
-				resp.clone = (): Response => {
-					return resp;
-				};
-
-				return resp;
-			} catch {
-				/* empty, let's just fallback to the original fetch */
-			}
+		const response = await handleInlineAssetRequest(request);
+		if (response) {
+			return response;
 		}
+
+		setRequestUserAgentIfNeeded(request);
 
 		return originalFetch(request);
 	};
 }
+
+/**
+ * This function checks if a given request is trying to fetch an inline if it is it returns a response containing a stream for the asset,
+ * otherwise returns null (signaling that the request hasn't been handled).
+ *
+ * This is necessary so that users can fetch urls such as: `new URL("file", import.meta.url)`
+ * (used for example with `@vercel/og`)
+ *
+ * Note: this function's aim is to mimic the following Next behavior:
+ * 	https://github.com/vercel/next.js/blob/6705c803021d3bdea7fec20e5d98f6899e49836d/packages/next/src/server/web/sandbox/fetch-inline-assets.ts
+ *
+ * @param request the request to handle
+ * @returns the response to return to the caller if the request was for an inline asset one (and the file exists), null otherwise
+ */
+async function handleInlineAssetRequest(request: Request) {
+	if (request.url.startsWith('blob:')) {
+		try {
+			const url = new URL(request.url);
+			const binaryContent = (
+				await import(`./__next-on-pages-dist__/assets/${url.pathname}.bin`)
+			).default;
+
+			// Note: we can't generate a real Response object here because this fetch might be called
+			//       at the top level of a dynamically imported module, and such cases produce the following
+			//       error:
+			//           Some functionality, such as asynchronous I/O, timeouts, and generating random values,
+			//           can only be performed while handling a request
+			//       this is a somewhat known workerd behavior (currently kept for security and performance reasons)
+			//
+			//       if the above issue/constraint were to change we should replace the following with a real Response object
+			const resp = {
+				async arrayBuffer() {
+					return binaryContent;
+				},
+				get body(): ReadableStream<unknown> | null {
+					return new ReadableStream({
+						start(controller) {
+							return pump();
+							function pump() {
+								const b = Buffer.from(binaryContent);
+								controller.enqueue(b);
+								controller.close();
+								return pump();
+							}
+						},
+					});
+				},
+				async text() {
+					const b = Buffer.from(binaryContent);
+					return b.toString();
+				},
+				async json() {
+					const b = Buffer.from(binaryContent);
+					return JSON.stringify(b.toString());
+				},
+				async blob() {
+					return new Blob(binaryContent);
+				},
+			} as Response;
+
+			// Note: clone is necessary so that body does work
+			resp.clone = (): Response => {
+				return resp;
+			};
+
+			return resp;
+		} catch {
+			/* empty */
+		}
+	}
+	return null;
+}
+
+/**
+ *	updates the provided request by adding a Next.js specific user-agent header if the request has no user-agent header
+ *
+ *  Note: this is done by the Vercel network, but also in their next dev server as you can see here:
+ * 		https://github.com/vercel/next.js/blob/6705c803021d3bdea7fec20e5d98f6899e49836d/packages/next/src/server/web/sandbox/context.ts#L318-L320)
+ * @param request the request to update
+ */
+function setRequestUserAgentIfNeeded(
+	request: Request<unknown, RequestInitCfProperties>,
+): void {
+	if (!request.headers.has('user-agent')) {
+		request.headers.set(`user-agent`, `Next.js Middleware`);
+	}
+}
+
+const patchFlagSymbol = Symbol.for('next-on-pages fetch patch');
+
+type Fetch = typeof globalThis.fetch & { [patchFlagSymbol]: boolean };


### PR DESCRIPTION
Example of what this PR fixed:

Fetch to the GitHub REST API:

[source code](https://github.com/dario-piotrowicz/next-apps-for-testing/blob/master/apps/simple-app-dir-13.4.2/app/api/gh-nop/route.ts)

| Before | After |
|--------|--------|
| ![Screenshot 2023-07-18 at 16 39 54](https://github.com/cloudflare/next-on-pages/assets/61631103/c0344943-6772-48e8-838d-1920033bff5a) | ![Screenshot 2023-07-18 at 16 38 54](https://github.com/cloudflare/next-on-pages/assets/61631103/915312b4-81ef-45ea-a842-cb0055c31723) | 
| <sup><sub>https://a3caa9a5.next-apps-for-testing.pages.dev/api/gh-nop/</sub></sup>|<sup><sub>https://2bdb5dc5.next-apps-for-testing.pages.dev/api/gh-nop/</sub></sup>|
