### PR TITLE
fix: middleware redirect not always bailing out of routing

### DIFF
--- a/.changeset/seven-socks-roll.md
+++ b/.changeset/seven-socks-roll.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix middleware redirects not always bailing out of the routing stages.

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -218,13 +218,7 @@ export class RoutesMatcher {
 			return false;
 		}
 
-		// console.log(JSON.stringify([...resp.headers]));
 		this.processMiddlewareResp(resp);
-		// console.log(
-		// 	JSON.stringify([...this.headers.normal]),
-		// 	JSON.stringify([...this.headers.important]),
-		// 	this.headers.middlewareLocation
-		// );
 		return true;
 	}
 

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -218,7 +218,13 @@ export class RoutesMatcher {
 			return false;
 		}
 
+		// console.log(JSON.stringify([...resp.headers]));
 		this.processMiddlewareResp(resp);
+		// console.log(
+		// 	JSON.stringify([...this.headers.normal]),
+		// 	JSON.stringify([...this.headers.important]),
+		// 	this.headers.middlewareLocation
+		// );
 		return true;
 	}
 
@@ -453,8 +459,10 @@ export class RoutesMatcher {
 		// Call and process the middleware if this is a middleware route.
 		const success = await this.runRouteMiddleware(route.middlewarePath);
 		if (!success) return 'error';
-		// If the middleware set a response body, we are done.
-		if (this.body !== undefined) return 'done';
+		// If the middleware set a response body or resulted in a redirect, we are done.
+		if (this.body !== undefined || this.headers.middlewareLocation) {
+			return 'done';
+		}
 
 		// Update final headers with the ones from this route.
 		this.applyRouteHeaders(route, srcMatch, captureGroupKeys);

--- a/packages/next-on-pages/tests/templates/requestTestData/middleware.ts
+++ b/packages/next-on-pages/tests/templates/requestTestData/middleware.ts
@@ -27,6 +27,14 @@ const rawVercelConfig: VercelConfig = {
 			middlewareRawSrc: ['/:nextData(_next/data/[^/]{1,})?/api/:path*(.json)?'],
 			override: true,
 		},
+		{
+			src: '^/((?!.+\\.rsc).+?)(?:/)?$',
+			has: [{ type: 'header', key: 'rsc' }],
+			dest: '/$1.rsc',
+			headers: { vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
+			continue: true,
+			override: true,
+		},
 		{ handle: 'resource' },
 		{ src: '/.*', status: 404 },
 		{ handle: 'hit' },
@@ -101,6 +109,18 @@ export const testSet: TestSet = {
 		{
 			name: 'middleware route returns redirect for `NextResponse.redirect()`',
 			paths: ['/api/hello?redirect'],
+			expected: {
+				status: 307,
+				data: '',
+				headers: {
+					location: 'http://localhost/somewhere-else',
+				},
+			},
+		},
+		{
+			name: 'middleware route returns redirect when a later matching config rule would be an override',
+			paths: ['/api/hello?redirect'],
+			headers: { rsc: '1' },
 			expected: {
 				status: 307,
 				data: '',


### PR DESCRIPTION
This PR does the following:
- Ensures we always bail out of routing when a middleware returns a redirect.
- Adds a test.

Previously, it was still possible for the routing to find a match in a later entry in the build output config. In the case of RSC requests, this would lead to overriding the found headers from the middleware because of the override rule on RSC matching entries in the build output config, discarding the redirect header from the middleware. This PR changes it so that when we encounter a redirect in a middleware, we bail out of routing straight away, instead of proceeding through the stages.

This is probably what should have been done originally, to be honest.

This resolves an issue that was raised in the Cloudflare Discord with Clerk.