### PR TITLE
feat: Bun as a package manager support

### DIFF
--- a/.changeset/polite-ways-matter.md
+++ b/.changeset/polite-ways-matter.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Support for using Bun as a package manager in projects.

--- a/packages/next-on-pages/env.d.ts
+++ b/packages/next-on-pages/env.d.ts
@@ -3,6 +3,8 @@ declare global {
 		interface ProcessEnv {
 			NODE_ENV?: string;
 			npm_config_user_agent?: string;
+			CF_PAGES?: string;
+			SHELL?: string;
 			[key: string]: string | Fetcher;
 		}
 	}

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -12,7 +12,7 @@ import {
 	processVercelOutput,
 	processOutputDir,
 } from './processVercelOutput';
-import { getCurrentPackageExecuter } from './packageManagerUtils';
+import { getPackageManagerInfo } from './packageManagerUtils';
 import { printBuildSummary, writeBuildInfo } from './buildSummary';
 import type { ProcessedVercelFunctions } from './processVercelFunctions';
 import { processVercelFunctions } from './processVercelFunctions';
@@ -36,14 +36,17 @@ export async function buildApplication({
 	| 'watch'
 	| 'outdir'
 >) {
+	const { baseCmd, execCmd, execArgs } = await getPackageManagerInfo();
+
 	let buildSuccess = true;
 	if (!skipBuild) {
 		try {
 			await buildVercelOutput();
 		} catch {
+			const execStr = `${execCmd ?? baseCmd} ${execArgs?.join(',')}`;
 			cliError(
 				`
-					The Vercel build (\`${await getCurrentPackageExecuter()} vercel build\`) command failed. For more details see the Vercel logs above.
+					The Vercel build (\`${execStr} vercel build\`) command failed. For more details see the Vercel logs above.
 					If you need help solving the issue, refer to the Vercel or Next.js documentation or their repositories.
 				`,
 				{ spaced: true },

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -43,7 +43,7 @@ export async function buildApplication({
 		try {
 			await buildVercelOutput();
 		} catch {
-			const execStr = `${execCmd ?? baseCmd} ${execArgs?.join(',')}`;
+			const execStr = `${execCmd ?? baseCmd} ${execArgs?.join(',') ?? ''}`;
 			cliError(
 				`
 					The Vercel build (\`${execStr} vercel build\`) command failed. For more details see the Vercel logs above.

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -12,7 +12,7 @@ import {
 	processVercelOutput,
 	processOutputDir,
 } from './processVercelOutput';
-import { getPackageManagerInfo } from './packageManagerUtils';
+import { getCurrentPackageManager, getExecStr } from './packageManagerUtils';
 import { printBuildSummary, writeBuildInfo } from './buildSummary';
 import type { ProcessedVercelFunctions } from './processVercelFunctions';
 import { processVercelFunctions } from './processVercelFunctions';
@@ -36,14 +36,14 @@ export async function buildApplication({
 	| 'watch'
 	| 'outdir'
 >) {
-	const { baseCmd, execCmd, execArgs } = await getPackageManagerInfo();
+	const pm = await getCurrentPackageManager();
 
 	let buildSuccess = true;
 	if (!skipBuild) {
 		try {
 			await buildVercelOutput();
 		} catch {
-			const execStr = `${execCmd ?? baseCmd} ${execArgs?.join(',') ?? ''}`;
+			const execStr = await getExecStr(pm, 'vercel');
 			cliError(
 				`
 					The Vercel build (\`${execStr} vercel build\`) command failed. For more details see the Vercel logs above.

--- a/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
+++ b/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
@@ -34,7 +34,7 @@ export async function buildVercelOutput(): Promise<void> {
 		await rm(tempVercelConfig.tempPath);
 	}
 
-	const execStr = `${execCmd ?? baseCmd} ${execArgs?.join(',')}`;
+	const execStr = `${execCmd ?? baseCmd} ${execArgs?.join(',') ?? ''}`;
 	cliLog(`Completed \`${execStr} vercel build\`.`);
 }
 

--- a/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
+++ b/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
@@ -72,7 +72,7 @@ async function generateProjectJsonFileIfNeeded(): Promise<void> {
 }
 
 /**
- * Creates a temporary Vercel config file that can be provided to the Vercel CLI via to give it
+ * Creates a temporary Vercel config file that can be provided to the Vercel CLI to give it
  * additional configuration when building the project.
  *
  * @param config The values to set in the temporary config file.

--- a/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
+++ b/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
@@ -69,6 +69,7 @@ async function generateProjectJsonFileIfNeeded(
 		const tempConfig: VercelConfigJson = {
 			buildCommand: 'bun run build',
 			installCommand: 'bun install',
+			framework: 'nextjs',
 			// User-defined config values should override the ones we set.
 			...originalConfig,
 		};
@@ -84,7 +85,11 @@ async function generateProjectJsonFileIfNeeded(
 	return undefined;
 }
 
-type VercelConfigJson = { buildCommand?: string; installCommand?: string };
+type VercelConfigJson = {
+	buildCommand?: string;
+	installCommand?: string;
+	framework?: string;
+};
 
 async function runVercelBuild(
 	pkgMng: PackageManager,

--- a/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
+++ b/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
@@ -2,13 +2,12 @@ import { writeFile, mkdir, rm, rmdir } from 'fs/promises';
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { join, resolve } from 'path';
 import { cliLog } from '../cli';
-import { validateDir, validateFile } from '../utils';
+import { readJsonFile, validateDir, validateFile } from '../utils';
 import type { PackageManager } from './packageManagerUtils';
-import { getPackageVersion } from './packageManagerUtils';
 import {
-	getCurrentPackageExecuter,
-	getCurrentPackageManager,
-	getPackageManagerSpawnCommand,
+	getPackageManagerInfo,
+	getPackageVersion,
+	waitForProcessToClose,
 } from './packageManagerUtils';
 
 /**
@@ -23,20 +22,34 @@ import {
  *
  */
 export async function buildVercelOutput(): Promise<void> {
-	const pkgMng = await getCurrentPackageManager();
-	cliLog(`Detected Package Manager: ${pkgMng}\n`);
+	const { pm, baseCmd, execCmd, execArgs } = await getPackageManagerInfo();
+	cliLog(`Detected Package Manager: ${pm}\n`);
+
 	cliLog('Preparing project...');
-	await generateProjectJsonFileIfNeeded();
+	const tempVercelConfig = await generateProjectJsonFileIfNeeded(pm);
 	cliLog('Project is ready');
-	await runVercelBuild(pkgMng);
-	cliLog(`Completed \`${await getCurrentPackageExecuter()} vercel build\`.`);
+
+	await runVercelBuild(pm, tempVercelConfig?.additionalArgs);
+	if (tempVercelConfig) {
+		await rm(tempVercelConfig.tempPath);
+	}
+
+	const execStr = `${execCmd ?? baseCmd} ${execArgs?.join(',')}`;
+	cliLog(`Completed \`${execStr} vercel build\`.`);
 }
 
 /**
- * The Vercel CLI seems to require the presence of a project.json file,
- * so we create a dummy one just to satisfy Vercel
+ * The Vercel CLI requires the presence of a project.json file, so we create a dummy one just to
+ * satisfy Vercel.
+ *
+ * Creates a temporary config file when using the Bun package manager so that Vercel knows to use
+ * Bun to install and build the project.
+ *
+ * @returns The path and args for a temporary config file, if one was created.
  */
-async function generateProjectJsonFileIfNeeded(): Promise<void> {
+async function generateProjectJsonFileIfNeeded(
+	pm?: PackageManager,
+): Promise<{ additionalArgs: string[]; tempPath: string } | undefined> {
 	const projectJsonFilePath = join('.vercel', 'project.json');
 	if (!(await validateFile(projectJsonFilePath))) {
 		await mkdir('.vercel', { recursive: true });
@@ -45,87 +58,85 @@ async function generateProjectJsonFileIfNeeded(): Promise<void> {
 			JSON.stringify({ projectId: '_', orgId: '_', settings: {} }),
 		);
 	}
+
+	// When using the Bun package manager, we need to ensure the Vercel CLI has a config file that
+	// tells it to use Bun, since Vercel doesn't support auto-detecting Bun yet.
+	if (pm === 'bun') {
+		const oldConfigPath = join('vercel.json');
+		const originalConfig = await readJsonFile<VercelConfigJson>(oldConfigPath);
+
+		const tempConfigPath = join('.vercel', 'temp-nop-config.json');
+		const tempConfig: VercelConfigJson = {
+			buildCommand: 'bun run build',
+			installCommand: 'bun install',
+			// User-defined config values should override the ones we set.
+			...originalConfig,
+		};
+
+		await writeFile(tempConfigPath, JSON.stringify(tempConfig));
+
+		return {
+			additionalArgs: ['--local-config', tempConfigPath],
+			tempPath: tempConfigPath,
+		};
+	}
+
+	return undefined;
 }
 
-async function runVercelBuild(pkgMng: PackageManager): Promise<void> {
-	const pkgMngCMD = getPackageManagerSpawnCommand(pkgMng);
+type VercelConfigJson = { buildCommand?: string; installCommand?: string };
 
-	if (pkgMng === 'yarn (classic)') {
+async function runVercelBuild(
+	pkgMng: PackageManager,
+	additionalArgs: string[] = [],
+): Promise<void> {
+	const pmInfo = await getPackageManagerInfo(pkgMng);
+	const { pm, baseCmd } = pmInfo;
+
+	if (pm === 'yarn (classic)') {
 		cliLog(
-			`Installing vercel as dev dependencies with 'yarn add vercel -D'...`,
+			`Installing vercel as dev dependencies with '${baseCmd} add vercel -D'...`,
 		);
 
-		const installVercel = spawn(pkgMngCMD, ['add', 'vercel', '-D']);
+		const installVercel = spawn(baseCmd, ['add', 'vercel', '-D']);
 
-		installVercel.stdout.on('data', data =>
-			cliLog(`\n${data}`, { fromVercelCli: true }),
-		);
-		installVercel.stderr.on('data', data =>
-			// here we use cliLog instead of cliError because the Vercel cli
-			// currently displays non-error messages in stderr
-			// so we just display all Vercel logs as standard logs
-			cliLog(`\n${data}`, { fromVercelCli: true }),
-		);
+		logVercelProcessOutput(installVercel);
 
-		await new Promise((resolve, reject) => {
-			installVercel.on('close', code => {
-				if (code === 0) {
-					resolve(null);
-				} else {
-					reject();
-				}
-			});
-		});
+		await waitForProcessToClose(installVercel);
 
 		cliLog('Install completed');
 	}
 
 	cliLog('Building project...');
 
-	const vercelBuild = await getVercelBuildChildProcess(pkgMng);
+	const vercelBuild = await getVercelBuildChildProcess(pm, additionalArgs);
 
-	vercelBuild.stdout.on('data', data =>
-		cliLog(`\n${data}`, { fromVercelCli: true }),
-	);
-	vercelBuild.stderr.on('data', data =>
-		// here we use cliLog instead of cliError because the Vercel cli
-		// currently displays non-error messages in stderr
-		// so we just display all Vercel logs as standard logs
-		cliLog(`\n${data}`, { fromVercelCli: true }),
-	);
+	logVercelProcessOutput(vercelBuild);
 
-	await new Promise((resolve, reject) => {
-		vercelBuild.on('close', code => {
-			if (code === 0) {
-				resolve(null);
-			} else {
-				reject();
-			}
-		});
-	});
+	await waitForProcessToClose(vercelBuild);
 }
 
 async function getVercelBuildChildProcess(
 	pkgMng: PackageManager,
+	additionalArgs: string[] = [],
 ): Promise<ChildProcessWithoutNullStreams> {
-	const pkgMngCMD = getPackageManagerSpawnCommand(pkgMng);
-	const isYarnBerry = pkgMng === 'yarn (berry)';
-	const isPnpm = pkgMngCMD.startsWith('pnpm');
-	let useDlx = false;
+	const { pm, baseCmd, execCmd, execArgs, dlxOrExec } =
+		await getPackageManagerInfo(pkgMng);
 
-	if (isYarnBerry || isPnpm) {
-		const vercelPackageIsInstalled = await isVercelPackageInstalled(pkgMng);
-		useDlx = !vercelPackageIsInstalled;
+	let dlxArgs: string[] = [];
+
+	if (dlxOrExec) {
+		const vercelPackageIsInstalled = await getPackageVersion('vercel', pm);
+		dlxArgs = dlxOrExec(!vercelPackageIsInstalled);
 	}
 
-	return spawn(pkgMngCMD, [...(useDlx ? ['dlx'] : []), 'vercel', 'build']);
-}
-
-async function isVercelPackageInstalled(
-	pkgMng: PackageManager,
-): Promise<boolean> {
-	const packageVersion = await getPackageVersion('vercel', pkgMng);
-	return !!packageVersion;
+	return spawn(execCmd ?? baseCmd, [
+		...dlxArgs,
+		...(execArgs ?? []),
+		'vercel',
+		'build',
+		...additionalArgs,
+	]);
 }
 
 /**
@@ -151,4 +162,24 @@ export async function deleteNextTelemetryFiles(
 			// Ignore error if the directory is not empty
 		}
 	}
+}
+
+/**
+ * Logs the output of the Vercel process to the CLI.
+ *
+ * @param vercelProcess Spawned Vercel process.
+ */
+function logVercelProcessOutput(
+	vercelProcess: ChildProcessWithoutNullStreams,
+): void {
+	vercelProcess.stdout.on('data', data =>
+		cliLog(`\n${data}`, { fromVercelCli: true }),
+	);
+
+	vercelProcess.stderr.on('data', data =>
+		// here we use cliLog instead of cliError because the Vercel cli
+		// currently displays non-error messages in stderr
+		// so we just display all Vercel logs as standard logs
+		cliLog(`\n${data}`, { fromVercelCli: true }),
+	);
 }

--- a/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
+++ b/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
@@ -90,8 +90,7 @@ async function runVercelBuild(
 	pkgMng: PackageManager,
 	additionalArgs: string[] = [],
 ): Promise<void> {
-	const pmInfo = await getPackageManagerInfo(pkgMng);
-	const { pm, baseCmd } = pmInfo;
+	const { pm, baseCmd } = await getPackageManagerInfo(pkgMng);
 
 	if (pm === 'yarn (classic)') {
 		cliLog(

--- a/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
+++ b/packages/next-on-pages/src/buildApplication/buildVercelOutput.ts
@@ -5,6 +5,8 @@ import { cliLog } from '../cli';
 import { readJsonFile, validateDir, validateFile } from '../utils';
 import type { PackageManager } from './packageManagerUtils';
 import {
+	getCurrentPackageManager,
+	getExecStr,
 	getPackageManagerInfo,
 	getPackageVersion,
 	waitForProcessToClose,
@@ -22,7 +24,7 @@ import {
  *
  */
 export async function buildVercelOutput(): Promise<void> {
-	const { pm, baseCmd, execCmd, execArgs } = await getPackageManagerInfo();
+	const pm = await getCurrentPackageManager();
 	cliLog(`Detected Package Manager: ${pm}\n`);
 
 	cliLog('Preparing project...');
@@ -34,7 +36,7 @@ export async function buildVercelOutput(): Promise<void> {
 		await rm(tempVercelConfig.tempPath);
 	}
 
-	const execStr = `${execCmd ?? baseCmd} ${execArgs?.join(',') ?? ''}`;
+	const execStr = await getExecStr(pm, 'vercel');
 	cliLog(`Completed \`${execStr} vercel build\`.`);
 }
 

--- a/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
+++ b/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
@@ -224,6 +224,35 @@ export async function waitForProcessToClose(
 }
 
 /**
+ * Gets the executable string used for the package manager.
+ *
+ * @param pm Package manager name.
+ * @param packageName Package name.
+ * @returns The executable string used for the package manager.
+ */
+export async function getExecStr(
+	pm: PackageManager,
+	packageName?: string,
+): Promise<string> {
+	const {
+		baseCmd,
+		execCmd,
+		dlxOrExec,
+		execArgs = [],
+	} = await getPackageManagerInfo(pm);
+
+	let dlxArgs: string[] = [];
+	if (packageName && dlxOrExec) {
+		const vercelPackageIsInstalled = await getPackageVersion(packageName, pm);
+		dlxArgs = dlxOrExec(!vercelPackageIsInstalled);
+	}
+
+	const args = [...dlxArgs, ...execArgs];
+
+	return `${execCmd ?? baseCmd} ${args.join(' ') ?? ''}`.trim();
+}
+
+/**
  * Checks whether the current platform is Windows.
  *
  * @returns Whether the current platform is Windows.

--- a/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
+++ b/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
@@ -169,7 +169,8 @@ export async function getPackageVersion(
 				pm === 'pnpm' ? commandOutputJson[0] : commandOutputJson;
 			packageVersion = pm.startsWith('yarn')
 				? packageInfo?.children?.Version
-				: packageInfo?.dependencies[packageName]?.version;
+				: packageInfo?.dependencies?.[packageName]?.version ??
+				  packageInfo?.devDependencies?.[packageName]?.version;
 		}
 
 		return packageVersion ?? null;

--- a/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
+++ b/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
@@ -10,7 +10,7 @@ import { validateFile } from '../utils';
  * Tries to detect the package manager based on the `npm_config_user_agent` environment variable,
  * or the lockfile in the project.
  *
- * Prioritizes Bun > PNPM > Yarn > NPM. If Bun is used on Windows or in the build image, it falls back
+ * Prioritizes PNPM > Yarn > Bun > NPM. If Bun is used on Windows or in the build image, it falls back
  * to the next suitable package manager, with NPM being the default option.
  *
  * @returns Package manager name.

--- a/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
+++ b/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
@@ -1,34 +1,58 @@
 import { execFileSync, spawn } from 'child_process';
 import { readFile } from 'fs/promises';
 import YAML from 'js-yaml';
-import { cliError } from '../cli';
+import { cliError, cliWarn } from '../cli';
 import { validateFile } from '../utils';
 
+/**
+ * Gets the current package manager for the project.
+ *
+ * Tries to detect the package manager based on the `npm_config_user_agent` environment variable,
+ * or the lockfile in the project.
+ *
+ * Prioritizes Bun > PNPM > Yarn > NPM. If Bun is used on Windows or in the build image, it falls back
+ * to the next suitable package manager, with NPM being the default option.
+ *
+ * @returns Package manager name.
+ */
 export async function getCurrentPackageManager(): Promise<PackageManager> {
 	const userAgent = process.env.npm_config_user_agent;
 
-	const hasYarnLock = await validateFile('yarn.lock');
-	const hasPnpmLock = await validateFile('pnpm-lock.yaml');
+	const [hasYarnAgent, hasPnpmAgent, hasBunAgent] = ['yarn', 'pnpm', 'bun'].map(
+		agent => userAgent?.startsWith(agent),
+	);
+	const [hasYarnLock, hasPnpmLock, hasBunLock] = await Promise.all(
+		['yarn.lock', 'pnpm-lock.yaml', 'bun.lockb'].map(validateFile),
+	);
 
-	if ((userAgent && userAgent.startsWith('pnpm')) || hasPnpmLock) return 'pnpm';
+	if (hasBunAgent || hasBunLock) {
+		if (isWindows()) {
+			cliWarn(
+				'Bun is not supported on Windows, falling back to alternative package manager',
+			);
+		} else if (process.env.CF_PAGES && !(await getBinaryVersion('bun'))) {
+			cliWarn(
+				'Bun is not supported in the Cloudflare Pages build image, falling back to alternative package manager',
+			);
+		} else {
+			return 'bun';
+		}
+	}
 
-	if ((userAgent && userAgent.startsWith('yarn')) || hasYarnLock) {
-		const yarn = getPackageManagerSpawnCommand('yarn');
-		const getYarnV = spawn(yarn, ['-v']);
+	if (hasPnpmAgent || hasPnpmLock) return 'pnpm';
+
+	if (hasYarnAgent || hasYarnLock) {
+		const { baseCmd } = await getPackageManagerInfo('yarn');
+		const getYarnV = spawn(baseCmd, ['-v']);
 		let yarnV = '';
+
 		getYarnV.stdout.on('data', data => {
 			yarnV = `${data}`.trimEnd();
 		});
 		getYarnV.stderr.on('data', data => cliError(`\n${data}`));
-		await new Promise((resolve, reject) => {
-			getYarnV.on('close', code => {
-				if (code === 0) {
-					resolve(null);
-				} else {
-					reject();
-				}
-			});
-		});
+
+		await waitForProcessToClose(getYarnV);
+
 		if (!yarnV.startsWith('1.')) {
 			const yarnrc = await readFile('.yarnrc.yml', 'utf-8');
 			const { nodeLinker } = YAML.load(yarnrc) as {
@@ -53,91 +77,174 @@ export async function getCurrentPackageManager(): Promise<PackageManager> {
 			return 'yarn (classic)';
 		}
 	}
+
 	return 'npm';
 }
 
-export async function getCurrentPackageExecuter(): Promise<string> {
+/**
+ * Retrieves information about the package manager, such as the commands that may be used to run it
+ * or to execute packages.
+ *
+ * @param pm Package manager name.
+ * @returns Information about the package manager.
+ */
+export async function getPackageManagerInfo(
+	pm?: PackageManager,
+): Promise<PackageManagerInfo> {
+	pm ??= await getCurrentPackageManager();
 	const cmd = isWindows() ? '.cmd' : '';
-	const packageManager = await getCurrentPackageManager();
-	switch (packageManager) {
-		case 'npm':
-			return `npx${cmd}`;
+
+	switch (pm) {
+		case 'bun':
+			return {
+				pm,
+				baseCmd: `bun${cmd}`,
+				execArgs: ['x'],
+				infoArgs: ['pm', 'ls'],
+				infoRegex: (name: string) => new RegExp(`^.+ ${name}@(.*)$`, 'im'),
+			};
 		case 'pnpm':
-			return `pnpx${cmd}`;
+			return {
+				pm,
+				baseCmd: `pnpm${cmd}`,
+				dlxOrExec: (useDlx: boolean) => [useDlx ? 'dlx' : 'exec'],
+				infoArgs: ['list', '--depth=0'],
+			};
 		case 'yarn (berry)':
-			return `yarn${cmd} dlx`;
 		case 'yarn (classic)':
-			return `yarn${cmd}`;
+		case 'yarn':
+			return {
+				pm,
+				baseCmd: `yarn${cmd}`,
+				dlxOrExec:
+					pm === 'yarn (berry)'
+						? (useDlx: boolean) => [useDlx ? 'dlx' : 'exec']
+						: undefined,
+				infoArgs: ['info'],
+			};
+		case 'npm':
 		default:
-			return `npx${cmd}`;
+			return {
+				pm,
+				baseCmd: `npm${cmd}`,
+				execCmd: `npx${cmd}`,
+				infoArgs: ['list', '--depth=0'],
+			};
 	}
 }
 
-const packageManagers = {
-	pnpm: 'pnpm',
-	'yarn (berry)': 'yarn',
-	'yarn (classic)': 'yarn',
-	yarn: 'yarn',
-	npm: 'npx',
-} as const;
-
-export type PackageManager = keyof typeof packageManagers;
-
-type PackageManagerCommand = `${(typeof packageManagers)[PackageManager]}${
-	| '.cmd'
-	| ''}`;
-
-export function getPackageManagerSpawnCommand(
-	pkgMng: keyof typeof packageManagers,
-): PackageManagerCommand {
-	const winCMD = isWindows() ? '.cmd' : '';
-	return `${packageManagers[pkgMng]}${winCMD}`;
-}
-
-function isWindows(): boolean {
-	return process.platform === 'win32';
-}
-
+/**
+ * Gets the version of a package installed in the project.
+ *
+ * @param packageName Name of the package to get the version of.
+ * @param packageManager Package manager to use.
+ * @returns Version of the package, or `null` if the package is not installed.
+ */
 export async function getPackageVersion(
 	packageName: string,
 	packageManager?: PackageManager,
 ): Promise<string | null> {
 	try {
 		packageManager ??= await getCurrentPackageManager();
-		const command = getPackageManagerSpawnCommand(packageManager);
+		const { pm, baseCmd, infoArgs, infoRegex } = await getPackageManagerInfo(
+			packageManager,
+		);
+
 		const commandOutput = execFileSync(
-			command.startsWith('npx') ? 'npm' : command,
-			[
-				command === 'yarn' ? 'info' : 'list',
-				packageName,
-				'--json',
-				...(command === 'yarn' ? [] : ['--depth=0']),
-			],
+			baseCmd,
+			[...infoArgs, packageName, '--json'],
 			{ stdio: 'pipe' },
 		)
 			.toString()
 			.trim();
 
-		const commandJsonOuput = JSON.parse(commandOutput);
-		const packageInfo =
-			packageManager === 'pnpm' ? commandJsonOuput[0] : commandJsonOuput;
-		const packageVersion =
-			command === 'yarn'
+		let packageVersion: string | undefined;
+
+		if (infoRegex) {
+			const match = commandOutput.match(infoRegex(packageName));
+			packageVersion = match?.[1];
+		} else {
+			const commandOutputJson = JSON.parse(commandOutput);
+			const packageInfo =
+				pm === 'pnpm' ? commandOutputJson[0] : commandOutputJson;
+			packageVersion = pm.startsWith('yarn')
 				? packageInfo?.children?.Version
 				: packageInfo?.dependencies[packageName]?.version;
+		}
+
 		return packageVersion ?? null;
 	} catch {
 		return null;
 	}
 }
 
-export function getBinaryVersion(binaryName: PackageManager): string | null {
-	const commandArgs = ['--version'];
+/**
+ * Gets the version of a binary installed on the machine.
+ *
+ * @param binaryName Name of the binary to get the version of.
+ * @returns Version of the binary, or `null` if the binary is not installed.
+ */
+export async function getBinaryVersion(
+	binaryName: string,
+): Promise<string | null> {
+	const versionFromProcess = process.versions[binaryName];
+	if (versionFromProcess) return versionFromProcess;
+
 	try {
-		return execFileSync(getPackageManagerSpawnCommand(binaryName), commandArgs)
+		const cmd = isWindows() ? '.cmd' : '';
+		return execFileSync(`${binaryName}${cmd}`, ['--version'])
 			.toString()
-			.trim();
+			.trim()
+			.replace(/^v/, '');
 	} catch {
 		return null;
 	}
 }
+
+/**
+ * Waits for a spawned process to close.
+ *
+ * @param spawnedProcess Spawned process to wait for.
+ * @returns Promise that resolves when the process closes with code 0, or rejects when the process
+ * closes with a non-zero code.
+ */
+export async function waitForProcessToClose(
+	spawnedProcess: ReturnType<typeof spawn>,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		spawnedProcess.on('close', code => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject();
+			}
+		});
+	});
+}
+
+/**
+ * Checks whether the current platform is Windows.
+ *
+ * @returns Whether the current platform is Windows.
+ */
+function isWindows(): boolean {
+	return process.platform === 'win32';
+}
+
+export type PackageManager =
+	| 'bun'
+	| 'pnpm'
+	| 'yarn (berry)'
+	| 'yarn (classic)'
+	| 'yarn'
+	| 'npm';
+
+export type PackageManagerInfo = {
+	pm: PackageManager;
+	baseCmd: string;
+	execCmd?: string;
+	execArgs?: string[];
+	dlxOrExec?: (useDlx: boolean) => string[];
+	infoArgs: string[];
+	infoRegex?: (name: string) => RegExp;
+};

--- a/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
+++ b/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
@@ -267,7 +267,6 @@ export type PackageManager =
 	| 'yarn'
 	| 'npm';
 
-
 type PlainPackageManager = Exclude<
 	PackageManager,
 	'yarn (berry)' | 'yarn (classic)'

--- a/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
+++ b/packages/next-on-pages/src/buildApplication/packageManagerUtils.ts
@@ -267,15 +267,6 @@ export type PackageManager =
 	| 'yarn'
 	| 'npm';
 
-// export type PackageManagerInfo = {
-// 	pm: PackageManager;
-// 	baseCmd: string;
-// 	execCmd?: string;
-// 	execArgs?: string[];
-// 	dlxOrExec?: (useDlx: boolean) => string[];
-// 	infoArgs: string[];
-// 	getPackageVersionRegex?: (name: string) => RegExp;
-// };
 
 type PlainPackageManager = Exclude<
 	PackageManager,

--- a/packages/next-on-pages/src/cli.ts
+++ b/packages/next-on-pages/src/cli.ts
@@ -251,6 +251,16 @@ function prepareCliMessage(
 
 export async function printEnvInfo(): Promise<void> {
 	const packageManager = await getCurrentPackageManager();
+
+	const [nodeVersion, bunVersion, pnpmVersion, yarnVersion, npmVersion] =
+		await Promise.all(
+			['node', 'bun', 'pnpm', 'yarn', 'npm'].map(getBinaryVersion),
+		);
+
+	const [vercelVersion, nextVersion] = await Promise.all(
+		['vercel', 'next'].map(async pkg => getPackageVersion(pkg, packageManager)),
+	);
+
 	const envInfoMessage = dedent(`
 		System:
 			Platform: ${os.platform()}
@@ -258,17 +268,18 @@ export async function printEnvInfo(): Promise<void> {
 			Version: ${os.version()}
 			CPU: (${os.cpus().length}) ${os.arch()} ${os.cpus()[0]?.model}
 			Memory: ${Math.round(os.totalmem() / 1024 / 1024 / 1024)} GB
-			Shell: ${process.env['SHELL']?.toString() ?? 'Unknown'}
+			Shell: ${process.env.SHELL?.toString() ?? 'Unknown'}
 		Binaries:
-			Node: ${process.versions.node}
-			Yarn: ${getBinaryVersion('yarn') ?? 'N/A'}
-			npm: ${getBinaryVersion('npm') ?? 'N/A'}
-			pnpm: ${getBinaryVersion('pnpm') ?? 'N/A'}
-		Package Manager Used: ${await getCurrentPackageManager()}
+			Node: ${nodeVersion ?? 'N/A'}
+			Bun: ${bunVersion ?? 'N/A'}
+			pnpm: ${pnpmVersion ?? 'N/A'}
+			Yarn: ${yarnVersion ?? 'N/A'}
+			npm: ${npmVersion ?? 'N/A'}
+		Package Manager Used: ${packageManager}
 		Relevant Packages:
 			@cloudflare/next-on-pages: ${nextOnPagesVersion}
-			vercel: ${(await getPackageVersion('vercel', packageManager)) ?? 'N/A'}
-			next: ${(await getPackageVersion('next', packageManager)) ?? 'N/A'}
+			vercel: ${vercelVersion ?? 'N/A'}
+			next: ${nextVersion ?? 'N/A'}
 	`);
 
 	// eslint-disable-next-line no-console

--- a/packages/next-on-pages/tests/src/buildApplication/packageManagerUtils.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/packageManagerUtils.test.ts
@@ -1,104 +1,191 @@
-import { describe, expect, vi, it, afterAll } from 'vitest';
+import { describe, test, expect, vi, afterAll } from 'vitest';
+import { EventEmitter } from 'events';
 import type { PackageManager } from '../../../src/buildApplication/packageManagerUtils';
 import {
-	getCurrentPackageExecuter,
 	getCurrentPackageManager,
+	getPackageManagerInfo,
 } from '../../../src/buildApplication/packageManagerUtils';
-import { EventEmitter } from 'events';
+import { mockConsole } from '../../_helpers';
 
 describe('getCurrentPackageManager', async () => {
-	it('should detect yarn (berry)', async () => {
+	test('should detect yarn (berry)', async () => {
 		await testWith({ packageManager: 'yarn (berry)' }, async () => {
 			const pkgMng = await getCurrentPackageManager();
 			expect(pkgMng).toEqual('yarn (berry)');
 		});
 	});
-	it('should detect yarn (classic)', async () => {
+
+	test('should detect yarn (classic)', async () => {
 		await testWith({ packageManager: 'yarn (classic)' }, async () => {
 			const pkgMng = await getCurrentPackageManager();
 			expect(pkgMng).toEqual('yarn (classic)');
 		});
 	});
-	it('should detected pnpm', async () => {
+
+	test('should detect pnpm', async () => {
 		await testWith({ packageManager: 'pnpm' }, async () => {
 			const pkgMng = await getCurrentPackageManager();
 			expect(pkgMng).toEqual('pnpm');
 		});
 	});
-	it('should detected npm', async () => {
+
+	test('should detect npm', async () => {
 		await testWith({ packageManager: 'npm' }, async () => {
 			const pkgMng = await getCurrentPackageManager();
 			expect(pkgMng).toEqual('npm');
 		});
 	});
+
+	test('should detect bun', async () => {
+		await testWith({ packageManager: 'bun' }, async () => {
+			const pkgMng = await getCurrentPackageManager();
+			expect(pkgMng).toEqual('bun');
+		});
+	});
 });
 
-describe('getCurrentPackageExecuter', () => {
-	it('should detect yarn (berry)', async () => {
+describe('getPackageManagerInfo', () => {
+	test('should detect yarn (berry) on linux', async () => {
 		await testWith({ packageManager: 'yarn (berry)' }, async () => {
-			const pkgMng = await getCurrentPackageExecuter();
-			expect(pkgMng).toEqual('yarn dlx');
-		});
-	});
-	it('should detect yarn (classic)', async () => {
-		await testWith({ packageManager: 'yarn (classic)' }, async () => {
-			const pkgMng = await getCurrentPackageExecuter();
-			expect(pkgMng).toEqual('yarn');
-		});
-	});
-	it('should detected pnpm', async () => {
-		await testWith({ packageManager: 'pnpm' }, async () => {
-			const pkgMng = await getCurrentPackageExecuter();
-			expect(pkgMng).toEqual('pnpx');
-		});
-	});
-	it('should detected npm', async () => {
-		await testWith({ packageManager: 'npm' }, async () => {
-			const pkgMng = await getCurrentPackageExecuter();
-			expect(pkgMng).toEqual('npx');
+			const { baseCmd, execCmd, execArgs, dlxOrExec } =
+				await getPackageManagerInfo();
+
+			expect(baseCmd).toEqual('yarn');
+			expect(execCmd).toEqual(undefined);
+			expect(execArgs).toEqual(undefined);
+			expect(dlxOrExec?.(true)).toEqual(['dlx']);
+			expect(dlxOrExec?.(false)).toEqual(['exec']);
 		});
 	});
 
-	it('should detect yarn (berry) on windows', async () => {
+	test('should detect yarn (classic) on linux', async () => {
+		await testWith({ packageManager: 'yarn (classic)' }, async () => {
+			const { baseCmd, execCmd, execArgs, dlxOrExec } =
+				await getPackageManagerInfo();
+
+			expect(baseCmd).toEqual('yarn');
+			expect(execCmd).toEqual(undefined);
+			expect(execArgs).toEqual(undefined);
+			expect(dlxOrExec).toEqual(undefined);
+		});
+	});
+
+	test('should detect pnpm on linux', async () => {
+		await testWith({ packageManager: 'pnpm' }, async () => {
+			const { baseCmd, execCmd, execArgs, dlxOrExec } =
+				await getPackageManagerInfo();
+
+			expect(baseCmd).toEqual('pnpm');
+			expect(execCmd).toEqual(undefined);
+			expect(execArgs).toEqual(undefined);
+			expect(execArgs).toEqual(undefined);
+			expect(dlxOrExec?.(true)).toEqual(['dlx']);
+			expect(dlxOrExec?.(false)).toEqual(['exec']);
+		});
+	});
+
+	test('should detect npm on linux', async () => {
+		await testWith({ packageManager: 'npm' }, async () => {
+			const { baseCmd, execCmd, execArgs, dlxOrExec } =
+				await getPackageManagerInfo();
+
+			expect(baseCmd).toEqual('npm');
+			expect(execCmd).toEqual('npx');
+			expect(execArgs).toEqual(undefined);
+			expect(dlxOrExec).toEqual(undefined);
+		});
+	});
+
+	test('should detect bun on linux', async () => {
+		await testWith({ packageManager: 'bun' }, async () => {
+			const { baseCmd, execCmd, execArgs, dlxOrExec } =
+				await getPackageManagerInfo();
+
+			expect(baseCmd).toEqual('bun');
+			expect(execCmd).toEqual(undefined);
+			expect(execArgs).toEqual(['x']);
+			expect(dlxOrExec).toEqual(undefined);
+		});
+	});
+
+	test('should detect yarn (berry) on windows', async () => {
 		await testWith(
 			{ packageManager: 'yarn (berry)', os: 'windows' },
 			async () => {
-				const pkgMng = await getCurrentPackageExecuter();
-				expect(pkgMng).toEqual('yarn.cmd dlx');
+				const { baseCmd, execCmd, execArgs, dlxOrExec } =
+					await getPackageManagerInfo();
+
+				expect(baseCmd).toEqual('yarn.cmd');
+				expect(execCmd).toEqual(undefined);
+				expect(execArgs).toEqual(undefined);
+				expect(dlxOrExec?.(true)).toEqual(['dlx']);
+				expect(dlxOrExec?.(false)).toEqual(['exec']);
 			},
 		);
 	});
-	it('should detect yarn (classic) on windows', async () => {
+
+	test('should detect yarn (classic) on windows', async () => {
 		await testWith(
 			{ packageManager: 'yarn (classic)', os: 'windows' },
 			async () => {
-				const pkgMng = await getCurrentPackageExecuter();
-				expect(pkgMng).toEqual('yarn.cmd');
+				const { baseCmd, execCmd, execArgs, dlxOrExec } =
+					await getPackageManagerInfo();
+
+				expect(baseCmd).toEqual('yarn.cmd');
+				expect(execCmd).toEqual(undefined);
+				expect(execArgs).toEqual(undefined);
+				expect(dlxOrExec).toEqual(undefined);
 			},
 		);
 	});
-	it('should detected pnpm on windows', async () => {
+
+	test('should detect pnpm on windows', async () => {
 		await testWith({ packageManager: 'pnpm', os: 'windows' }, async () => {
-			const pkgMng = await getCurrentPackageExecuter();
-			expect(pkgMng).toEqual('pnpx.cmd');
+			const { baseCmd, execCmd, execArgs, dlxOrExec } =
+				await getPackageManagerInfo();
+
+			expect(baseCmd).toEqual('pnpm.cmd');
+			expect(execCmd).toEqual(undefined);
+			expect(execArgs).toEqual(undefined);
+			expect(dlxOrExec?.(true)).toEqual(['dlx']);
+			expect(dlxOrExec?.(false)).toEqual(['exec']);
 		});
 	});
-	it('should detected npm on windows', async () => {
+
+	test('should detect npm on windows', async () => {
 		await testWith({ packageManager: 'npm', os: 'windows' }, async () => {
-			const pkgMng = await getCurrentPackageExecuter();
-			expect(pkgMng).toEqual('npx.cmd');
+			const { baseCmd, execCmd, execArgs, dlxOrExec } =
+				await getPackageManagerInfo();
+
+			expect(baseCmd).toEqual('npm.cmd');
+			expect(execCmd).toEqual('npx.cmd');
+			expect(execArgs).toEqual(undefined);
+			expect(dlxOrExec).toEqual(undefined);
+		});
+	});
+
+	test('should detect fallback instead of bun on windows', async () => {
+		await testWith({ packageManager: 'bun', os: 'windows' }, async () => {
+			const mockedWarn = mockConsole('warn');
+
+			const { baseCmd, execCmd, execArgs, dlxOrExec } =
+				await getPackageManagerInfo();
+
+			expect(baseCmd).toEqual('npm.cmd');
+			expect(execCmd).toEqual('npx.cmd');
+			expect(execArgs).toEqual(undefined);
+			expect(dlxOrExec).toEqual(undefined);
+
+			mockedWarn.expectCalls([
+				/Bun is not supported on Windows, falling back to alternative/,
+			]);
+			mockedWarn.restore();
 		});
 	});
 });
 
 async function testWith(
-	{
-		packageManager,
-		os = 'linux/macos',
-	}: {
-		packageManager: Exclude<PackageManager, 'yarn'>;
-		os?: 'windows' | 'linux/macos';
-	},
+	{ packageManager, os = 'linux/macos' }: TestWithOpts,
 	test: () => Promise<void>,
 ): Promise<void> {
 	currentMocks.packageManager = packageManager;
@@ -111,10 +198,12 @@ async function testWith(
 	vi.unstubAllEnvs();
 }
 
-const currentMocks: {
+type TestWithOpts = {
 	packageManager: Exclude<PackageManager, 'yarn'>;
-	os: 'windows' | 'linux/macos';
-} = {
+	os?: 'windows' | 'linux/macos';
+};
+
+const currentMocks: TestWithOpts = {
 	packageManager: 'npm',
 	os: 'windows',
 };

--- a/packages/next-on-pages/tests/src/buildApplication/packageManagerUtils.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/packageManagerUtils.test.ts
@@ -177,7 +177,7 @@ describe('getPackageManagerInfo', () => {
 			expect(dlxOrExec).toEqual(undefined);
 
 			mockedWarn.expectCalls([
-				/Bun is not supported on Windows, falling back to alternative/,
+				/Bun is not supported on Windows, falling back to npm/,
 			]);
 			mockedWarn.restore();
 		});


### PR DESCRIPTION
This PR does the following:
- Introduces support for using Bun as a package manager in projects.
- Refactors some of the package manager utilities (sorry, I couldn't help myself).
- Fixes pnpm always using `dlx` instead of `exec` when `vercel` is installed as a dev dependency.
- Updates the relevant tests.

Manual Testing Locally:
- [x] Bun
- [x] pnpm
- [x] Yarn*
- [x] npm 

<details>

<summary>* yarn</summary>

Tested manually with yarn 1:
![Screenshot 2023-07-27 at 16 55 22](https://github.com/cloudflare/next-on-pages/assets/61631103/672a4a3d-2a6a-45c8-ba2f-bc1938f81fa7)

I don't think you can test prereleases with yarn berry so I'm asking that
</details>