### PR TITLE
feat: group identifiers by their consumers

### DIFF
--- a/.changeset/khaki-parrots-visit.md
+++ b/.changeset/khaki-parrots-visit.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Group code block identifiers by the function files that they are consumed in. This reduces the total number of unique files created for identifiers that are used in multiple functions, like Webpack chunks or manifests.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/ast.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/ast.ts
@@ -46,10 +46,7 @@ export function collectIdentifiers(
  * @param identifierMaps The maps of found identifiers in the AST.
  */
 export function groupIdentifiers(identifierMaps: IdentifierMaps) {
-	// Webpack Chunks
-	groupIdentifiersByType(identifierMaps.webpack);
-	// Manifests
-	groupIdentifiersByType(identifierMaps.manifest);
+	Object.values(identifierMaps).forEach(map => groupIdentifiersByType(map));
 }
 
 type IdentifierMaps = Record<IdentifierType, IdentifiersMap>;

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/ast.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/ast.ts
@@ -123,15 +123,17 @@ function groupIdentifiersByType(foundIdentifiers: IdentifiersMap): void {
 	}
 
 	for (const [, identifiers] of groupedIdentifiers) {
-		// Generate a hash for the grouped file name to prevent excessively long file names.
-		const newGroupedPath = createHash('md5')
-			.update([...identifiers].join('-'))
-			.digest('hex');
+		if (identifiers.size > 1) {
+			// Generate a hash for the grouped file name to prevent excessively long file names.
+			const newGroupedPath = createHash('md5')
+				.update([...identifiers].join('-'))
+				.digest('hex');
 
-		// Update each identifier in the group with the new grouped path.
-		for (const identifier of identifiers) {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			foundIdentifiers.get(identifier)!.groupedPath = newGroupedPath;
+			// Update each identifier in the group with the new grouped path.
+			for (const identifier of identifiers) {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				foundIdentifiers.get(identifier)!.groupedPath = newGroupedPath;
+			}
 		}
 	}
 }

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/ast.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/ast.ts
@@ -46,7 +46,10 @@ export function collectIdentifiers(
  * @param identifierMaps The maps of found identifiers in the AST.
  */
 export function groupIdentifiers(identifierMaps: IdentifierMaps) {
-	Object.values(identifierMaps).forEach(map => groupIdentifiersByType(map));
+	// Webpack Chunks
+	groupIdentifiersByType(identifierMaps.webpack);
+	// Manifests
+	groupIdentifiersByType(identifierMaps.manifest);
 }
 
 type IdentifierMaps = Record<IdentifierType, IdentifiersMap>;

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -1,6 +1,6 @@
 import { parse } from 'acorn';
 import type * as AST from 'ast-types/gen/kinds';
-import { readFile, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, relative } from 'node:path';
 import type { ProcessVercelFunctionsOpts } from '.';
 import type { CollectedFunctions, FunctionInfo } from './configs';
@@ -12,7 +12,7 @@ import type {
 	RawIdentifier,
 	RawIdentifierWithImport,
 } from './ast';
-import { collectIdentifiers } from './ast';
+import { collectIdentifiers, groupIdentifiers } from './ast';
 import { buildFile, getRelativePathToAncestor } from './build';
 import {
 	addLeadingSlash,
@@ -83,12 +83,12 @@ async function processFunctionIdentifiers(
 			// Sort so that we make replacements from the end of the file to the start.
 			.sort((a, b) => b.start - a.start);
 
-		// Tracks the promises for building the identifiers so that we can wait for them all to finish.
-		const buildIdentifiersPromises: Promise<void>[] = [];
+		// Tracks the paths to the identifier files that need to be built before building the function's file.
+		const identifierPathsToBuild = new Set<string>();
 
 		// Tracks the imports to prepend to the final code for the function and identifiers.
 		const importsToPrepend: NewImportInfo[] = [];
-		const wasmImportsToPrepend: Map<string, string[]> = new Map();
+		const wasmImportsToPrepend = new Map<string, string[]>();
 
 		const newFnLocation = join('functions', `${fnInfo.relativePath}.js`);
 		const newFnPath = join(opts.nopDistDir, newFnLocation);
@@ -107,17 +107,17 @@ async function processFunctionIdentifiers(
 				);
 
 				fileContents = updatedContents;
-			} else if (identifierInfo.consumers > 1) {
+			} else if (identifierInfo.consumers.length > 1) {
 				// Only dedupe code blocks if there are multiple consumers.
-				const { updatedContents, newImport, buildPromise, wasmImports } =
-					processCodeBlockIdentifier(
+				const { updatedContents, newFilePath, newImport, wasmImports } =
+					await processCodeBlockIdentifier(
 						{ type, identifier, start, end, info: identifierInfo },
 						{ fileContents, wasmIdentifierKeys },
 						opts,
 					);
 
 				fileContents = updatedContents;
-				if (buildPromise) buildIdentifiersPromises.push(buildPromise);
+				if (newFilePath) identifierPathsToBuild.add(newFilePath);
 				if (newImport) importsToPrepend.push(newImport);
 				if (wasmImports.length) {
 					wasmImportsToPrepend.set(
@@ -128,8 +128,12 @@ async function processFunctionIdentifiers(
 			}
 		}
 
-		// Wait for any identifiers to be built before building the function's file.
-		await Promise.all(buildIdentifiersPromises);
+		// Build the identifier files before building the function's file.
+		await Promise.all(
+			[...identifierPathsToBuild].map(async path =>
+				buildFile(await readFile(path, 'utf8'), path),
+			),
+		);
 
 		// If wasm identifier is used in code block, prepend the import to the code block's file.
 		await prependWasmImportsToCodeBlocks(
@@ -169,14 +173,21 @@ async function buildFunctionFile(
 ): Promise<{ buildPromise: Promise<void> }> {
 	let functionImports = '';
 
-	importsToPrepend.forEach(({ key, path }) => {
+	// Group the identifier imports by the keys for each path.
+	const groupedImports = importsToPrepend.reduce((acc, { key, path }) => {
+		const existing = acc.get(path);
+		acc.set(path, existing ? `${existing},${key}` : key);
+		return acc;
+	}, new Map<string, string>());
+
+	groupedImports.forEach((keys, path) => {
 		const relativeImportPath = getRelativePathToAncestor({
 			from: newFnLocation,
 			relativeTo: nopDistDir,
 		});
 		const importPath = join(relativeImportPath, addLeadingSlash(path));
 
-		functionImports += `import ${key} from '${importPath}';\n`;
+		functionImports += `import { ${keys} } from '${importPath}';\n`;
 	});
 
 	fnInfo.outputPath = relative(workerJsDir, newFnPath);
@@ -299,54 +310,57 @@ type ProcessImportIdentifierOpts = {
  * @param ident The code block identifier to process.
  * @param processOpts Contents of the function's file.
  * @param opts Options for processing the function.
- * @returns A promise that resolves when the code block is built, and the new import info to prepend
- * to the function's file, along with the updated file contents.
+ * @returns The new path for the identifier, and the new import info to prepend to the function's
+ * file, along with the updated file contents.
  */
-function processCodeBlockIdentifier(
+async function processCodeBlockIdentifier(
 	ident: RawIdentifier<IdentifierType> & { info: IdentifierInfo },
 	{ fileContents, wasmIdentifierKeys }: ProcessCodeBlockIdentifierOpts,
 	{ nopDistDir, workerJsDir }: ProcessVercelFunctionsOpts,
-): ProcessCodeBlockIdentifierResult {
+): Promise<ProcessCodeBlockIdentifierResult> {
 	const { type, identifier, start, end, info } = ident;
 	let updatedContents = fileContents;
 
 	const codeBlock = updatedContents.slice(start, end);
 
-	let buildPromise: Promise<void> | undefined;
-	let newImport: NewImportInfo | undefined;
+	let identifierKey = identifier;
+	let newCodeBlock = identifier;
+
+	if (type === 'webpack') {
+		identifierKey = `__chunk_${identifier}`;
+		newCodeBlock = identifierKey;
+	} else if (type === 'manifest') {
+		newCodeBlock = `self.${identifier}=${identifier};`;
+	}
+
+	let newFilePath: string | undefined;
 	const wasmImports: string[] = [];
 
 	if (!info.newDest) {
-		const newPath = join(nopDistDir, type, `${identifier}.js`);
-		info.newDest = relative(workerJsDir, newPath);
+		const identTypeDir = join(nopDistDir, type);
+		newFilePath = join(identTypeDir, `${info.groupedPath ?? identifier}.js`);
+		info.newDest = relative(workerJsDir, newFilePath);
 
 		// Record the wasm identifiers used in the code block.
 		wasmIdentifierKeys
 			.filter(key => codeBlock.includes(key))
 			.forEach(key => wasmImports.push(key));
 
-		buildPromise = buildFile(`export default ${codeBlock}`, newPath);
+		await mkdir(identTypeDir, { recursive: true });
+		await appendFile(
+			newFilePath,
+			`export const ${identifierKey} = ${codeBlock}\n`,
+		);
 	}
 
-	if (type === 'webpack') {
-		const newVal = `__chunk_${identifier}`;
-		updatedContents = replaceLastSubstringInstance(
-			updatedContents,
-			codeBlock,
-			newVal,
-		);
-		newImport = { key: newVal, path: info.newDest };
-	} else if (type === 'manifest') {
-		const newVal = `self.${identifier}=${identifier};`;
-		updatedContents = replaceLastSubstringInstance(
-			updatedContents,
-			codeBlock,
-			newVal,
-		);
-		newImport = { key: identifier, path: info.newDest };
-	}
+	const newImport: NewImportInfo = { key: identifierKey, path: info.newDest };
+	updatedContents = replaceLastSubstringInstance(
+		updatedContents,
+		codeBlock,
+		newCodeBlock,
+	);
 
-	return { updatedContents, newImport, buildPromise, wasmImports };
+	return { updatedContents, newFilePath, newImport, wasmImports };
 }
 
 type ProcessCodeBlockIdentifierOpts = {
@@ -356,7 +370,7 @@ type ProcessCodeBlockIdentifierOpts = {
 
 type ProcessCodeBlockIdentifierResult = {
 	updatedContents: string;
-	buildPromise?: Promise<void>;
+	newFilePath?: string;
 	newImport?: NewImportInfo;
 	wasmImports: string[];
 };
@@ -394,10 +408,12 @@ async function getFunctionIdentifiers(
 		collectIdentifiers(
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			{ identifierMaps, programIdentifiers: entrypointsMap.get(entrypoint)! },
-			program,
+			{ program, entrypoint },
 			{ disableChunksDedup },
 		);
 	}
+
+	groupIdentifiers(identifierMaps);
 
 	return { identifierMaps, entrypointsMap };
 }

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -354,6 +354,7 @@ async function processCodeBlockIdentifier(
 	}
 
 	const newImport: NewImportInfo = { key: identifierKey, path: info.newDest };
+
 	updatedContents = replaceLastSubstringInstance(
 		updatedContents,
 		codeBlock,

--- a/packages/next-on-pages/tests/src/buildApplication/buildSummary.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/buildSummary.test.ts
@@ -66,7 +66,7 @@ describe('buildSummary', () => {
 			identifiers: {
 				entrypointsMap: new Map(),
 				identifierMaps: {
-					wasm: new Map([['wasm-one', { consumers: 1 }]]),
+					wasm: new Map([['wasm-one', { consumers: ['/home'] }]]),
 					manifest: new Map(),
 					webpack: new Map(),
 				},
@@ -161,9 +161,11 @@ describe('buildSummary', () => {
 			identifiers: {
 				entrypointsMap: new Map(),
 				identifierMaps: {
-					wasm: new Map([['wasm-one', { consumers: 1 }]]),
-					manifest: new Map([['__BUILD_MANIFEST', { consumers: 5 }]]),
-					webpack: new Map([['872', { consumers: 1 }]]),
+					wasm: new Map([['wasm-one', { consumers: ['/middleware'] }]]),
+					manifest: new Map([
+						['__BUILD_MANIFEST', { consumers: ['/home', '/nested/home'] }],
+					]),
+					webpack: new Map([['872', { consumers: ['/home'] }]]),
 				},
 			},
 		};
@@ -203,7 +205,7 @@ describe('buildSummary', () => {
 			},
 			staticAssets: ['/static-one', '/static-two'],
 			identifiers: {
-				manifest: { __BUILD_MANIFEST: { consumers: 5 } },
+				manifest: { __BUILD_MANIFEST: { consumers: 2 } },
 				wasm: { 'wasm-one': { consumers: 1 } },
 				webpack: { '872': { consumers: 1 } },
 			},


### PR DESCRIPTION
This PR does the following:
- Groups code block identifiers by their consumers.

This drastically reduces the number of unique files created for things like Webpack chunks by grouping them into the same file when they are consumed by the same function, which was causing issues in certain projects.

Fixes [#3391](https://github.com/cloudflare/workers-sdk/issues/3391) (right?)