### PR TITLE
fix: patch fetch in the fetch handler instead of global scope

### DIFF
--- a/.changeset/twenty-eggs-lick.md
+++ b/.changeset/twenty-eggs-lick.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Patch the fetch function inside the fetch handler, instead of in the global scope.

--- a/packages/next-on-pages/templates/_worker.js/index.ts
+++ b/packages/next-on-pages/templates/_worker.js/index.ts
@@ -15,10 +15,10 @@ declare const __BUILD_OUTPUT__: VercelBuildOutput;
 
 declare const __ENV_ALS_PROMISE__: Promise<null | AsyncLocalStorage<unknown>>;
 
-patchFetch();
-
 export default {
 	async fetch(request, env, ctx) {
+		patchFetch();
+
 		const envAsyncLocalStorage = await __ENV_ALS_PROMISE__;
 		if (!envAsyncLocalStorage) {
 			const reqUrl = new URL(request.url);


### PR DESCRIPTION
fixes https://github.com/cloudflare/next-on-pages/issues/535

Honestly, this one kind of confuses me a bit, but from what I can tell, patching the fetch in the global scope results in it interacting with the static generation store from the previously run function.

You can see in the below screenshot that for some reason part way through running the function, it skips from the index.func.js to the other.func.js, even though there are no references in either file to use the webpack chunks inlined in the other (i am using disable-chunks-dedup here).

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/75dd7228-9d8c-4abd-bb72-0740ba78317e)

And my console.logs in each function file also indicate that it bizarrely jumps between executing code in one another.

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/49e3efa2-631b-41d7-9d74-2eddf1ec11c9)

<details>
<summary>index.func.js</summary>

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/283e3744-50e0-48ea-96e2-690324c33eaa)
![image](https://github.com/cloudflare/next-on-pages/assets/10815538/2b6dfa6c-db9a-4153-add6-b4f632c364c5)
![image](https://github.com/cloudflare/next-on-pages/assets/10815538/6f1c9bfd-a595-400a-8017-e154eeb5f043)
</details>

<details>
<summary>other.func.js</summary>

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/a64e4508-ec22-4824-a8c6-c3b43df7c01b)
![image](https://github.com/cloudflare/next-on-pages/assets/10815538/0ddd5d8e-c05f-48fb-8c53-bbdf2c1863c9)
![image](https://github.com/cloudflare/next-on-pages/assets/10815538/c9593fbb-4c3e-4eeb-8325-c312cb0d9a53)
</details>


So it really is quite strange that it is behaving like so when you patch the fetch in the global scope... Simply moving the fetch patch inside the fetch handler fixes the issue.