### PR TITLE
fix: `/_next/static` in subdir not excluded from routing

### DIFF
--- a/.changeset/tough-ghosts-boil.md
+++ b/.changeset/tough-ghosts-boil.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix the `/_next/static` exclusion in `_routes.json` being incorrect when the directory is not in the root.

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -120,6 +120,8 @@ async function prepareAndBuildWorker(
 		!disableWorkerMinification,
 	);
 
+	await buildMetadataFiles(outputDir, { staticAssets });
+
 	printBuildSummary(staticAssets, processedVercelOutput, processedFunctions);
 	await writeBuildInfo(
 		join(outputDir, '_worker.js'),
@@ -129,6 +131,4 @@ async function prepareAndBuildWorker(
 	);
 
 	cliSuccess(`Generated '${outputtedWorkerPath}'.`);
-
-	await buildMetadataFiles(outputDir, { staticAssets });
 }

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -63,7 +63,6 @@ export async function buildApplication({
 		disableChunksDedup,
 		disableWorkerMinification,
 	});
-	await buildMetadataFiles(outputDir);
 
 	const totalBuildTime = ((Date.now() - buildStartTime) / 1000).toFixed(2);
 	cliLog(`Build completed in ${totalBuildTime.toLocaleString()}s`);
@@ -130,4 +129,6 @@ async function prepareAndBuildWorker(
 	);
 
 	cliSuccess(`Generated '${outputtedWorkerPath}'.`);
+
+	await buildMetadataFiles(outputDir, { staticAssets });
 }

--- a/packages/next-on-pages/src/buildApplication/buildMetadataFiles.ts
+++ b/packages/next-on-pages/src/buildApplication/buildMetadataFiles.ts
@@ -44,14 +44,8 @@ ${Object.entries(nextStaticHeaders)
 	}
 }
 
-async function buildRoutes(
-	outputDir: string,
-	{ staticAssets }: BuildMetadataFilesOpts,
-) {
-	const nextStaticRegex = /^(.*\/_next\/static)\/.+$/;
-	const nextStaticAsset = staticAssets.find(a => nextStaticRegex.test(a));
-	const nextStaticPath =
-		nextStaticAsset?.match(nextStaticRegex)?.[1] ?? '/_next/static';
+async function buildRoutes(outputDir: string, opts: BuildMetadataFilesOpts) {
+	const nextStaticPath = getNextStaticDirPath(opts);
 
 	try {
 		await writeFile(
@@ -69,6 +63,21 @@ async function buildRoutes(
 			throw e;
 		}
 	}
+}
+
+/**
+ * Finds the path to the `/_next/static` directory from the list of static assets. Accounts for the
+ * path being inside sub-directories, e.g. `/blog/_next/static`, and falls back to `/_next/static`.
+ *
+ * @param opts Options for building metadata files.
+ * @returns The path to the `/_next/static` directory.
+ */
+function getNextStaticDirPath({
+	staticAssets,
+}: BuildMetadataFilesOpts): string {
+	const regex = /^(.*\/_next\/static)\/.+$/;
+	const asset = staticAssets.find(a => regex.test(a));
+	return asset?.match(regex)?.[1] ?? '/_next/static';
 }
 
 type BuildMetadataFilesOpts = {


### PR DESCRIPTION
This PR does the following:
- Grabs the `{...}/_next/static` path from the static assets instead of always using `/_next/static` for the `_routes.json` file.

This allows the `/_next/static` assets to be excluded from worker invocations when in a subdirectory, instead of always assuming they are at the root.

Fixes #396