### PR TITLE
remove 'watch mode' from unexpected error message

### DIFF
--- a/.changeset/cool-bikes-invite.md
+++ b/.changeset/cool-bikes-invite.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+remove wrong 'Watch mode' prefix to generic unexpected error message

--- a/packages/next-on-pages/src/index.ts
+++ b/packages/next-on-pages/src/index.ts
@@ -72,7 +72,7 @@ function runBuild(options: CliOptions) {
 				`);
 			}
 		}
-	}).catch(error => cliError(`Watch mode unexpected error: ${error}`));
+	}).catch(error => cliError(`Unexpected error: ${error}`));
 }
 
 function setWatchMode(fn: () => void): void {


### PR DESCRIPTION
pretty minor stuff but I noticed that this error says `watch mode` even though it a generic error that also applies in non-watch mode