### PR TITLE
fix: ignore invalid i18n functions with valid alternatives

### DIFF
--- a/.changeset/rich-squids-visit.md
+++ b/.changeset/rich-squids-visit.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Ignore invalid nodejs i18n functions with valid alternatives.

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -107,6 +107,7 @@ async function prepareAndBuildWorker(
 			workerJsDir,
 			nopDistDir: join(workerJsDir, '__next-on-pages-dist__'),
 			disableChunksDedup,
+			vercelConfig,
 		});
 	}
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/configs.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/configs.ts
@@ -63,7 +63,7 @@ export type CollectedFunctions = {
 	edgeFunctions: Map<string, FunctionInfo>;
 	prerenderedFunctions: Map<string, FunctionInfo>;
 	invalidFunctions: Map<string, FunctionInfo>;
-	ignoredFunctions: Map<string, FunctionInfo>;
+	ignoredFunctions: Map<string, FunctionInfo & { reason?: string }>;
 };
 
 export type FunctionInfo = {

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/edgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/edgeFunctions.ts
@@ -93,7 +93,7 @@ async function checkEntrypoint(
 	entrypoint: string,
 ): Promise<
 	| { value: 'invalid' }
-	| { value: 'ignore', reason: string }
+	| { value: 'ignore'; reason: string }
 	| { value: 'valid'; finalEntrypoint: string }
 > {
 	let finalEntrypoint = entrypoint;

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/edgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/edgeFunctions.ts
@@ -54,7 +54,10 @@ export async function processEdgeFunctions(
 				break;
 			}
 			case 'ignore': {
-				ignoredFunctions.set(path, fnInfo);
+				ignoredFunctions.set(path, {
+					reason: entrypointStatus.reason,
+					...fnInfo,
+				});
 				edgeFunctions.delete(path);
 				break;
 			}
@@ -89,7 +92,8 @@ async function checkEntrypoint(
 	relativePath: string,
 	entrypoint: string,
 ): Promise<
-	{ value: 'ignore' | 'invalid' } | { value: 'valid'; finalEntrypoint: string }
+	| { value: 'ignore' | 'invalid'; reason?: string }
+	| { value: 'valid'; finalEntrypoint: string }
 > {
 	let finalEntrypoint = entrypoint;
 
@@ -109,7 +113,7 @@ async function checkEntrypoint(
 			cliWarn(
 				`Detected an invalid middleware function for ${relativePath}. Skipping...`,
 			);
-			return { value: 'ignore' };
+			return { value: 'ignore', reason: 'invalid middleware function' };
 		}
 
 		return { value: 'invalid' };
@@ -196,7 +200,10 @@ function replaceRscWithNonRsc(
 			tempFunctionsMap.delete(formattedPath);
 			edgeFunctions.delete(path);
 			invalidFunctions.delete(path);
-			ignoredFunctions.set(path, rscFnInfo);
+			ignoredFunctions.set(path, {
+				reason: 'unnecessary rsc function',
+				...rscFnInfo,
+			});
 		}
 	}
 }

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/edgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/edgeFunctions.ts
@@ -92,7 +92,8 @@ async function checkEntrypoint(
 	relativePath: string,
 	entrypoint: string,
 ): Promise<
-	| { value: 'ignore' | 'invalid'; reason?: string }
+	| { value: 'invalid' }
+	| { value: 'ignore', reason: string }
 	| { value: 'valid'; finalEntrypoint: string }
 > {
 	let finalEntrypoint = entrypoint;

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/index.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/index.ts
@@ -23,7 +23,7 @@ export async function processVercelFunctions(
 
 	await processEdgeFunctions(collectedFunctions);
 
-	await checkInvalidFunctions(collectedFunctions);
+	await checkInvalidFunctions(collectedFunctions, opts);
 
 	const identifiers = await dedupeEdgeFunctions(collectedFunctions, opts);
 
@@ -36,6 +36,7 @@ export type ProcessVercelFunctionsOpts = {
 	workerJsDir: string;
 	nopDistDir: string;
 	disableChunksDedup?: boolean;
+	vercelConfig: VercelConfig;
 };
 
 export type ProcessedVercelFunctions = {

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
@@ -110,6 +110,11 @@ async function tryToFixI18nFunctions(
 		return acc;
 	}, new Set<string>());
 
+	if (!foundI18nKeys.size) {
+		// no i18n keys found in the build output config, so we can't fix anything
+		return;
+	}
+
 	for (const [fullPath, fnInfo] of invalidFunctions.entries()) {
 		for (const i18nKey of foundI18nKeys) {
 			const firstRouteSegment = stripFuncExtension(fnInfo.relativePath)

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
@@ -4,6 +4,7 @@ import { getPackageVersion } from '../packageManagerUtils';
 import { stripFuncExtension } from '../../utils';
 import type { CollectedFunctions, FunctionInfo } from './configs';
 import { join, resolve } from 'path';
+import type { ProcessVercelFunctionsOpts } from '.';
 
 /**
  * Checks if there are any invalid functions from the Vercel build output.
@@ -14,11 +15,15 @@ import { join, resolve } from 'path';
  * If however the build output can't be used, an error message will be printed and the process will exit.
  *
  * @param collectedFunctions Collected functions from the Vercel build output.
+ * @param opts Options for processing Vercel functions.
  */
 export async function checkInvalidFunctions(
 	collectedFunctions: CollectedFunctions,
+	opts: Pick<ProcessVercelFunctionsOpts, 'functionsDir' | 'vercelConfig'>,
 ): Promise<void> {
 	await tryToFixNotFoundRoute(collectedFunctions);
+
+	await tryToFixI18nFunctions(collectedFunctions, opts);
 
 	if (collectedFunctions.invalidFunctions.size > 0) {
 		await printInvalidFunctionsErrorMessage(
@@ -68,6 +73,64 @@ async function tryToFixNotFoundRoute(
 			not supported by @cloudflare/next-on-pages, if that's actually the case please
 			remove the runtime logic from your not-found route
 		`);
+	}
+}
+
+/**
+ * Tries to fix potential unnecessary and invalid i18n functions from the Vercel build output.
+ *
+ * This is a workaround for Vercel creating invalid Node.js i18n functions in the build output, and
+ * is achieved by combing through the Vercel build output config to find i18n keys that match the
+ * invalid functions.
+ *
+ * @param collectedFunctions Collected functions from the Vercel build output.
+ * @param opts Options for processing Vercel functions.
+ */
+async function tryToFixI18nFunctions(
+	{ edgeFunctions, invalidFunctions, ignoredFunctions }: CollectedFunctions,
+	{
+		vercelConfig,
+		functionsDir,
+	}: Pick<ProcessVercelFunctionsOpts, 'functionsDir' | 'vercelConfig'>,
+): Promise<void> {
+	if (!invalidFunctions.size || !vercelConfig.routes?.length) {
+		return;
+	}
+
+	const foundI18nKeys = vercelConfig.routes.reduce((acc, route) => {
+		if ('handle' in route) return acc;
+
+		// Matches the format used in certain source route entries in the build output config.
+		// e.g. "src": "/(?<nextLocale>default|en|ja)(/.*|$)"
+		/\(\??<nextLocale>([^)]+)\)/
+			.exec(route.src)?.[1]
+			?.split('|')
+			?.forEach(locale => acc.add(locale));
+
+		return acc;
+	}, new Set<string>());
+
+	for (const [fullPath, fnInfo] of invalidFunctions.entries()) {
+		for (const i18nKey of foundI18nKeys) {
+			const firstRouteSegment = stripFuncExtension(fnInfo.relativePath)
+				.replace(/^\//, '')
+				.split('/')[0];
+
+			if (firstRouteSegment === i18nKey) {
+				const pathWithoutI18nKey = fnInfo.relativePath
+					.replace(new RegExp(`^/${i18nKey}.func`), '/index.func')
+					.replace(new RegExp(`^/${i18nKey}/`), '/');
+				const fullPathWithoutI18nKey = join(functionsDir, pathWithoutI18nKey);
+
+				if (edgeFunctions.has(fullPathWithoutI18nKey)) {
+					invalidFunctions.delete(fullPath);
+					ignoredFunctions.set(fullPath, {
+						reason: 'unnecessary invalid i18n function',
+						...fnInfo,
+					});
+				}
+			}
+		}
 	}
 }
 

--- a/packages/next-on-pages/tests/_helpers/index.ts
+++ b/packages/next-on-pages/tests/_helpers/index.ts
@@ -403,8 +403,9 @@ export async function collectFunctionsFrom(
 	});
 
 	await processOutputDir(outputDir, await getVercelStaticAssets());
-	const collectedFunctions =
-		await collectFunctionConfigsRecursively(functionsDir);
+	const collectedFunctions = await collectFunctionConfigsRecursively(
+		functionsDir,
+	);
 
 	return { collectedFunctions, restoreFsMock: () => mockFs.restore() };
 }

--- a/packages/next-on-pages/tests/_helpers/index.ts
+++ b/packages/next-on-pages/tests/_helpers/index.ts
@@ -222,6 +222,7 @@ export async function createRouterTestData(
 		workerJsDir: workerJsDir,
 		nopDistDir: join(workerJsDir, '__next-on-pages-dist__'),
 		disableChunksDedup: true,
+		vercelConfig: { version: 3 },
 	});
 
 	const staticAssets = await getVercelStaticAssets();

--- a/packages/next-on-pages/tests/_helpers/index.ts
+++ b/packages/next-on-pages/tests/_helpers/index.ts
@@ -403,9 +403,8 @@ export async function collectFunctionsFrom(
 	});
 
 	await processOutputDir(outputDir, await getVercelStaticAssets());
-	const collectedFunctions = await collectFunctionConfigsRecursively(
-		functionsDir,
-	);
+	const collectedFunctions =
+		await collectFunctionConfigsRecursively(functionsDir);
 
 	return { collectedFunctions, restoreFsMock: () => mockFs.restore() };
 }

--- a/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/invalidFunctions.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/invalidFunctions.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, afterEach, vi } from 'vitest';
+import mockFs from 'mock-fs';
+import {
+	collectFunctionsFrom,
+	mockConsole,
+	edgeFuncDir,
+	nodejsFuncDir,
+	getRouteInfo,
+} from '../../../_helpers';
+import { resolve } from 'path';
+import { processEdgeFunctions } from '../../../../src/buildApplication/processVercelFunctions/edgeFunctions';
+import { checkInvalidFunctions } from '../../../../src/buildApplication/processVercelFunctions/invalidFunctions';
+
+const functionsDir = resolve('.vercel/output/functions');
+
+describe('checkInvalidFunctions', () => {
+	afterEach(() => mockFs.restore());
+
+	test('should ignore i18n index with valid alternative', async () => {
+		const { collectedFunctions, restoreFsMock } = await collectFunctionsFrom({
+			functions: {
+				'index.func': edgeFuncDir,
+				'en.func': nodejsFuncDir,
+			},
+		});
+
+		await processEdgeFunctions(collectedFunctions);
+		await checkInvalidFunctions(collectedFunctions, {
+			functionsDir,
+			vercelConfig: {
+				version: 3,
+				routes: [{ src: '/(?<nextLocale>fr|en|nl)(/.*|$)' }],
+			},
+		});
+		restoreFsMock();
+
+		const { edgeFunctions, invalidFunctions } = collectedFunctions;
+
+		expect(edgeFunctions.size).toEqual(1);
+		expect(getRouteInfo(edgeFunctions, 'index.func')).toEqual({
+			path: '/index',
+			overrides: ['/'],
+		});
+
+		expect(invalidFunctions.size).toEqual(0);
+	});
+
+	test('should ignore i18n nested route with valid alternative', async () => {
+		const { collectedFunctions, restoreFsMock } = await collectFunctionsFrom({
+			functions: {
+				test: { 'route.func': edgeFuncDir },
+				en: { test: { 'route.func': nodejsFuncDir } },
+			},
+		});
+
+		await processEdgeFunctions(collectedFunctions);
+		await checkInvalidFunctions(collectedFunctions, {
+			functionsDir,
+			vercelConfig: {
+				version: 3,
+				routes: [{ src: '/(?<nextLocale>fr|en|nl)(/.*|$)' }],
+			},
+		});
+		restoreFsMock();
+
+		const { edgeFunctions, invalidFunctions } = collectedFunctions;
+
+		expect(edgeFunctions.size).toEqual(1);
+		expect(getRouteInfo(edgeFunctions, 'test/route.func')).toEqual({
+			path: '/test/route',
+			overrides: [],
+		});
+
+		expect(invalidFunctions.size).toEqual(0);
+	});
+
+	test('should not ignore i18n with no valid alternative', async () => {
+		const processExitMock = vi
+			.spyOn(process, 'exit')
+			.mockImplementation(async () => undefined as never);
+		const mockedConsole = mockConsole('error');
+
+		const { collectedFunctions, restoreFsMock } = await collectFunctionsFrom({
+			functions: {
+				'en.func': nodejsFuncDir,
+			},
+		});
+
+		await processEdgeFunctions(collectedFunctions);
+		await checkInvalidFunctions(collectedFunctions, {
+			functionsDir,
+			vercelConfig: {
+				version: 3,
+				routes: [{ src: '/(?<nextLocale>fr|en|nl)(/.*|$)' }],
+			},
+		});
+		restoreFsMock();
+
+		const { edgeFunctions, invalidFunctions } = collectedFunctions;
+
+		expect(edgeFunctions.size).toEqual(0);
+
+		expect(invalidFunctions.size).toEqual(1);
+		expect(invalidFunctions.has(resolve(functionsDir, 'en.func'))).toEqual(
+			true,
+		);
+
+		expect(processExitMock).toHaveBeenCalledWith(1);
+		mockedConsole.expectCalls([
+			/The following routes were not configured to run with the Edge Runtime(?:.|\n)+- \/en/,
+		]);
+
+		processExitMock.mockRestore();
+		mockedConsole.restore();
+	});
+});

--- a/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/invalidFunctions.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/invalidFunctions.test.ts
@@ -34,15 +34,21 @@ describe('checkInvalidFunctions', () => {
 		});
 		restoreFsMock();
 
-		const { edgeFunctions, invalidFunctions } = collectedFunctions;
+		const { edgeFunctions, invalidFunctions, ignoredFunctions } =
+			collectedFunctions;
 
 		expect(edgeFunctions.size).toEqual(1);
 		expect(getRouteInfo(edgeFunctions, 'index.func')).toEqual({
 			path: '/index',
-			overrides: ['/'],
+			overrides: ['/', '/en'],
 		});
 
 		expect(invalidFunctions.size).toEqual(0);
+
+		expect(ignoredFunctions.size).toEqual(1);
+		expect(ignoredFunctions.has(resolve(functionsDir, 'en.func'))).toEqual(
+			true,
+		);
 	});
 
 	test('should ignore i18n nested route with valid alternative', async () => {
@@ -63,15 +69,21 @@ describe('checkInvalidFunctions', () => {
 		});
 		restoreFsMock();
 
-		const { edgeFunctions, invalidFunctions } = collectedFunctions;
+		const { edgeFunctions, invalidFunctions, ignoredFunctions } =
+			collectedFunctions;
 
 		expect(edgeFunctions.size).toEqual(1);
 		expect(getRouteInfo(edgeFunctions, 'test/route.func')).toEqual({
 			path: '/test/route',
-			overrides: [],
+			overrides: ['/en/test/route'],
 		});
 
 		expect(invalidFunctions.size).toEqual(0);
+
+		expect(ignoredFunctions.size).toEqual(1);
+		expect(
+			ignoredFunctions.has(resolve(functionsDir, 'en/test/route.func')),
+		).toEqual(true);
 	});
 
 	test('should not ignore i18n with no valid alternative', async () => {
@@ -96,7 +108,8 @@ describe('checkInvalidFunctions', () => {
 		});
 		restoreFsMock();
 
-		const { edgeFunctions, invalidFunctions } = collectedFunctions;
+		const { edgeFunctions, invalidFunctions, ignoredFunctions } =
+			collectedFunctions;
 
 		expect(edgeFunctions.size).toEqual(0);
 
@@ -104,6 +117,8 @@ describe('checkInvalidFunctions', () => {
 		expect(invalidFunctions.has(resolve(functionsDir, 'en.func'))).toEqual(
 			true,
 		);
+
+		expect(ignoredFunctions.size).toEqual(0);
 
 		expect(processExitMock).toHaveBeenCalledWith(1);
 		mockedConsole.expectCalls([

--- a/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/prerenderFunctions.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/prerenderFunctions.test.ts
@@ -39,6 +39,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -92,6 +93,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -144,6 +146,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -201,6 +204,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -261,6 +265,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -315,6 +320,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -366,6 +372,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -418,6 +425,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -465,6 +473,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir,
 			workerJsDir,
 			nopDistDir,
+			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -510,6 +519,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir: customOutputDir,
 			workerJsDir: customWorkerJsDir,
 			nopDistDir: join(customWorkerJsDir, '__next-on-pages-dist__'),
+			vercelConfig: { version: 3 },
 		});
 
 		const { edgeFunctions, prerenderedFunctions, invalidFunctions } =
@@ -576,6 +586,7 @@ describe('processPrerenderFunctions', () => {
 			outputDir: resolve('custom'),
 			workerJsDir: customWorkerJsDir,
 			nopDistDir: join(customWorkerJsDir, '__next-on-pages-dist__'),
+			vercelConfig: { version: 3 },
 		});
 
 		const { edgeFunctions, prerenderedFunctions, invalidFunctions } =


### PR DESCRIPTION
This PR does the following:
- Checks the build output config for i18n keys.
- Ignores invalid functions that match those i18n keys and have a valid alternative function.
- Adds a reason to the ignored function entries in the nop-build-log file.
- Adds a few tests for the fix.

fixes #464 which is caused by Vercel CLI version >= 32.2.0