### PR TITLE
Add vercel@32 as a peer dependency

### DIFF
--- a/.changeset/sweet-grapes-dance.md
+++ b/.changeset/sweet-grapes-dance.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Add vercel@32 as a peer dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -20093,7 +20093,7 @@
 				"vitest-environment-miniflare": "^2.13.0"
 			},
 			"peerDependencies": {
-				"vercel": "^30.0.0",
+				"vercel": "^30.0.0 || ^31.0.0 || ^32.0.0",
 				"wrangler": "^3.0.0"
 			}
 		},

--- a/packages/next-on-pages/package.json
+++ b/packages/next-on-pages/package.json
@@ -44,7 +44,7 @@
 		"zodcli": "^0.0.4"
 	},
 	"peerDependencies": {
-		"vercel": "^30.0.0 || ^31.0.0",
+		"vercel": "^30.0.0 || ^31.0.0 || ^32.0.0",
 		"wrangler": "^3.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
[vercel@32](https://github.com/vercel/vercel/releases/tag/vercel%4032.0.0) has been released.
The only major change is that the Node.js minimum has been raised, so adding it to peer dependencies should not be a problem.