### PR TITLE
fix: `process.env` not enumerable due to being a proxy

### DIFF
--- a/.changeset/five-rules-call.md
+++ b/.changeset/five-rules-call.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix `process.env` not being enumerable due to being a proxy.

--- a/packages/next-on-pages/src/buildApplication/generateGlobalJs.ts
+++ b/packages/next-on-pages/src/buildApplication/generateGlobalJs.ts
@@ -21,7 +21,7 @@ export function generateGlobalJs(): string {
 					{},
 					{
 						ownKeys: () => Reflect.ownKeys(envAsyncLocalStorage.getStore()),
-						getOwnPropertyDescriptor: () => ({ enumerable: true, configurable: true }),
+            getOwnPropertyDescriptor: (_, ...args) => Object.getOwnPropertyDescriptor(als.getStore(), ...args),
 						get: (_, property) => Reflect.get(envAsyncLocalStorage.getStore(), property),
 						set: (_, property, value) => Reflect.set(envAsyncLocalStorage.getStore(), property, value),
 				}),

--- a/packages/next-on-pages/src/buildApplication/generateGlobalJs.ts
+++ b/packages/next-on-pages/src/buildApplication/generateGlobalJs.ts
@@ -21,7 +21,8 @@ export function generateGlobalJs(): string {
 					{},
 					{
 						ownKeys: () => Reflect.ownKeys(envAsyncLocalStorage.getStore()),
-            getOwnPropertyDescriptor: (_, ...args) => Object.getOwnPropertyDescriptor(als.getStore(), ...args),
+						getOwnPropertyDescriptor: (_, ...args) =>
+							Reflect.getOwnPropertyDescriptor(envAsyncLocalStorage.getStore(), ...args),
 						get: (_, property) => Reflect.get(envAsyncLocalStorage.getStore(), property),
 						set: (_, property, value) => Reflect.set(envAsyncLocalStorage.getStore(), property, value),
 				}),

--- a/packages/next-on-pages/src/buildApplication/generateGlobalJs.ts
+++ b/packages/next-on-pages/src/buildApplication/generateGlobalJs.ts
@@ -20,6 +20,8 @@ export function generateGlobalJs(): string {
 				env: new Proxy(
 					{},
 					{
+						ownKeys: () => Reflect.ownKeys(envAsyncLocalStorage.getStore()),
+						getOwnPropertyDescriptor: () => ({ enumerable: true, configurable: true }),
 						get: (_, property) => Reflect.get(envAsyncLocalStorage.getStore(), property),
 						set: (_, property, value) => Reflect.set(envAsyncLocalStorage.getStore(), property, value),
 				}),


### PR DESCRIPTION
This PR does the following:
- Allows `process.env` to be enumerated over.

This enables things like `Object.entries(process.env)` to work when it's a proxy.