### PR TITLE
fix: dynamic params with underscore not applying correctly

### DIFF
--- a/.changeset/old-sheep-visit.md
+++ b/.changeset/old-sheep-visit.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix dynamic parameters with an underscore leading to an incorrect param being provided.

--- a/packages/next-on-pages/templates/_worker.js/utils/pcre.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/pcre.ts
@@ -44,7 +44,7 @@ export function applyPCREMatches(
 	match: RegExpMatchArray,
 	captureGroupKeys: string[],
 ): string {
-	return rawStr.replace(/\$([a-zA-Z0-9]+)/g, (_, key) => {
+	return rawStr.replace(/\$([a-zA-Z0-9_]+)/g, (_, key) => {
 		const index = captureGroupKeys.indexOf(key);
 		// If the extracted key does not exist as a named capture group from the matcher, we can
 		// reasonably assume it's a number and return the matched index. Fallback to an empty string.

--- a/packages/next-on-pages/tests/templates/utils/pcre.test.ts
+++ b/packages/next-on-pages/tests/templates/utils/pcre.test.ts
@@ -127,6 +127,16 @@ describe('applyPCREMatches', () => {
 				newDest: '/new/nde/dest?id=',
 			},
 		},
+		{
+			name: 'should process dest for a route with named group containing underscore',
+			url: 'https://example.com/index',
+			route: { src: '^/i(?<na_me>nde)x(?:/)?', dest: '/new/$na_me/dest' },
+			expected: {
+				match: true,
+				captureGroupKeys: ['na_me'],
+				newDest: '/new/nde/dest',
+			},
+		},
 	];
 
 	testCases.forEach(testCase => {


### PR DESCRIPTION
This PR does the following:
- Accounts for underscores when applying PCRE matches.

NOTE: Vercel does not include the underscore in the [code](https://github.com/vercel/vercel/blob/0a08e4b/packages/cli/src/util/dev/router.ts#L16) that I used as a reference when originally writing this. I am sceptical as to whether we should proceed with this, but as it works in `next dev`, I imagine we should go ahead with it.

fixes https://github.com/cloudflare/next-on-pages/issues/453