### PR TITLE
fix: normalize injected import paths on windows

### DIFF
--- a/.changeset/fifty-radios-rhyme.md
+++ b/.changeset/fifty-radios-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Normalize injected import paths for builds done on Windows machines.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/build.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/build.ts
@@ -2,6 +2,7 @@ import type { Plugin } from 'esbuild';
 import { build } from 'esbuild';
 import { mkdir } from 'node:fs/promises';
 import { dirname, join, relative, resolve } from 'node:path';
+import { normalizePath } from '../../utils';
 
 /**
  * Builds a file using esbuild.
@@ -17,9 +18,11 @@ export async function buildFile(
 	filePath: string,
 	{ relativeTo }: Omit<RelativePathOpts, 'from'> = {},
 ) {
-	const relativeNopDistPath = join(
-		getRelativePathToAncestor({ from: filePath, relativeTo }),
-		'__next-on-pages-dist__',
+	const relativeNopDistPath = normalizePath(
+		join(
+			getRelativePathToAncestor({ from: filePath, relativeTo }),
+			'__next-on-pages-dist__',
+		),
 	);
 
 	await mkdir(dirname(filePath), { recursive: true });

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -17,6 +17,7 @@ import { buildFile, getRelativePathToAncestor } from './build';
 import {
 	addLeadingSlash,
 	copyFileWithDir,
+	normalizePath,
 	replaceLastSubstringInstance,
 	validateFile,
 } from '../../utils';
@@ -185,7 +186,9 @@ async function buildFunctionFile(
 			from: newFnLocation,
 			relativeTo: nopDistDir,
 		});
-		const importPath = join(relativeImportPath, addLeadingSlash(path));
+		const importPath = normalizePath(
+			join(relativeImportPath, addLeadingSlash(path)),
+		);
 
 		functionImports += `import { ${keys} } from '${importPath}';\n`;
 	});
@@ -233,7 +236,9 @@ async function prependWasmImportsToCodeBlocks(
 				for (const identifier of wasmImports) {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					const { newDest } = identifierMaps.wasm.get(identifier)!;
-					const wasmImportPath = join(relativeImportPath, newDest as string);
+					const wasmImportPath = normalizePath(
+						join(relativeImportPath, newDest as string),
+					);
 					functionImports += `import ${identifier} from "${wasmImportPath}";\n`;
 				}
 
@@ -274,7 +279,7 @@ async function processImportIdentifier(
 
 		const oldPath = join(dirname(entrypoint), importPath);
 		const newPath = join(nopDistDir, type, importPathWithoutType);
-		info.newDest = relative(workerJsDir, newPath);
+		info.newDest = normalizePath(relative(workerJsDir, newPath));
 
 		await copyFileWithDir(oldPath, newPath);
 	}
@@ -283,7 +288,7 @@ async function processImportIdentifier(
 		from: newFnLocation,
 		relativeTo: nopDistDir,
 	});
-	const newImportPath = join(relativeImportPath, info.newDest);
+	const newImportPath = normalizePath(join(relativeImportPath, info.newDest));
 
 	const newVal = `import ${identifier} from "${newImportPath}";`;
 	updatedContents = replaceLastSubstringInstance(
@@ -339,7 +344,7 @@ async function processCodeBlockIdentifier(
 	if (!info.newDest) {
 		const identTypeDir = join(nopDistDir, type);
 		newFilePath = join(identTypeDir, `${info.groupedPath ?? identifier}.js`);
-		info.newDest = relative(workerJsDir, newFilePath);
+		info.newDest = normalizePath(relative(workerJsDir, newFilePath));
 
 		// Record the wasm identifiers used in the code block.
 		wasmIdentifierKeys


### PR DESCRIPTION
This PR does the following:
- Normalizes the import paths that get injected on Windows machines.

This should hopefully resolve the following issue that I believe is caused by backslashes in Windows path names:

```
[X [ERROR] Could not resolve "......__next-on-pages-dist__webpackee2d6a0d46f7afe4402d9e841f4a3be3.js"

    <stdin>:1:124:
      1 │ ...838 } from '..\..\..\__next-on-pages-dist__\webpack\ee2d6a0d46f7...
        ╵               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "......__next-on-pages-dist__webpackee2d6a0d46f7afe4402d9e841f4a3be3.js" as external to exclude it from the bundle, which will remove this error.
```