### PR TITLE
fix wasmImportsToPrepend overriding existing imports

### DIFF
--- a/.changeset/wild-olives-invent.md
+++ b/.changeset/wild-olives-invent.md
@@ -1,0 +1,12 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+fix wasms not always getting imported when necessary
+
+Details:
+when dealing with wasms that have more than 1 consumer, when we collect
+the wasm imports to prepend for a specific edge funcion we're always
+re-setting the array of wasm imports instead of appending them, this 
+causes edge functions to always only consider the last wasm
+import, the changes here fix such behavior

--- a/.changeset/wild-olives-invent.md
+++ b/.changeset/wild-olives-invent.md
@@ -7,6 +7,6 @@ fix wasms not always getting imported when necessary
 Details:
 when dealing with wasms that have more than 1 consumer, when we collect
 the wasm imports to prepend for a specific edge funcion we're always
-re-setting the array of wasm imports instead of appending them, this 
+re-setting the array of wasm imports instead of appending them, this
 causes edge functions to always only consider the last wasm
 import, the changes here fix such behavior

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -121,10 +121,10 @@ async function processFunctionIdentifiers(
 				if (newFilePath) identifierPathsToBuild.add(newFilePath);
 				if (newImport) importsToPrepend.push(newImport);
 				if (wasmImports.length) {
-					wasmImportsToPrepend.set(
-						identifierInfo.newDest as string,
-						wasmImports,
-					);
+					const newDest = identifierInfo.newDest as string;
+					const existingWasmImports = wasmImportsToPrepend.get(newDest) ?? [];
+					const newWasmImports = existingWasmImports.concat(wasmImports);
+					wasmImportsToPrepend.set(newDest, newWasmImports);
 				}
 			}
 		}

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -89,7 +89,7 @@ async function processFunctionIdentifiers(
 
 		// Tracks the imports to prepend to the final code for the function and identifiers.
 		const importsToPrepend: NewImportInfo[] = [];
-		const wasmImportsToPrepend = new Map<string, string[]>();
+		const wasmImportsToPrepend = new Map<string, Set<string>>();
 
 		const newFnLocation = join('functions', `${fnInfo.relativePath}.js`);
 		const newFnPath = join(opts.nopDistDir, newFnLocation);
@@ -122,9 +122,12 @@ async function processFunctionIdentifiers(
 				if (newImport) importsToPrepend.push(newImport);
 				if (wasmImports.length) {
 					const newDest = identifierInfo.newDest as string;
-					const existingWasmImports = wasmImportsToPrepend.get(newDest) ?? [];
-					const newWasmImports = existingWasmImports.concat(wasmImports);
-					wasmImportsToPrepend.set(newDest, newWasmImports);
+					if (!wasmImportsToPrepend.get(newDest)) {
+						wasmImportsToPrepend.set(newDest, new Set());
+					}
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					const destImports = wasmImportsToPrepend.get(newDest)!;
+					wasmImports.forEach(wasmImport => destImports.add(wasmImport));
 				}
 			}
 		}
@@ -218,7 +221,7 @@ type BuildFunctionFileOpts = {
  * @param opts Options for processing the function.
  */
 async function prependWasmImportsToCodeBlocks(
-	wasmImportsToPrepend: Map<string, string[]>,
+	wasmImportsToPrepend: Map<string, Set<string>>,
 	identifierMaps: Record<IdentifierType, IdentifiersMap>,
 	{ workerJsDir, nopDistDir }: ProcessVercelFunctionsOpts,
 ) {


### PR DESCRIPTION
when dealing with wasms that have more than 1 consumer, when we collect the wasm imports to prepend for a specific edge funcion we're always re-setting the array of wasm imports instead of appending them, this causes edge functions to always only consider the last wasm import, fix such issue

resolves #494