### PR TITLE
Fixes for ESLint rule no-app-not-found-runtime

### DIFF
--- a/.changeset/neat-deers-work.md
+++ b/.changeset/neat-deers-work.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-next-on-pages': patch
+---
+
+Support for using src folder with no-app-not-found-runtime lint rule

--- a/.changeset/rare-rings-own.md
+++ b/.changeset/rare-rings-own.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-next-on-pages': patch
+---
+
+Use correct name for export of no-app-not-found-runtime lint rule

--- a/packages/eslint-plugin-next-on-pages/src/index.ts
+++ b/packages/eslint-plugin-next-on-pages/src/index.ts
@@ -1,6 +1,6 @@
 import noNodeJsRuntime from './rules/no-nodejs-runtime';
 import noUnsupportedConfigs from './rules/no-unsupported-configs';
-import noAppNotFound from './rules/no-app-not-found-runtime';
+import noAppNotFoundRuntime from './rules/no-app-not-found-runtime';
 
 import type { ESLint } from 'eslint';
 
@@ -8,13 +8,13 @@ const config: ESLint.Plugin = {
 	rules: {
 		'no-nodejs-runtime': noNodeJsRuntime,
 		'no-unsupported-configs': noUnsupportedConfigs,
-		'no-app-not-found': noAppNotFound,
+		'no-app-not-found-runtime': noAppNotFoundRuntime,
 	},
 	configs: {
 		recommended: {
 			plugins: ['eslint-plugin-next-on-pages'],
 			rules: {
-				'next-on-pages/no-app-not-found': 'error',
+				'next-on-pages/no-app-not-found-runtime': 'error',
 				'next-on-pages/no-nodejs-runtime': 'error',
 				'next-on-pages/no-unsupported-configs': 'error',
 			},

--- a/packages/eslint-plugin-next-on-pages/src/rules/no-app-not-found-runtime.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-app-not-found-runtime.ts
@@ -3,7 +3,7 @@ import type { Rule } from 'eslint';
 const rule: Rule.RuleModule = {
 	create: context => {
 		const isAppNotFoundRoute = new RegExp(
-			`${context.cwd}/app/not-found\\.(tsx|jsx)$`
+			`${context.cwd}(/src)?/app/not-found\\.(tsx|jsx)$`,
 		).test(context.filename);
 		return {
 			ExportNamedDeclaration: node => {

--- a/packages/eslint-plugin-next-on-pages/src/rules/no-app-not-found-runtime.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-app-not-found-runtime.ts
@@ -3,7 +3,7 @@ import type { Rule } from 'eslint';
 const rule: Rule.RuleModule = {
 	create: context => {
 		const isAppNotFoundRoute = new RegExp(
-			`${context.cwd}/app/not-found\\.(tsx|jsx)`,
+			`${context.cwd}/app/not-found\\.(tsx|jsx)$`
 		).test(context.filename);
 		return {
 			ExportNamedDeclaration: node => {
@@ -22,7 +22,7 @@ const rule: Rule.RuleModule = {
 				) {
 					context.report({
 						message:
-							'Only static not-found pages are currently supported, please remove the runtime export.' +
+							'Only static not-found pages are currently supported, please remove the runtime export in ' +
 							context.filename,
 						node,
 						fix: fixer => fixer.remove(node),

--- a/packages/eslint-plugin-next-on-pages/tests/rules/no-app-not-found-runtime.test.ts
+++ b/packages/eslint-plugin-next-on-pages/tests/rules/no-app-not-found-runtime.test.ts
@@ -1,0 +1,49 @@
+import path from 'path';
+import { RuleTester } from 'eslint';
+
+import rule from '../../src/rules/no-app-not-found-runtime';
+import { describe, test } from 'vitest';
+
+const tester = new RuleTester({
+	parser: require.resolve('@typescript-eslint/parser'),
+});
+
+const contextCwd = path.join(__dirname, '../..');
+
+describe('no-app-not-found-runtime', () => {
+	test('should work', () => {
+		tester.run('no-app-not-found-runtime', rule, {
+			valid: [
+				{
+					filename: path.join(contextCwd, '/app/not-found.tsx'),
+					code: `
+						export default function Page() {
+							return 'Not Found';
+						}
+					`,
+				},
+				{
+					filename: path.join(contextCwd, '/app/page.tsx'),
+					code: `
+						export const runtime = 'edge';
+						export default function Page() {
+							return 'Hello';
+						}
+						`,
+				},
+			],
+			invalid: [
+				{
+					filename: path.join(contextCwd, '/app/not-found.tsx'),
+					code: "export const runtime = 'edge';",
+					errors: [
+						{
+							message: `Only static not-found pages are currently supported, please remove the runtime export in ${contextCwd}/app/not-found.tsx`,
+						},
+					],
+					output: '',
+				},
+			],
+		});
+	});
+});

--- a/packages/eslint-plugin-next-on-pages/tests/rules/no-app-not-found-runtime.test.ts
+++ b/packages/eslint-plugin-next-on-pages/tests/rules/no-app-not-found-runtime.test.ts
@@ -46,4 +46,31 @@ describe('no-app-not-found-runtime', () => {
 			],
 		});
 	});
+
+	test('should work with src folder', () => {
+		tester.run('no-app-not-found-runtime', rule, {
+			valid: [
+				{
+					filename: path.join(contextCwd, '/src/app/not-found.tsx'),
+					code: `
+						export default function Page() {
+							return 'Not Found';
+						}
+					`,
+				},
+			],
+			invalid: [
+				{
+					filename: path.join(contextCwd, '/src/app/not-found.tsx'),
+					code: "export const runtime = 'edge';",
+					errors: [
+						{
+							message: `Only static not-found pages are currently supported, please remove the runtime export in ${contextCwd}/src/app/not-found.tsx`,
+						},
+					],
+					output: '',
+				},
+			],
+		});
+	});
 });


### PR DESCRIPTION
Fixes #530 
fixes #531

I put them in the same PR to avoid conflicts when merging since I also added a test file that both of them use.