### PR TITLE
fix: named captures in `has` fields not applying to route dest

### DIFF
--- a/.changeset/famous-dragons-joke.md
+++ b/.changeset/famous-dragons-joke.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': patch
 ---
 
-Fix named capture groups in query param `has` entries in the build output config not applying to route destination paths.
+Fix named capture groups in `has` entries in the build output config not applying to route destination paths.

--- a/.changeset/famous-dragons-joke.md
+++ b/.changeset/famous-dragons-joke.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix named capture groups in query param `has` entries in the build output config not applying to route destination paths.

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -5,7 +5,7 @@ import {
 	applyHeaders,
 	applyPCREMatches,
 	applySearchParams,
-	hasField,
+	checkhasField,
 	getNextPhase,
 	isUrl,
 	matchPCRE,
@@ -115,7 +115,7 @@ export class RoutesMatcher {
 		// All `has` conditions must be met - skip if one is not met.
 		if (
 			route.has?.find(has => {
-				const result = hasField(has, hasFieldProps);
+				const result = checkhasField(has, hasFieldProps);
 				if (result.newRouteDest) {
 					// If the `has` condition had a named capture to update the destination, update it.
 					hasFieldProps.routeDest = result.newRouteDest;
@@ -127,7 +127,7 @@ export class RoutesMatcher {
 		}
 
 		// All `missing` conditions must not be met - skip if one is met.
-		if (route.missing?.find(has => hasField(has, hasFieldProps).valid)) {
+		if (route.missing?.find(has => checkhasField(has, hasFieldProps).valid)) {
 			return;
 		}
 

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -91,7 +91,7 @@ export class RoutesMatcher {
 	private checkRouteMatch(
 		route: VercelSource,
 		checkStatus?: boolean,
-	): MatchPCREResult | undefined {
+	): { routeMatch: MatchPCREResult; routeDest?: string } | undefined {
 		const srcMatch = matchPCRE(route.src, this.path, route.caseSensitive);
 		if (!srcMatch.match) return;
 
@@ -109,15 +109,25 @@ export class RoutesMatcher {
 			url: this.url,
 			cookies: this.cookies,
 			headers: this.reqCtx.request.headers,
+			routeDest: route.dest,
 		};
 
 		// All `has` conditions must be met - skip if one is not met.
-		if (route.has?.find(has => !hasField(has, hasFieldProps))) {
+		if (
+			route.has?.find(has => {
+				const result = hasField(has, hasFieldProps);
+				if (result.newRouteDest) {
+					// If the `has` condition had a named capture to update the destination, update it.
+					hasFieldProps.routeDest = result.newRouteDest;
+				}
+				return !result.valid;
+			})
+		) {
 			return;
 		}
 
 		// All `missing` conditions must not be met - skip if one is met.
-		if (route.missing?.find(has => hasField(has, hasFieldProps))) {
+		if (route.missing?.find(has => hasField(has, hasFieldProps).valid)) {
 			return;
 		}
 
@@ -126,7 +136,7 @@ export class RoutesMatcher {
 			return;
 		}
 
-		return srcMatch;
+		return { routeMatch: srcMatch, routeDest: hasFieldProps.routeDest };
 	}
 
 	/**
@@ -428,8 +438,11 @@ export class RoutesMatcher {
 		phase: VercelPhase,
 		rawRoute: VercelSource,
 	): Promise<CheckRouteStatus> {
-		const route = this.getLocaleFriendlyRoute(rawRoute, phase);
-		const routeMatch = this.checkRouteMatch(route, phase === 'error');
+		const localeFriendlyRoute = this.getLocaleFriendlyRoute(rawRoute, phase);
+		const { routeMatch, routeDest } =
+			this.checkRouteMatch(localeFriendlyRoute, phase === 'error') ?? {};
+
+		const route: VercelSource = { ...localeFriendlyRoute, dest: routeDest };
 
 		// If this route doesn't match, continue to the next one.
 		if (!routeMatch?.match) return 'skip';

--- a/packages/next-on-pages/templates/_worker.js/utils/pcre.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/pcre.ts
@@ -20,7 +20,7 @@ export type MatchPCREResult = {
 export function matchPCRE(
 	expr: string,
 	val: string | undefined | null,
-	caseSensitive?: boolean
+	caseSensitive?: boolean,
 ): MatchPCREResult {
 	if (val === null || val === undefined) {
 		return { match: null, captureGroupKeys: [] };
@@ -41,13 +41,14 @@ export function matchPCRE(
  * @param rawStr String to process.
  * @param match Matches from the PCRE matcher.
  * @param captureGroupKeys Named capture group keys from the PCRE matcher.
+ * @param opts Options for applying the PCRE matches.
  * @returns The processed string with replaced parameters.
  */
 export function applyPCREMatches(
 	rawStr: string,
 	match: RegExpMatchArray,
 	captureGroupKeys: string[],
-	{ namedOnly }: { namedOnly?: boolean } = {}
+	{ namedOnly }: { namedOnly?: boolean } = {},
 ): string {
 	return rawStr.replace(/\$([a-zA-Z0-9_]+)/g, (originalValue, key) => {
 		const index = captureGroupKeys.indexOf(key);

--- a/packages/next-on-pages/templates/_worker.js/utils/pcre.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/pcre.ts
@@ -19,9 +19,13 @@ export type MatchPCREResult = {
  */
 export function matchPCRE(
 	expr: string,
-	val: string,
-	caseSensitive?: boolean,
+	val: string | undefined | null,
+	caseSensitive?: boolean
 ): MatchPCREResult {
+	if (val === null || val === undefined) {
+		return { match: null, captureGroupKeys: [] };
+	}
+
 	const flag = caseSensitive ? '' : 'i';
 	const captureGroupKeys: string[] = [];
 
@@ -43,9 +47,16 @@ export function applyPCREMatches(
 	rawStr: string,
 	match: RegExpMatchArray,
 	captureGroupKeys: string[],
+	{ namedOnly }: { namedOnly?: boolean } = {}
 ): string {
-	return rawStr.replace(/\$([a-zA-Z0-9_]+)/g, (_, key) => {
+	return rawStr.replace(/\$([a-zA-Z0-9_]+)/g, (originalValue, key) => {
 		const index = captureGroupKeys.indexOf(key);
+
+		// If we only want named capture groups, and the key is not found, return the original value.
+		if (namedOnly && index === -1) {
+			return originalValue;
+		}
+
 		// If the extracted key does not exist as a named capture group from the matcher, we can
 		// reasonably assume it's a number and return the matched index. Fallback to an empty string.
 		return (index === -1 ? match[parseInt(key, 10)] : match[index + 1]) || '';

--- a/packages/next-on-pages/tests/templates/utils/matcher.test.ts
+++ b/packages/next-on-pages/tests/templates/utils/matcher.test.ts
@@ -10,12 +10,13 @@ type HasFieldTestCase = {
 };
 
 const req = new Request(
-	'https://test.com/index?queryWithValue=value&queryWithoutValue=&name=john',
+	'https://test.com/index?queryWithValue=value&queryWithoutValue=&source=query',
 	{
 		headers: {
+			source: 'header',
 			headerWithValue: 'value',
 			headerWithoutValue: undefined as unknown as string,
-			cookie: 'cookieWithValue=value; cookieWithoutValue=',
+			cookie: 'cookieWithValue=value; cookieWithoutValue=; source=cookie',
 		},
 	},
 );
@@ -91,27 +92,39 @@ describe('hasField', () => {
 		},
 		{
 			name: 'query: has with named capture returns a new dest on match',
-			has: { type: 'query', key: 'name', value: '(?<name>.*)' },
-			dest: '/test/$name',
-			expected: { valid: true, newRouteDest: '/test/john' },
+			has: { type: 'query', key: 'source', value: '(?<source>.*)' },
+			dest: '/source/$source',
+			expected: { valid: true, newRouteDest: '/source/query' },
 		},
 		{
 			name: 'query: has with named capture does not update missing named captures in dest',
-			has: { type: 'query', key: 'name', value: '(?<name>.*)' },
-			dest: '/test/$name/$age',
-			expected: { valid: true, newRouteDest: '/test/john/$age' },
+			has: { type: 'query', key: 'source', value: '(?<source>.*)' },
+			dest: '/source/$source/$age',
+			expected: { valid: true, newRouteDest: '/source/query/$age' },
 		},
 		{
 			name: 'query: has with named capture return valid on match when key is not in dest',
-			has: { type: 'query', key: 'name', value: '(?<name>.*)' },
-			dest: '/test/$age',
-			expected: { valid: true, newRouteDest: '/test/$age' },
+			has: { type: 'query', key: 'source', value: '(?<source>.*)' },
+			dest: '/source/$age',
+			expected: { valid: true, newRouteDest: '/source/$age' },
 		},
 		{
 			name: 'query: has with named capture does not return dest on no matches',
-			has: { type: 'query', key: 'invalidKey', value: '(?<name>.*)' },
-			dest: '/test/$name',
+			has: { type: 'query', key: 'invalidKey', value: '(?<source>.*)' },
+			dest: '/source/$source',
 			expected: { valid: false, newRouteDest: undefined },
+		},
+		{
+			name: 'header: has with named capture returns a new dest on match',
+			has: { type: 'header', key: 'source', value: '(?<source>.*)' },
+			dest: '/source/$source',
+			expected: { valid: true, newRouteDest: '/source/header' },
+		},
+		{
+			name: 'cookie: has with named capture returns a new dest on match',
+			has: { type: 'cookie', key: 'source', value: '(?<source>.*)' },
+			dest: '/source/$source',
+			expected: { valid: true, newRouteDest: '/source/cookie' },
 		},
 	];
 

--- a/packages/next-on-pages/tests/templates/utils/matcher.test.ts
+++ b/packages/next-on-pages/tests/templates/utils/matcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest';
 import { parse } from 'cookie';
-import { hasField } from '../../../templates/_worker.js/utils';
+import { checkhasField } from '../../../templates/_worker.js/utils';
 
 type HasFieldTestCase = {
 	name: string;
@@ -23,7 +23,7 @@ const req = new Request(
 const url = new URL(req.url);
 const cookies = parse(req.headers.get('cookie') ?? '');
 
-describe('hasField', () => {
+describe('checkhasField', () => {
 	const testCases: HasFieldTestCase[] = [
 		{
 			name: 'host: valid host returns true',
@@ -130,7 +130,7 @@ describe('hasField', () => {
 
 	testCases.forEach(testCase => {
 		test(testCase.name, () => {
-			const result = hasField(testCase.has, {
+			const result = checkhasField(testCase.has, {
 				url,
 				cookies,
 				headers: req.headers,

--- a/packages/next-on-pages/tests/templates/utils/pcre.test.ts
+++ b/packages/next-on-pages/tests/templates/utils/pcre.test.ts
@@ -51,7 +51,7 @@ describe('matchPCRE', () => {
 			const result = matchPCRE(
 				testCase.route.src,
 				new URL(testCase.url).pathname,
-				testCase.route.caseSensitive
+				testCase.route.caseSensitive,
 			);
 			expect({ ...result, match: !!result.match }).toEqual(testCase.expected);
 		});
@@ -156,14 +156,14 @@ describe('applyPCREMatches', () => {
 			const { match, captureGroupKeys } = matchPCRE(
 				testCase.route.src,
 				new URL(testCase.url).pathname,
-				testCase.route.caseSensitive
+				testCase.route.caseSensitive,
 			);
 			const result = applyPCREMatches(
 				testCase.route.dest ?? '',
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				match!,
 				captureGroupKeys,
-				testCase.opts
+				testCase.opts,
 			);
 
 			const { newDest: expectedNewDest, ...expected } = testCase.expected;


### PR DESCRIPTION
This PR does the following:
- Changes the logic to use the PCRE match function for `has` entries as the regex is expected to be in the PCRE format.
- For PCRE matches in the `has` entries, attempts to update the route's destination with any named capture groups extracted.

Relevant docs: https://nextjs.org/docs/app/api-reference/next-config-js/rewrites#header-cookie-and-query-matching

fixes #448