### PR TITLE
watch mode only on file changes

### DIFF
--- a/.changeset/wet-laws-wink.md
+++ b/.changeset/wet-laws-wink.md
@@ -1,0 +1,8 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+watch mode only on file changes
+
+only watch for file changes instead of watching for all possible changes (such as directories additions/removals, etc...),
+making sure that we don't rerun the build process unnecessarily

--- a/packages/next-on-pages/src/index.ts
+++ b/packages/next-on-pages/src/index.ts
@@ -81,5 +81,5 @@ function setWatchMode(fn: () => void): void {
 			'package.json',
 		],
 		ignoreInitial: true,
-	}).on('all', fn);
+	}).on('change', fn);
 }


### PR DESCRIPTION
fixes #400 

> **Note**
> By debugging an application using yarn (to solve #400) I noticed that the `public` directory was continuously getting detected as being added, I am not sure why that is but I don't think there is any benefit for us in watching directories addition/removals and the like, so I am simply changing the watch function to only trigger the re-build on file changes (which I'd assume are the only events we should care about)