### PR TITLE
temp-fix: rendering error in next.js 14.0.2 caused by next.js bug

### DIFF
--- a/.changeset/eighty-spoons-decide.md
+++ b/.changeset/eighty-spoons-decide.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Temporary hotfix for `vercel/next.js#58265` so that rendering in Next.js >= 14.0.2 works.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -484,6 +484,14 @@ function fixFunctionContents(contents: string): string {
 		'$1',
 	);
 
+	// TODO: Remove once `vercel/next.js#58265` is fixed.
+	// This resolves a critical issue in Next.js 14.0.2 that breaks edge runtime rendering due to the assumption
+	// that the the passed internal request is of type `NodeNextRequest` and never `WebNextRequest`.
+	contents = contents.replace(
+		/;let{originalRequest:(\w+)}=(\w+);/gm,
+		';let{originalRequest:$1=$2}=$2;',
+	);
+
 	return contents;
 }
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -484,7 +484,7 @@ function fixFunctionContents(contents: string): string {
 		'$1',
 	);
 
-	// TODO: Remove once `vercel/next.js#58265` is fixed.
+	// TODO: Remove once https://github.com/vercel/next.js/issues/58265 is fixed.
 	// This resolves a critical issue in Next.js 14.0.2 that breaks edge runtime rendering due to the assumption
 	// that the the passed internal request is of type `NodeNextRequest` and never `WebNextRequest`.
 	contents = contents.replace(


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/57815 introduced a critical bug for us that breaks rendering due to the assumption that their internal request shape is always `NodeNextRequest` (and should have the `originalRequest` property on it), and is never `WebNextRequest` (which doesn't have the `originalRequest` property).

This fix is intended to be a temporary band-aid until the issue is fixed in Next.js. I raised an issue at https://github.com/vercel/next.js/issues/58265.

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/41e2b9a2-5882-4dfc-8e16-ef1a0555bed4)
