### PR TITLE
remove retires from pull-request.yml e2es

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,6 +42,7 @@ jobs:
   e2e-tests:
     name: e2e tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -55,11 +56,7 @@ jobs:
           skip-caching: true
 
       - name: Run e2e tests
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 2
-          timeout_minutes: 20
-          command: npm run test:e2e -- -- --log-timestamp --install-wrangler=3.8.0
+        run: npm run test:e2e -- -- --log-timestamp --install-wrangler=3.8.0
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
As you can see from this sequence of failed runs: https://github.com/cloudflare/next-on-pages/actions/runs/6373798679/job/17315329436?pr=473

It looks like that if the e2es fail once then the second time around they fail because the e2es runner can't find any test files anymore

So based on this, it is pretty pointless on retrying the step multiple times (it is actually harmful since it can hide the real issue as it happened to me in the runs mentioned above), so I am removing the retries for now

____

 ### Note
In the past we had this: https://github.com/cloudflare/next-on-pages/blob/671ff82c292ce29d8990a22b0c97c2e7ec990f24/pages-e2e/package.json#L5-L7 (`but` there is a typo, it was supposed to be `bug` 🤦)

and I do think that it was helping with the above issue, so I am not 100% sure what's best, to remove the retries altogether or to re-introduce this hack

(the e2es seem to be much more stable than before so maybe we could indeed try to remove the retries and see for a bit how that goes 🤔)

Any thoughts?