### PR TITLE
include templates in next-on-pages lint script

### DIFF
--- a/packages/next-on-pages/package.json
+++ b/packages/next-on-pages/package.json
@@ -3,7 +3,7 @@
 	"version": "1.5.1",
 	"bin": "./bin/index.js",
 	"scripts": {
-		"lint": "eslint src",
+		"lint": "eslint src templates",
 		"types-check": "tsc --noEmit",
 		"build": "esbuild --bundle --platform=node ./src/index.ts --external:esbuild --external:chokidar --outfile=./dist/index.js",
 		"build:watch": "npm run build -- --watch=forever",

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -476,7 +476,7 @@ export class RoutesMatcher {
 				// This happens with invalid `/_next/static/...` and `/_next/data/...` requests.
 
 				if (phase !== 'miss') {
-					return await this.checkPhase(getNextPhase(phase));
+					return this.checkPhase(getNextPhase(phase));
 				}
 
 				this.status = 404;
@@ -485,7 +485,7 @@ export class RoutesMatcher {
 				// avoids rewrites in `none` that do the opposite of those in `miss`, and would cause infinite
 				// loops (e.g. i18n). If it is in the build output, remove a potentially applied `404` status.
 				if (!(this.path in this.output)) {
-					return await this.checkPhase('filesystem');
+					return this.checkPhase('filesystem');
 				}
 
 				if (this.status === 404) {
@@ -494,7 +494,7 @@ export class RoutesMatcher {
 			} else {
 				// In all other instances, we need to enter the `none` phase so we can ensure that requests
 				// for the `RSC` variant of pages are served correctly.
-				return await this.checkPhase('none');
+				return this.checkPhase('none');
 			}
 		}
 
@@ -577,7 +577,7 @@ export class RoutesMatcher {
 			nextPhase = getNextPhase(phase);
 		}
 
-		return await this.checkPhase(nextPhase);
+		return this.checkPhase(nextPhase);
 	}
 
 	/**


### PR DESCRIPTION
The next-on-pages lint script was wrongfully not including the templates directory so I am adding it so that we correctly get lints checks there
