### PR TITLE
add $ to all route srcs

### DIFF
--- a/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
+++ b/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
@@ -84,7 +84,15 @@ export function processVercelConfig(
 
 	let currentPhase: VercelHandleValue | 'none' = 'none';
 	config.routes?.forEach(route => {
-		if (route.src) {
+		// The following src tweaks apply only on non-handler routes
+		// see: https://github.com/vercel/vercel/blob/ea5bc88/packages/routing-utils/src/index.ts#L58
+		const isHandler = isVercelHandler(route);
+
+		// routes pointing to '/' with a locale might need not to be tweaked (as suggested by one of our i18n tests)
+		// so just to be on the safe side we also skip those (note that this might actually be unnecessary)
+		const isLocaleIndex = !isHandler && !!(route.locale && route.src === '/');
+
+		if (route.src && !isHandler && !isLocaleIndex) {
 			// Route src should always start with a '^'
 			// see: https://github.com/vercel/vercel/blob/ea5bc88/packages/routing-utils/src/index.ts#L77
 			if (!route.src.startsWith('^')) {

--- a/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
+++ b/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
@@ -86,7 +86,7 @@ export function processVercelConfig(
 	config.routes?.forEach(route => {
 		// Vercel output routes sometimes include `$`s and sometimes they do not, but it seems
 		// like in either case Vercel behaves as if they're present, so we need to mimic such behavior
-		if(route.src && !route.src.endsWith('$')) {
+		if (route.src && !route.src.endsWith('$')) {
 			route.src += '$';
 		}
 

--- a/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
+++ b/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
@@ -70,7 +70,7 @@ export function processVercelConfig(
 	config: VercelConfig,
 ): ProcessedVercelConfig {
 	const processedConfig: ProcessedVercelConfig = {
-		...config,
+		...structuredClone(config),
 		routes: {
 			none: [],
 			filesystem: [],
@@ -84,11 +84,10 @@ export function processVercelConfig(
 
 	let currentPhase: VercelHandleValue | 'none' = 'none';
 	config.routes?.forEach(route => {
-		// Vercel generates `^/` as the regex instead of `^/$` for their root prefer route.
-		// This makes the route match everything and not only the actual root requests, so
-		// here we need to fix such erroneous regex.
-		if (route.src === '^/' && route.dest === '/index.prefetch.rsc') {
-			route.src = '^/$';
+		// Vercel output routes sometimes include `$`s and sometimes they do not, but it seems
+		// like in either case Vercel behaves as if they're present, so we need to mimic such behavior
+		if(route.src && !route.src.endsWith('$')) {
+			route.src += '$';
 		}
 
 		if (isVercelHandler(route)) {

--- a/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
+++ b/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
@@ -70,7 +70,7 @@ export function processVercelConfig(
 	config: VercelConfig,
 ): ProcessedVercelConfig {
 	const processedConfig: ProcessedVercelConfig = {
-		...structuredClone(config),
+		...JSON.parse(JSON.stringify(config)),
 		routes: {
 			none: [],
 			filesystem: [],

--- a/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
+++ b/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
@@ -86,7 +86,12 @@ export function processVercelConfig(
 	config.routes?.forEach(route => {
 		// Vercel output routes sometimes include `$`s and sometimes they do not, but it seems
 		// like in either case Vercel behaves as if they're present, so we need to mimic such behavior
-		if (route.src && !route.src.endsWith('$')) {
+		if (
+			route.src &&
+			!route.src.endsWith('$') &&
+			route.src !== '/' &&
+			!route.src.endsWith('(.*)')
+		) {
 			route.src += '$';
 		}
 

--- a/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
+++ b/packages/next-on-pages/src/buildApplication/getVercelConfig.ts
@@ -84,15 +84,18 @@ export function processVercelConfig(
 
 	let currentPhase: VercelHandleValue | 'none' = 'none';
 	config.routes?.forEach(route => {
-		// Vercel output routes sometimes include `$`s and sometimes they do not, but it seems
-		// like in either case Vercel behaves as if they're present, so we need to mimic such behavior
-		if (
-			route.src &&
-			!route.src.endsWith('$') &&
-			route.src !== '/' &&
-			!route.src.endsWith('(.*)')
-		) {
-			route.src += '$';
+		if (route.src) {
+			// Route src should always start with a '^'
+			// see: https://github.com/vercel/vercel/blob/ea5bc88/packages/routing-utils/src/index.ts#L77
+			if (!route.src.startsWith('^')) {
+				route.src = `^${route.src}`;
+			}
+
+			// Route src should always end with a '$'
+			// see: https://github.com/vercel/vercel/blob/ea5bc88/packages/routing-utils/src/index.ts#L82
+			if (!route.src.endsWith('$')) {
+				route.src = `${route.src}$`;
+			}
 		}
 
 		if (isVercelHandler(route)) {

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -421,7 +421,10 @@ export class RoutesMatcher {
 		}
 
 		if (isLocaleTrailingSlashRegex(route.src, this.locales)) {
-			return { ...route, src: route.src.replace(/\/\(\.\*\)$/, '(?:/(.*))?$') };
+			return {
+				...route,
+				src: route.src.replace(/\/\(\.\*\)\$$/, '(?:/(.*))?$'),
+			};
 		}
 
 		return route;

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -417,7 +417,7 @@ export class RoutesMatcher {
 		const isLocaleIndex =
 			/^\/$/.test(route.src) && route.src.slice(1) in this.locales;
 		if (isLocaleIndex) {
-			return { ...route, src: `^${route.src}$` };
+			return { ...route, src: `${route.src}` };
 		}
 
 		if (isLocaleTrailingSlashRegex(route.src, this.locales)) {

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -415,7 +415,7 @@ export class RoutesMatcher {
 		}
 
 		const isLocaleIndex =
-			/^\//.test(route.src) && route.src.slice(1) in this.locales;
+			/^\/$/.test(route.src) && route.src.slice(1) in this.locales;
 		if (isLocaleIndex) {
 			return { ...route, src: `^${route.src}$` };
 		}

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -393,10 +393,6 @@ export class RoutesMatcher {
 	 * Modifies the source route's `src` regex to be friendly with previously found locale's in the
 	 * `miss` phase.
 	 *
-	 * Sometimes, there is a source route with `src: '/{locale}'`, which rewrites all paths containing
-	 * the locale to `/`. This is problematic for matching, and should only do this if the path is
-	 * exactly the locale, i.e. `^/{locale}$`.
-	 *
 	 * There is a source route generated for rewriting `/{locale}/*` to `/*` when no file was found
 	 * for the path. This causes issues when using an SSR function for the index page as the request
 	 * to `/{locale}` will not be caught by the regex. Therefore, the regex needs to be updated to
@@ -412,12 +408,6 @@ export class RoutesMatcher {
 	): VercelSource {
 		if (!this.locales || phase !== 'miss') {
 			return route;
-		}
-
-		const isLocaleIndex =
-			/^\/$/.test(route.src) && route.src.slice(1) in this.locales;
-		if (isLocaleIndex) {
-			return { ...route, src: `${route.src}` };
 		}
 
 		if (isLocaleTrailingSlashRegex(route.src, this.locales)) {

--- a/packages/next-on-pages/templates/_worker.js/utils/routing.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/routing.ts
@@ -138,7 +138,7 @@ export async function runOrFetchBuildOutputItem(
  * Checks if a source route's matcher uses the regex format for locales with a trailing slash, where
  * the locales specified are known.
  *
- * Determines whether a matcher is in the format of `^//?(?:en|fr|nl)/(.*)`.
+ * Determines whether a matcher is in the format of `^//?(?:en|fr|nl)/(.*)$`.
  *
  * @param src Source route `src` regex value.
  * @param locales Known available locales.
@@ -149,7 +149,7 @@ export function isLocaleTrailingSlashRegex(
 	locales: Record<string, string>,
 ) {
 	const prefix = '^//?(?:';
-	const suffix = ')/(.*)';
+	const suffix = ')/(.*)$';
 
 	if (!src.startsWith(prefix) || !src.endsWith(suffix)) {
 		return false;

--- a/packages/next-on-pages/tests/src/buildApplication/getVercelConfig.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/getVercelConfig.test.ts
@@ -20,9 +20,9 @@ describe('processVercelConfig', () => {
 		expect(processVercelConfig(inputtedConfig)).toEqual({
 			version: 3,
 			routes: {
-				none: [{ src: '/test-1$', dest: '/test-2' }],
-				filesystem: [{ src: '/test-3$', dest: '/test-4' }],
-				miss: [{ src: '/test-2$', dest: '/test-6' }],
+				none: [{ src: '^/test-1$', dest: '/test-2' }],
+				filesystem: [{ src: '^/test-3$', dest: '/test-4' }],
+				miss: [{ src: '^/test-2$', dest: '/test-6' }],
 				rewrite: [],
 				resource: [],
 				hit: [],

--- a/packages/next-on-pages/tests/src/buildApplication/getVercelConfig.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/getVercelConfig.test.ts
@@ -20,9 +20,9 @@ describe('processVercelConfig', () => {
 		expect(processVercelConfig(inputtedConfig)).toEqual({
 			version: 3,
 			routes: {
-				none: [{ src: '/test-1', dest: '/test-2' }],
-				filesystem: [{ src: '/test-3', dest: '/test-4' }],
-				miss: [{ src: '/test-2', dest: '/test-6' }],
+				none: [{ src: '/test-1$', dest: '/test-2' }],
+				filesystem: [{ src: '/test-3$', dest: '/test-4' }],
+				miss: [{ src: '/test-2$', dest: '/test-6' }],
 				rewrite: [],
 				resource: [],
 				hit: [],

--- a/packages/next-on-pages/tests/src/buildApplication/processVercelOutput.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/processVercelOutput.test.ts
@@ -55,11 +55,11 @@ describe('processVercelOutput', () => {
 				version: 3,
 				routes: {
 					none: [
-						{ src: '/test-1$', dest: '/test-2' },
-						{ src: '/use-middleware$', middlewarePath: 'middleware' },
+						{ src: '^/test-1$', dest: '/test-2' },
+						{ src: '^/use-middleware$', middlewarePath: 'middleware' },
 					],
-					filesystem: [{ src: '/test-3$', dest: '/test-4' }],
-					miss: [{ src: '/test-2$', dest: '/test-6' }],
+					filesystem: [{ src: '^/test-3$', dest: '/test-4' }],
+					miss: [{ src: '^/test-2$', dest: '/test-6' }],
 					rewrite: [],
 					resource: [],
 					hit: [],

--- a/packages/next-on-pages/tests/src/buildApplication/processVercelOutput.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/processVercelOutput.test.ts
@@ -55,11 +55,11 @@ describe('processVercelOutput', () => {
 				version: 3,
 				routes: {
 					none: [
-						{ src: '/test-1', dest: '/test-2' },
-						{ src: '/use-middleware', middlewarePath: 'middleware' },
+						{ src: '/test-1$', dest: '/test-2' },
+						{ src: '/use-middleware$', middlewarePath: 'middleware' },
 					],
-					filesystem: [{ src: '/test-3', dest: '/test-4' }],
-					miss: [{ src: '/test-2', dest: '/test-6' }],
+					filesystem: [{ src: '/test-3$', dest: '/test-4' }],
+					miss: [{ src: '/test-2$', dest: '/test-6' }],
 					rewrite: [],
 					resource: [],
 					hit: [],

--- a/pages-e2e/features/appRouting/500.test.ts
+++ b/pages-e2e/features/appRouting/500.test.ts
@@ -2,18 +2,14 @@ import { describe, test } from 'vitest';
 import { getAssertVisible } from '@features-utils/getAssertVisible';
 
 describe('default error page', () => {
-	test(`visiting a page that throws results in the default 500 internal server error page`, async () => {
+	test(`visiting a page that throws results in the default server error page`, async () => {
 		const page = await BROWSER.newPage();
 		const assertVisible = getAssertVisible(page);
 
 		await page.goto(`${DEPLOYMENT_URL}/500-error`);
 
-		await assertVisible('h1', {
-			hasText: '500',
-		});
-
 		await assertVisible('h2', {
-			hasText: 'Internal Server Error.',
+			hasText: 'Application error',
 		});
 	});
 });


### PR DESCRIPTION
issue #470 happens because Vercel generated route srcs don't contain appropriate `$` at the end, if can be fixed by adding ad-hoc `$` as we've done in the past, I am however trying to see, can we just always add `$`? is that how Vercel interprets such regexes anyways?