### PR TITLE
fix: rewritten url not applying search params

### DIFF
--- a/.changeset/selfish-dryers-doubt.md
+++ b/.changeset/selfish-dryers-doubt.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Apply search params to rewritten URLs in matching.

--- a/packages/next-on-pages/templates/_worker.js/handleRequest.ts
+++ b/packages/next-on-pages/templates/_worker.js/handleRequest.ts
@@ -1,5 +1,10 @@
 import type { MatchedSet } from './utils';
-import { applyHeaders, isUrl, runOrFetchBuildOutputItem } from './utils';
+import {
+	applyHeaders,
+	applySearchParams,
+	isUrl,
+	runOrFetchBuildOutputItem,
+} from './utils';
 import { RoutesMatcher } from './routes-matcher';
 import type { RequestContext } from '../../src/utils/requestContext';
 
@@ -93,7 +98,9 @@ async function generateResponse(
 		resp = new Response(body, { status });
 	} else if (isUrl(path)) {
 		// If the path is an URL from matching, that means it was rewritten to a full URL.
-		resp = await fetch(new URL(path), reqCtx.request);
+		const url = new URL(path);
+		applySearchParams(url.searchParams, searchParams);
+		resp = await fetch(url, reqCtx.request);
 	} else {
 		// Otherwise, we need to serve a file from the Vercel build output.
 		resp = await runOrFetchBuildOutputItem(output[path], reqCtx, {

--- a/packages/next-on-pages/tests/templates/handleRequest.test.ts
+++ b/packages/next-on-pages/tests/templates/handleRequest.test.ts
@@ -99,7 +99,7 @@ async function runTestSet({ config, files, testCases }: TestSet) {
 		const url = new URL(req.url);
 
 		if (url.hostname === 'external-test-url.com') {
-			return new Response('external test url response');
+			return new Response(`external test url response: ${url.href}`);
 		}
 
 		return originalFetch(...args);

--- a/packages/next-on-pages/tests/templates/requestTestData/configRewritesRedirectsHeaders.ts
+++ b/packages/next-on-pages/tests/templates/requestTestData/configRewritesRedirectsHeaders.ts
@@ -165,10 +165,10 @@ export const testSet: TestSet = {
 		},
 		{
 			name: 'rewrites - `fallback`: rewrites on any request that has not been matched',
-			paths: ['/plain'],
+			paths: ['/plain?test=1'],
 			expected: {
 				status: 200,
-				data: 'external test url response',
+				data: 'external test url response: https://external-test-url.com/plain?test=1',
 				headers: {
 					'content-type': 'text/plain;charset=UTF-8',
 				},


### PR DESCRIPTION
This PR does the following:
- Applies search params to rewritten URLs during routing.
- Updates the relevant test.

fixes #429