### PR TITLE
fix: broken function entrypoints on windows

### DIFF
--- a/.changeset/orange-swans-peel.md
+++ b/.changeset/orange-swans-peel.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Normalize the injected function entrypoints for Windows.

--- a/packages/next-on-pages/src/buildApplication/buildWorkerFile.ts
+++ b/packages/next-on-pages/src/buildApplication/buildWorkerFile.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'os';
 import { generateGlobalJs } from './generateGlobalJs';
 import type { ProcessedVercelOutput } from './processVercelOutput';
 import { getNodeEnv } from '../utils/getNodeEnv';
+import { normalizePath } from '../utils';
 
 /**
  * Construct a record for the build output map.
@@ -31,12 +32,10 @@ export function constructBuildOutputRecord(
 
 	return `{
 				type: ${JSON.stringify(item.type)},
-				entrypoint: '${item.entrypoint
-					.replace(outputDir, '')
-					.replace(
-						/^\/_worker\.js\/__next-on-pages-dist__\//,
-						'./__next-on-pages-dist__/',
-					)}'
+				entrypoint: '${normalizePath(item.entrypoint.replace(outputDir, '')).replace(
+					/^\/_worker\.js\/__next-on-pages-dist__\//,
+					'./__next-on-pages-dist__/',
+				)}'
 			}`;
 }
 


### PR DESCRIPTION
This PR does the following:
- Normalizes the injected entrypoint for Windows platforms.

This fixes an issue where the function entrypoint we inject breaks as it might use double backslashes on Windows because, well, Windows has to ruin everything.

```
"/api/hello":{type:"function",entrypoint:"__next-on-pages-dist__\functionsapihello.func.js"}
```