### PR TITLE
Replace append with set in adjustRequestForVercel (Fixes #507)

### DIFF
--- a/.changeset/quiet-roses-design.md
+++ b/.changeset/quiet-roses-design.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Changes to the x-vercel-ip headers to bring their structure in line with deployments to Vercel.

--- a/packages/next-on-pages/templates/_worker.js/utils/request.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/request.ts
@@ -8,17 +8,17 @@ export function adjustRequestForVercel(request: Request): Request {
 	const adjustedHeaders = new Headers(request.headers);
 
 	if (request.cf) {
-		adjustedHeaders.append('x-vercel-ip-city', request.cf.city as string);
-		adjustedHeaders.append('x-vercel-ip-country', request.cf.country as string);
-		adjustedHeaders.append(
+		adjustedHeaders.set('x-vercel-ip-city', request.cf.city as string);
+		adjustedHeaders.set('x-vercel-ip-country', request.cf.country as string);
+		adjustedHeaders.set(
 			'x-vercel-ip-country-region',
 			request.cf.region as string,
 		);
-		adjustedHeaders.append(
+		adjustedHeaders.set(
 			'x-vercel-ip-latitude',
 			request.cf.latitude as string,
 		);
-		adjustedHeaders.append(
+		adjustedHeaders.set(
 			'x-vercel-ip-longitude',
 			request.cf.longitude as string,
 		);

--- a/packages/next-on-pages/templates/_worker.js/utils/request.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/request.ts
@@ -14,10 +14,7 @@ export function adjustRequestForVercel(request: Request): Request {
 			'x-vercel-ip-country-region',
 			request.cf.region as string,
 		);
-		adjustedHeaders.set(
-			'x-vercel-ip-latitude',
-			request.cf.latitude as string,
-		);
+		adjustedHeaders.set('x-vercel-ip-latitude', request.cf.latitude as string);
 		adjustedHeaders.set(
 			'x-vercel-ip-longitude',
 			request.cf.longitude as string,


### PR DESCRIPTION
This pull request aims to fix the small incompatibility between real Vercel and the simulated Vercel headers by replacing headers, instead of appending to their values. This should fix #507 