### PR TITLE
Add new `helpers` sub-module with `getRequestExecutionContext`

### DIFF
--- a/.changeset/happy-beds-talk.md
+++ b/.changeset/happy-beds-talk.md
@@ -1,0 +1,14 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Add new `helpers` sub-module with `getRequestExecutionContext`.
+
+Add a new `helpers` module that will provide utilities that will allow developer to utilize better next-on-pages and the cloudflare platform.
+
+The `getRequestExecutionContext` function has been introduced with helpers.
+This function provides an execution context object (`ctx`) to the developer.
+
+This function throws an error when executed on the client.
+This function also returns a mocked context when executed in a non pages environment.
+This is useful when executing unit tests, for example, as it prevents errors from occurring.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7152,6 +7152,109 @@
 			"version": "0.0.1",
 			"license": "MIT"
 		},
+		"node_modules/concurrently": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.1.tgz",
+			"integrity": "sha512-nVraf3aXOpIcNud5pB9M82p1tynmZkrSGQ1p6X/VY8cJ+2LMVqAgXsJxYYefACSHbTYlm92O1xuhdGTjwoEvbQ==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"date-fns": "^2.30.0",
+				"lodash": "^4.17.21",
+				"rxjs": "^7.8.1",
+				"shell-quote": "^1.8.1",
+				"spawn-command": "0.0.2",
+				"supports-color": "^8.1.1",
+				"tree-kill": "^1.2.2",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"conc": "dist/bin/concurrently.js",
+				"concurrently": "dist/bin/concurrently.js"
+			},
+			"engines": {
+				"node": "^14.13.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+			}
+		},
+		"node_modules/concurrently/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/concurrently/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/concurrently/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/concurrently/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/concurrently/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
 		"node_modules/console-control-strings": {
 			"version": "1.1.0",
 			"license": "ISC",
@@ -7340,6 +7443,22 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/date-fns": {
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.21.0"
+			},
+			"engines": {
+				"node": ">=0.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/date-fns"
 			}
 		},
 		"node_modules/deasync": {
@@ -12444,8 +12563,7 @@
 		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",
@@ -15830,7 +15948,6 @@
 		"node_modules/rxjs": {
 			"version": "7.8.1",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
@@ -16002,6 +16119,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/shell-quote": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/shellac": {
@@ -16318,6 +16444,12 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/spawn-command": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+			"integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+			"dev": true
 		},
 		"node_modules/spawndamnit": {
 			"version": "2.0.0",
@@ -16940,6 +17072,15 @@
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"license": "MIT"
+		},
+		"node_modules/tree-kill": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true,
+			"bin": {
+				"tree-kill": "cli.js"
+			}
 		},
 		"node_modules/trim-newlines": {
 			"version": "3.0.1",
@@ -20597,6 +20738,7 @@
 				"@types/js-yaml": "^4.0.5",
 				"@types/mock-fs": "^4.13.1",
 				"@types/node": "^20.1.4",
+				"concurrently": "^8.2.1",
 				"dedent-tabs": "^0.10.3",
 				"eslint": "^8.35.0",
 				"image-to-base64": "^2.2.0",
@@ -22361,6 +22503,7 @@
 				"ast-types": "^0.14.2",
 				"chalk": "^5.2.0",
 				"chokidar": "^3.5.3",
+				"concurrently": "^8.2.1",
 				"cookie": "^0.5.0",
 				"dedent-tabs": "^0.10.3",
 				"esbuild": "^0.15.3",
@@ -25427,6 +25570,79 @@
 		"concat-map": {
 			"version": "0.0.1"
 		},
+		"concurrently": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.1.tgz",
+			"integrity": "sha512-nVraf3aXOpIcNud5pB9M82p1tynmZkrSGQ1p6X/VY8cJ+2LMVqAgXsJxYYefACSHbTYlm92O1xuhdGTjwoEvbQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.2",
+				"date-fns": "^2.30.0",
+				"lodash": "^4.17.21",
+				"rxjs": "^7.8.1",
+				"shell-quote": "^1.8.1",
+				"spawn-command": "0.0.2",
+				"supports-color": "^8.1.1",
+				"tree-kill": "^1.2.2",
+				"yargs": "^17.7.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^4.0.0"
+							}
+						}
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"console-control-strings": {
 			"version": "1.1.0",
 			"peer": true
@@ -25545,6 +25761,15 @@
 		"data-uri-to-buffer": {
 			"version": "3.0.1",
 			"peer": true
+		},
+		"date-fns": {
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.21.0"
+			}
 		},
 		"deasync": {
 			"version": "0.1.28",
@@ -28712,8 +28937,7 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.21",
-			"peer": true
+			"version": "4.17.21"
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
@@ -30790,7 +31014,6 @@
 		},
 		"rxjs": {
 			"version": "7.8.1",
-			"peer": true,
 			"requires": {
 				"tslib": "^2.1.0"
 			}
@@ -30908,6 +31131,12 @@
 		},
 		"shebang-regex": {
 			"version": "3.0.0"
+		},
+		"shell-quote": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+			"dev": true
 		},
 		"shellac": {
 			"version": "0.8.0",
@@ -31113,6 +31342,12 @@
 		"space-separated-tokens": {
 			"version": "2.0.2",
 			"peer": true
+		},
+		"spawn-command": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+			"integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+			"dev": true
 		},
 		"spawndamnit": {
 			"version": "2.0.0",
@@ -31546,6 +31781,12 @@
 		},
 		"tr46": {
 			"version": "0.0.3"
+		},
+		"tree-kill": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true
 		},
 		"trim-newlines": {
 			"version": "3.0.1",

--- a/packages/next-on-pages/env.d.ts
+++ b/packages/next-on-pages/env.d.ts
@@ -4,6 +4,7 @@ declare global {
 			NODE_ENV?: string;
 			npm_config_user_agent?: string;
 			CF_PAGES?: string;
+			CF_NEXT_ON_PAGES_EXECUTION_CONTEXT?: ExecutionContext;
 			SHELL?: string;
 			[key: string]: string | Fetcher;
 		}

--- a/packages/next-on-pages/package.json
+++ b/packages/next-on-pages/package.json
@@ -2,11 +2,27 @@
 	"name": "@cloudflare/next-on-pages",
 	"version": "1.6.3",
 	"bin": "./bin/index.js",
+	"exports": {
+		"./helpers": "./dist/helpers/index.js"
+	},
+	"typesVersions": {
+		"*": {
+			"helpers": [
+				"./dist/helpers/index.d.ts"
+			]
+		}
+	},
 	"scripts": {
 		"lint": "eslint src templates",
 		"types-check": "tsc --noEmit",
-		"build": "esbuild --bundle --platform=node ./src/index.ts --external:esbuild --external:chokidar --outfile=./dist/index.js",
-		"build:watch": "npm run build -- --watch=forever",
+		"build": "concurrently --raw 'npm:build:*(!watch)'",
+		"build:watch": "concurrently --raw 'npm:build:*:watch'",
+		"build:cli": "esbuild --bundle --platform=node ./src/index.ts --external:esbuild --external:chokidar --outfile=./dist/index.js",
+		"build:cli:watch": "npm run build:cli -- --watch=forever",
+		"build:helpers": "npx esbuild --bundle --platform=node --format=esm ./src/helpers/index.ts --external:esbuild --external:chokidar --outfile=./dist/helpers/index.js",
+		"build:helpers-types": "tsc  -p ./src/helpers --emitDeclarationOnly --declaration --outDir ./dist/helpers",
+		"build:helpers:watch": "npm run build:helpers -- --watch=forever",
+		"build:helpers-types:watch": " npm run build:helpers-types -- --watch",
 		"postbuild": "node ./build-no-nodejs-compat-flag-static-error-page.mjs",
 		"prepare": "npm run build",
 		"test:unit": "npx vitest --config vitest.config.ts"
@@ -59,6 +75,7 @@
 		"@types/js-yaml": "^4.0.5",
 		"@types/mock-fs": "^4.13.1",
 		"@types/node": "^20.1.4",
+		"concurrently": "^8.2.1",
 		"dedent-tabs": "^0.10.3",
 		"eslint": "^8.35.0",
 		"mock-fs": "^5.2.0",

--- a/packages/next-on-pages/src/helpers/getRequestExecutionContext.ts
+++ b/packages/next-on-pages/src/helpers/getRequestExecutionContext.ts
@@ -1,0 +1,36 @@
+/**
+ * returns the request's execution context (usually referred as ctx).
+ *
+ * Note:
+ *   This function throws when run on the client, where there is execution context.
+ *   This function returns the mocked execution context in non pages environments.
+ *
+ * @returns the request's execution context
+ */
+export const getRequestExecutionContext = (): ExecutionContext => {
+	if (typeof process === 'undefined') {
+		throw new Error(
+			'Error: trying to access the request execution context on the client',
+		);
+	}
+
+	const context = process.env.CF_NEXT_ON_PAGES_EXECUTION_CONTEXT;
+	if (context) return context;
+
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		waitUntil: (promise: Promise<any>) => {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'The mocked waitUntil function is executed. It may behave differently from the pages environment.',
+			);
+			void promise;
+		},
+		passThroughOnException: () => {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'The mocked passThroughOnException function is executed. It may behave differently from the pages environment.',
+			);
+		},
+	};
+};

--- a/packages/next-on-pages/src/helpers/index.ts
+++ b/packages/next-on-pages/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './getRequestExecutionContext';

--- a/packages/next-on-pages/src/helpers/tsconfig.json
+++ b/packages/next-on-pages/src/helpers/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"types": ["node", "@cloudflare/workers-types"],
+		"declaration": true,
+		"declarationMap": true
+	},
+	"include": [".", "../../env.d.ts"]
+}

--- a/packages/next-on-pages/templates/_worker.js/index.ts
+++ b/packages/next-on-pages/templates/_worker.js/index.ts
@@ -33,7 +33,12 @@ export default {
 
 		return envAsyncLocalStorage.run(
 			// NOTE: The `SUSPENSE_CACHE_URL` is used to tell the Next.js Fetch Cache where to send requests.
-			{ ...env, NODE_ENV: __NODE_ENV__, SUSPENSE_CACHE_URL },
+			{
+				...env,
+				NODE_ENV: __NODE_ENV__,
+				SUSPENSE_CACHE_URL,
+				CF_NEXT_ON_PAGES_EXECUTION_CONTEXT: ctx,
+			},
 			async () => {
 				const url = new URL(request.url);
 				if (url.pathname.startsWith('/_next/image')) {


### PR DESCRIPTION
Add a helper function where ExecutionContext can be retrieved.
If you don't like this API, it's not a problem to close it.

We are currently using it in our project, and it's working well.
https://github.com/looks-to-me/looks-to-me/blob/3b5393ecc95e6e1af3e8bbd949ba5a246a23ec47/app/src/app/(main)/images/posts/%5Bid%5D/route.ts#L60 

This implementation is based on the following pull request for reference.
- #233
- #265