### PR TITLE
fix: `next.config.js` URL rewrites unintentionally redirecting instead of rewriting

### DIFF
--- a/.changeset/gorgeous-carrots-breathe.md
+++ b/.changeset/gorgeous-carrots-breathe.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix `next.config.js` rewrites unintentionally redirecting the user instead of rewriting the request.

--- a/packages/next-on-pages/templates/_worker.js/handleRequest.ts
+++ b/packages/next-on-pages/templates/_worker.js/handleRequest.ts
@@ -93,7 +93,7 @@ async function generateResponse(
 		resp = new Response(body, { status });
 	} else if (isUrl(path)) {
 		// If the path is an URL from matching, that means it was rewritten to a full URL.
-		resp = await fetch(new URL(path), { headers: reqCtx.request.headers });
+		resp = await fetch(new URL(path), reqCtx.request);
 	} else {
 		// Otherwise, we need to serve a file from the Vercel build output.
 		resp = await runOrFetchBuildOutputItem(output[path], reqCtx, {

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -593,11 +593,6 @@ export class RoutesMatcher {
 		this.checkPhaseCounter = 0;
 		const result = await this.checkPhase(phase);
 
-		// Check if path is an external URL.
-		if (isUrl(this.path)) {
-			this.headers.normal.set('location', this.path);
-		}
-
 		// Update status to redirect user to external URL.
 		if (
 			this.headers.normal.has('location') &&

--- a/packages/next-on-pages/tests/_helpers/index.ts
+++ b/packages/next-on-pages/tests/_helpers/index.ts
@@ -29,8 +29,9 @@ export type TestCase = {
 	method?: string;
 	expected: {
 		status: number;
-		data: string;
+		data: string | RegExp;
 		headers?: Record<string, string>;
+		ignoreHeaders?: boolean;
 		reqHeaders?: Record<string, string>;
 		mockConsole?: { log?: string[]; error?: (string | Error)[] };
 	};

--- a/packages/next-on-pages/tests/templates/handleRequest.test.ts
+++ b/packages/next-on-pages/tests/templates/handleRequest.test.ts
@@ -63,10 +63,17 @@ function runTestCase(
 			);
 
 			expect(res.status).toEqual(expected.status);
-			await expect(res.text()).resolves.toEqual(expected.data);
-			expect(Object.fromEntries(res.headers.entries())).toEqual(
-				expected.headers || {},
-			);
+			const textContent = await res.text();
+			if (expected.data instanceof RegExp) {
+				expect(textContent).toMatch(expected.data);
+			} else {
+				expect(textContent).toEqual(expected.data);
+			}
+			if (!expected.ignoreHeaders) {
+				expect(Object.fromEntries(res.headers.entries())).toEqual(
+					expected.headers || {},
+				);
+			}
 			if (expected.reqHeaders) {
 				expect(Object.fromEntries(req.headers.entries())).toEqual(
 					expected.reqHeaders,

--- a/packages/next-on-pages/tests/templates/requestTestData/configRewritesRedirectsHeaders.ts
+++ b/packages/next-on-pages/tests/templates/requestTestData/configRewritesRedirectsHeaders.ts
@@ -60,7 +60,7 @@ const rawVercelConfig: VercelConfig = {
 		{ handle: 'resource' },
 		{
 			src: '^(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$',
-			dest: 'https://uuid.rocks/$1',
+			dest: 'https://external-test-url.com/$1',
 			check: true,
 		},
 		{ src: '/.*', status: 404 },
@@ -168,8 +168,10 @@ export const testSet: TestSet = {
 			paths: ['/plain'],
 			expected: {
 				status: 200,
-				data: /^\w+-\w+-\w+-\w+-\w+$/,
-				ignoreHeaders: true,
+				data: 'external test url response',
+				headers: {
+					'content-type': 'text/plain;charset=UTF-8',
+				},
 			},
 		},
 		{

--- a/packages/next-on-pages/tests/templates/requestTestData/configRewritesRedirectsHeaders.ts
+++ b/packages/next-on-pages/tests/templates/requestTestData/configRewritesRedirectsHeaders.ts
@@ -60,7 +60,7 @@ const rawVercelConfig: VercelConfig = {
 		{ handle: 'resource' },
 		{
 			src: '^(?:/((?:[^/]+?)(?:/(?:[^/]+?))*))?(?:/)?$',
-			dest: 'https://my-old-site.com/$1',
+			dest: 'https://uuid.rocks/$1',
 			check: true,
 		},
 		{ src: '/.*', status: 404 },
@@ -165,11 +165,11 @@ export const testSet: TestSet = {
 		},
 		{
 			name: 'rewrites - `fallback`: rewrites on any request that has not been matched',
-			paths: ['/invalid-route'],
+			paths: ['/plain'],
 			expected: {
-				status: 307,
-				data: '',
-				headers: { location: 'https://my-old-site.com/invalid-route' },
+				status: 200,
+				data: /^\w+-\w+-\w+-\w+-\w+$/,
+				ignoreHeaders: true,
 			},
 		},
 		{


### PR DESCRIPTION
This PR does the following:
- Fixes an issue where full-URL rewrites were actually redirecting instead of rewriting the URL.
- Fixes the relevant test.

Previously, when a path was rewritten to an URL and it didn't set a `location` header, we set one for it. This was incorrect and it should not have done this. Instead, we should have treated that as the new rewritten destination and sent a fetch request to *proxy* the request to the URL. The response from fetching the rewritten URL should then be used as the response to be returned to the client.

Note that I am currently using Jacob (on Pages team)'s site for the tests, but I am happy to change the URL if you wish.