### PR TITLE
fix: several issues with `next.config.js` `basePath` option

### DIFF
--- a/.changeset/great-geckos-brake.md
+++ b/.changeset/great-geckos-brake.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix prerendered `next.config.js` `basePath` root infinite redirect due to Cloudflare Pages handling of `/{path}/index`.

--- a/.changeset/silent-walls-remain.md
+++ b/.changeset/silent-walls-remain.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix nested `index.rsc` routes not generating a non-index override.

--- a/.changeset/ten-feet-thank.md
+++ b/.changeset/ten-feet-thank.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix the `/_not-found` invalid function hack to work with `next.config.js` `basePath`.

--- a/.changeset/wise-jeans-lay.md
+++ b/.changeset/wise-jeans-lay.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix unncessary invalid function at the root not being discarded when using `next.config.js` `basePath` option.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
@@ -10,7 +10,10 @@ import type { CollectedFunctions, FunctionInfo } from './configs';
 import { join } from 'path';
 import type { ProcessVercelFunctionsOpts } from '.';
 
-type Opts = Pick<ProcessVercelFunctionsOpts, 'functionsDir' | 'vercelConfig'>;
+type InvalidFunctionsOpts = Pick<
+	ProcessVercelFunctionsOpts,
+	'functionsDir' | 'vercelConfig'
+>;
 
 /**
  * Checks if there are any invalid functions from the Vercel build output.
@@ -25,7 +28,7 @@ type Opts = Pick<ProcessVercelFunctionsOpts, 'functionsDir' | 'vercelConfig'>;
  */
 export async function checkInvalidFunctions(
 	collectedFunctions: CollectedFunctions,
-	opts: Opts,
+	opts: InvalidFunctionsOpts,
 ): Promise<void> {
 	await tryToFixNotFoundRoute(collectedFunctions);
 
@@ -116,10 +119,7 @@ async function tryToFixNotFoundRoute({
  */
 async function tryToFixI18nFunctions(
 	{ edgeFunctions, invalidFunctions, ignoredFunctions }: CollectedFunctions,
-	{
-		vercelConfig,
-		functionsDir,
-	}: Pick<ProcessVercelFunctionsOpts, 'functionsDir' | 'vercelConfig'>,
+	{ vercelConfig, functionsDir }: InvalidFunctionsOpts,
 ): Promise<void> {
 	if (!invalidFunctions.size || !vercelConfig.routes?.length) {
 		return;

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
@@ -221,8 +221,8 @@ async function printInvalidFunctionsErrorMessage(
  * Tries to fix potential invalid functions with a valid /index alternative from the Vercel build
  * output.
  *
- * This deals with an edge case when using `basePath` and it creates an invalid function for the
- * `/` route, but has a valid alternative at `/index`.
+ * This deals with an edge case when using `basePath` creates an invalid function for the
+ * `/` route, but a valid alternative is created at `/index`.
  *
  * @param collectedFunctions Collected functions from the Vercel build output.
  */

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/prerenderFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/prerenderFunctions.ts
@@ -13,7 +13,10 @@ import {
 } from '../../utils';
 import { cliWarn } from '../../cli';
 
-type Opts = Pick<ProcessVercelFunctionsOpts, 'functionsDir' | 'outputDir'>;
+type PrerenderFunctionsOpts = Pick<
+	ProcessVercelFunctionsOpts,
+	'functionsDir' | 'outputDir'
+>;
 
 /**
  * Processes the prerendered routes found in the Vercel build output.
@@ -28,7 +31,7 @@ type Opts = Pick<ProcessVercelFunctionsOpts, 'functionsDir' | 'outputDir'>;
  */
 export async function processPrerenderFunctions(
 	{ invalidFunctions, prerenderedFunctions }: CollectedFunctions,
-	opts: Opts,
+	opts: PrerenderFunctionsOpts,
 ): Promise<void> {
 	for (const [path, fnInfo] of prerenderedFunctions) {
 		const routeInfo = await validateRoute(path, fnInfo.relativePath, opts);
@@ -61,7 +64,7 @@ export async function processPrerenderFunctions(
 async function validateRoute(
 	fullPath: string,
 	relativePath: string,
-	opts: Opts,
+	opts: PrerenderFunctionsOpts,
 ): Promise<ValidatedRouteInfo | null> {
 	const config = await getRouteConfig(fullPath, relativePath);
 	if (!config) return null;
@@ -119,7 +122,7 @@ async function getRouteConfig(
 async function getRoutePath(
 	{ fallback }: VercelPrerenderConfig,
 	relativePath: string,
-	{ functionsDir }: Opts,
+	{ functionsDir }: PrerenderFunctionsOpts,
 ): Promise<string | null> {
 	const prerenderRoute = join(dirname(relativePath), fallback.fsPath);
 	const prerenderFile = join(functionsDir, prerenderRoute);
@@ -153,7 +156,7 @@ async function getRoutePath(
 async function getRouteDest(
 	{ fallback }: VercelPrerenderConfig,
 	relativePath: string,
-	{ outputDir }: Opts,
+	{ outputDir }: PrerenderFunctionsOpts,
 ): Promise<{ destFile: string; destRoute: string }> {
 	const fixedFileName = fallback.fsPath.replace(
 		/\.prerender-fallback(?:\.(?:rsc|body|json))?/gi,

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/prerenderFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/prerenderFunctions.ts
@@ -13,6 +13,8 @@ import {
 } from '../../utils';
 import { cliWarn } from '../../cli';
 
+type Opts = Pick<ProcessVercelFunctionsOpts, 'functionsDir' | 'outputDir'>;
+
 /**
  * Processes the prerendered routes found in the Vercel build output.
  *
@@ -26,7 +28,7 @@ import { cliWarn } from '../../cli';
  */
 export async function processPrerenderFunctions(
 	{ invalidFunctions, prerenderedFunctions }: CollectedFunctions,
-	opts: ProcessVercelFunctionsOpts,
+	opts: Opts,
 ): Promise<void> {
 	for (const [path, fnInfo] of prerenderedFunctions) {
 		const routeInfo = await validateRoute(path, fnInfo.relativePath, opts);
@@ -59,7 +61,7 @@ export async function processPrerenderFunctions(
 async function validateRoute(
 	fullPath: string,
 	relativePath: string,
-	opts: ProcessVercelFunctionsOpts,
+	opts: Opts,
 ): Promise<ValidatedRouteInfo | null> {
 	const config = await getRouteConfig(fullPath, relativePath);
 	if (!config) return null;
@@ -117,7 +119,7 @@ async function getRouteConfig(
 async function getRoutePath(
 	{ fallback }: VercelPrerenderConfig,
 	relativePath: string,
-	{ functionsDir }: ProcessVercelFunctionsOpts,
+	{ functionsDir }: Opts,
 ): Promise<string | null> {
 	const prerenderRoute = join(dirname(relativePath), fallback.fsPath);
 	const prerenderFile = join(functionsDir, prerenderRoute);
@@ -151,7 +153,7 @@ async function getRoutePath(
 async function getRouteDest(
 	{ fallback }: VercelPrerenderConfig,
 	relativePath: string,
-	{ outputDir }: ProcessVercelFunctionsOpts,
+	{ outputDir }: Opts,
 ): Promise<{ destFile: string; destRoute: string }> {
 	const fixedFileName = fallback.fsPath.replace(
 		/\.prerender-fallback(?:\.(?:rsc|body|json))?/gi,

--- a/packages/next-on-pages/src/utils/routing.ts
+++ b/packages/next-on-pages/src/utils/routing.ts
@@ -78,9 +78,18 @@ export function formatRoutePath(path: string) {
 export function getRouteOverrides(routePath: string): string[] {
 	const formattedPathName = formatRoutePath(routePath);
 	const withoutHtmlExt = formattedPathName.replace(/\.html$/, '');
+	const withoutIndexRsc = formattedPathName.replace(
+		/(.+)\/index\.rsc$/,
+		'$1.rsc',
+	);
 	const strippedIndexRoute = stripIndexRoute(withoutHtmlExt);
 
 	return [
-		...new Set([formattedPathName, withoutHtmlExt, strippedIndexRoute]),
+		...new Set([
+			formattedPathName,
+			withoutIndexRsc,
+			withoutHtmlExt,
+			strippedIndexRoute,
+		]),
 	].filter(route => route !== routePath);
 }

--- a/packages/next-on-pages/templates/_worker.js/utils/http.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/http.ts
@@ -90,7 +90,8 @@ export function createRouteRequest(req: Request, path: string) {
 
 	newUrl.pathname = newUrl.pathname
 		.replace(/^\/index.html$/, '/')
-		.replace(/\.html$/, '');
+		.replace(/\.html$/, '')
+		.replace(/(.+)\/index$/, '$1/');
 
 	return new Request(newUrl, req);
 }

--- a/packages/next-on-pages/templates/_worker.js/utils/http.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/http.ts
@@ -89,9 +89,8 @@ export function createRouteRequest(req: Request, path: string) {
 	applySearchParams(newUrl.searchParams, new URL(req.url).searchParams);
 
 	newUrl.pathname = newUrl.pathname
-		.replace(/^\/index.html$/, '/')
-		.replace(/\.html$/, '')
-		.replace(/(.+)\/index$/, '$1/');
+		.replace(/\/index.html$/, '/')
+		.replace(/\.html$/, '');
 
 	return new Request(newUrl, req);
 }

--- a/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/prerenderFunctions.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/prerenderFunctions.test.ts
@@ -8,14 +8,12 @@ import {
 	prerenderFuncDir,
 	getRouteInfo,
 } from '../../../_helpers';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 import { readdirSync } from 'node:fs';
 import { processPrerenderFunctions } from '../../../../src/buildApplication/processVercelFunctions/prerenderFunctions';
 
 const functionsDir = resolve('.vercel/output/functions');
 const outputDir = resolve('.vercel/output/static');
-const workerJsDir = join(outputDir, '_worker.js');
-const nopDistDir = join(workerJsDir, '__next-on-pages-dist__');
 
 describe('processPrerenderFunctions', () => {
 	afterEach(() => mockFs.restore());
@@ -37,9 +35,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -91,9 +86,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -144,9 +136,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -202,9 +191,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -263,9 +249,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -318,9 +301,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -370,9 +350,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -423,9 +400,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -471,9 +445,6 @@ describe('processPrerenderFunctions', () => {
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir,
-			workerJsDir,
-			nopDistDir,
-			vercelConfig: { version: 3 },
 		});
 		restoreFsMock();
 
@@ -512,14 +483,9 @@ describe('processPrerenderFunctions', () => {
 			{ outputDir: resolve('custom') },
 		);
 
-		const customOutputDir = resolve('custom');
-		const customWorkerJsDir = join(customOutputDir, '_worker.js');
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
-			outputDir: customOutputDir,
-			workerJsDir: customWorkerJsDir,
-			nopDistDir: join(customWorkerJsDir, '__next-on-pages-dist__'),
-			vercelConfig: { version: 3 },
+			outputDir: resolve('custom'),
 		});
 
 		const { edgeFunctions, prerenderedFunctions, invalidFunctions } =
@@ -579,14 +545,9 @@ describe('processPrerenderFunctions', () => {
 			{ outputDir: resolve('custom') },
 		);
 
-		const customOutputDir = resolve('custom');
-		const customWorkerJsDir = join(customOutputDir, '_worker.js');
 		await processPrerenderFunctions(collectedFunctions, {
 			functionsDir,
 			outputDir: resolve('custom'),
-			workerJsDir: customWorkerJsDir,
-			nopDistDir: join(customWorkerJsDir, '__next-on-pages-dist__'),
-			vercelConfig: { version: 3 },
 		});
 
 		const { edgeFunctions, prerenderedFunctions, invalidFunctions } =


### PR DESCRIPTION
This PR fixes the following issues relating to the `next.config.js` `basePath` option:
- infinite redirect for prerendered base path root.
- base path root index.rsc not generating a non-index rsc override.
- _not-found function hack not working with base paths.
- not discard an invalid unnecessary base path function at the root with a valid alternative.

fixes #516