### PR TITLE
feat: kv binding support for suspense cache

### DIFF
--- a/.changeset/twelve-cobras-double.md
+++ b/.changeset/twelve-cobras-double.md
@@ -2,4 +2,9 @@
 '@cloudflare/next-on-pages': minor
 ---
 
-Support for using KV bindings with the Suspense Cache via `process.env.__NEXT_ON_PAGES__KV_SUSPENSE_CACHE`.
+Add support for using a KV to implement the Suspense Cache via naming convention
+
+With this change users can have their suspense cache implemented via a KV binding, in order to
+opt-in to such implementation they simply need to make sure that their application has a KV binding
+named `__NEXT_ON_PAGES__KV_SUSPENSE_CACHE` (the next-on-pages worker will pick up such
+binding and use it to implement the suspense cache instead of using the default workers cache API).

--- a/.changeset/twelve-cobras-double.md
+++ b/.changeset/twelve-cobras-double.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Support for using KV bindings with the Suspense Cache via `process.env.__NEXT_ON_PAGES__KV_SUSPENSE_CACHE`.

--- a/packages/next-on-pages/docs/caching.md
+++ b/packages/next-on-pages/docs/caching.md
@@ -18,4 +18,4 @@ Due to how the Cache API works, you need to be using a domain for your deploymen
 
 [Workers KV](https://developers.cloudflare.com/kv/) is a low-latency key-value store that is ideal for storing data that should be globally distributed. KV is eventually consistent, which means that it will take up to 60 seconds for updates to be reflected globally.
 
-To use Workers KV for caching, you need to add a binding to your Pages project with the name `KV_SUSPENSE_CACHE`, and map it to a KV namespace.
+To use Workers KV for caching, you need to add a binding to your Pages project with the name `__NEXT_ON_PAGES__KV_SUSPENSE_CACHE`, and map it to a KV namespace.

--- a/packages/next-on-pages/docs/caching.md
+++ b/packages/next-on-pages/docs/caching.md
@@ -4,7 +4,7 @@
 
 ## Storage Options
 
-There are various different bindings and storage options that one could use for caching. At the moment, `@cloudflare/next-on-pages` supports the Cache API out-of-the-box.
+There are various different bindings and storage options that one could use for caching. At the moment, `@cloudflare/next-on-pages` supports the Cache API and Workers KV out-of-the-box.
 
 In the future, support will be available for creating custom cache interfaces and using different bindings.
 
@@ -13,3 +13,9 @@ In the future, support will be available for creating custom cache interfaces an
 The [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) is a per data-center cache that is ideal for storing data that is not required to be accessible globally. It is worth noting that Vercel's Data Cache is regional, like with the Cache API, so there is no difference in terms of data availability.
 
 Due to how the Cache API works, you need to be using a domain for your deployment for it to take effect.
+
+### Workers KV
+
+[Workers KV](https://developers.cloudflare.com/kv/) is a low-latency key-value store that is ideal for storing data that should be globally distributed. KV is eventually consistent, which means that it will take up to 60 seconds for updates to be reflected globally.
+
+To use Workers KV for caching, you need to add a binding to your Pages project with the name `KV_SUSPENSE_CACHE`, and map it to a KV namespace.

--- a/packages/next-on-pages/env.d.ts
+++ b/packages/next-on-pages/env.d.ts
@@ -5,6 +5,7 @@ declare global {
 			npm_config_user_agent?: string;
 			CF_PAGES?: string;
 			SHELL?: string;
+			KV_SUSPENSE_CACHE?: KVNamespace;
 			[key: string]: string | Fetcher;
 		}
 	}

--- a/packages/next-on-pages/env.d.ts
+++ b/packages/next-on-pages/env.d.ts
@@ -5,7 +5,7 @@ declare global {
 			npm_config_user_agent?: string;
 			CF_PAGES?: string;
 			SHELL?: string;
-			KV_SUSPENSE_CACHE?: KVNamespace;
+			__NEXT_ON_PAGES__KV_SUSPENSE_CACHE?: KVNamespace;
 			[key: string]: string | Fetcher;
 		}
 	}

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -107,6 +107,7 @@ async function prepareAndBuildWorker(
 	const functionsDir = resolve('.vercel', 'output', 'functions');
 	const workerJsDir = join(outputDir, '_worker.js');
 	const nopDistDir = join(workerJsDir, '__next-on-pages-dist__');
+	const templatesDir = join(__dirname, '..', 'templates');
 
 	if (!(await validateDir(functionsDir))) {
 		cliLog(
@@ -132,7 +133,7 @@ async function prepareAndBuildWorker(
 
 	const outputtedWorkerPath = await buildWorkerFile(
 		processedVercelOutput,
-		outputDir,
+		{ outputDir, workerJsDir, nopDistDir, templatesDir },
 		!disableWorkerMinification,
 	);
 

--- a/packages/next-on-pages/src/buildApplication/buildWorkerFile.ts
+++ b/packages/next-on-pages/src/buildApplication/buildWorkerFile.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import { join, relative } from 'path';
 import { build } from 'esbuild';
 import { tmpdir } from 'os';
@@ -88,21 +88,6 @@ export async function buildWorkerFile(
 		platform: 'neutral',
 		outdir: join(nopDistDir, 'cache'),
 		minify,
-		plugins: [
-			{
-				name: 'fix-import-extension-for-unbundled-adaptors',
-				setup(build) {
-					build.onLoad({ filter: /.*/ }, async args => {
-						const contents = await readFile(args.path, 'utf8');
-						const newContents = contents.replace(
-							"from './adaptor';",
-							"from './adaptor.js';",
-						);
-						return { contents: newContents, loader: 'default' };
-					});
-				},
-			},
-		],
 	});
 
 	return relative('.', outputFile);

--- a/packages/next-on-pages/templates/_worker.js/utils/cache.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/cache.ts
@@ -1,7 +1,5 @@
 import type { CacheAdaptor, IncrementalCacheValue } from '../../cache';
 import { SUSPENSE_CACHE_URL } from '../../cache';
-import type CacheApiAdaptor from '../../cache/cache-api';
-import type KVAdaptor from '../../cache/kv';
 
 /**
  * Handles an internal request to the suspense cache.
@@ -72,19 +70,12 @@ export async function handleSuspenseCacheRequest(request: Request) {
  * @returns Adaptor for the suspense cache.
  */
 export async function getSuspenseCacheAdaptor(): Promise<CacheAdaptor> {
-	if (process.env.KV_SUSPENSE_CACHE) {
+	if (process.env.__NEXT_ON_PAGES__KV_SUSPENSE_CACHE) {
 		return getInternalCacheAdaptor('kv');
 	}
 
 	return getInternalCacheAdaptor('cache-api');
 }
-
-type InternalAdaptors = 'kv' | 'cache-api';
-type DeriveAdaptorType<T extends InternalAdaptors> = T extends 'kv'
-	? KVAdaptor
-	: T extends 'cache-api'
-	? CacheApiAdaptor
-	: never;
 
 /**
  * Gets an internal cache adaptor.
@@ -92,9 +83,9 @@ type DeriveAdaptorType<T extends InternalAdaptors> = T extends 'kv'
  * @param type The type of adaptor to get.
  * @returns A new instance of the adaptor.
  */
-async function getInternalCacheAdaptor<T extends InternalAdaptors>(
-	type: T,
-): Promise<DeriveAdaptorType<T>> {
+async function getInternalCacheAdaptor(
+	type: 'kv' | 'cache-api',
+): Promise<CacheAdaptor> {
 	const adaptor = await import(`./__next-on-pages-dist__/cache/${type}.js`);
 	return new adaptor.default();
 }

--- a/packages/next-on-pages/templates/cache/adaptor.ts
+++ b/packages/next-on-pages/templates/cache/adaptor.ts
@@ -177,6 +177,16 @@ export class CacheAdaptor {
 
 		await this.saveTagsManifest();
 	}
+
+	/**
+	 * Builds the full cache key for the suspense cache.
+	 *
+	 * @param key Key for the item in the suspense cache.
+	 * @returns The fully-formed cache key for the suspense cache.
+	 */
+	public buildCacheKey(key: string) {
+		return `https://${SUSPENSE_CACHE_URL}/entry/${key}`;
+	}
 }
 
 // https://github.com/vercel/next.js/blob/261db49/packages/next/src/server/lib/incremental-cache/file-system-cache.ts#L17

--- a/packages/next-on-pages/templates/cache/cache-api.ts
+++ b/packages/next-on-pages/templates/cache/cache-api.ts
@@ -1,7 +1,7 @@
-import { CacheAdaptor, SUSPENSE_CACHE_URL } from './adaptor';
+import { CacheAdaptor } from './adaptor';
 
 /** Suspense Cache adaptor for the Cache API. */
-export class CacheApiAdaptor extends CacheAdaptor {
+export default class CacheApiAdaptor extends CacheAdaptor {
 	/** Name of the cache to open in the Cache API. */
 	public cacheName = 'suspense-cache';
 
@@ -28,15 +28,5 @@ export class CacheApiAdaptor extends CacheAdaptor {
 			}),
 		});
 		await cache.put(this.buildCacheKey(key), response);
-	}
-
-	/**
-	 * Builds the full cache key for the suspense cache.
-	 *
-	 * @param key Key for the item in the suspense cache.
-	 * @returns The fully-formed cache key for the suspense cache.
-	 */
-	public buildCacheKey(key: string) {
-		return `https://${SUSPENSE_CACHE_URL}/entry/${key}`;
 	}
 }

--- a/packages/next-on-pages/templates/cache/cache-api.ts
+++ b/packages/next-on-pages/templates/cache/cache-api.ts
@@ -1,4 +1,4 @@
-import { CacheAdaptor } from './adaptor';
+import { CacheAdaptor } from './adaptor.js';
 
 /** Suspense Cache adaptor for the Cache API. */
 export default class CacheApiAdaptor extends CacheAdaptor {

--- a/packages/next-on-pages/templates/cache/kv.ts
+++ b/packages/next-on-pages/templates/cache/kv.ts
@@ -1,4 +1,4 @@
-import { CacheAdaptor } from './adaptor';
+import { CacheAdaptor } from './adaptor.js';
 
 /** Suspense Cache adaptor for Workers KV. */
 export default class KVAdaptor extends CacheAdaptor {
@@ -7,7 +7,7 @@ export default class KVAdaptor extends CacheAdaptor {
 	}
 
 	public override async retrieve(key: string) {
-		const value = await process.env.KV_SUSPENSE_CACHE?.get(
+		const value = await process.env.__NEXT_ON_PAGES__KV_SUSPENSE_CACHE?.get(
 			this.buildCacheKey(key),
 		);
 
@@ -15,6 +15,9 @@ export default class KVAdaptor extends CacheAdaptor {
 	}
 
 	public override async update(key: string, value: string) {
-		await process.env.KV_SUSPENSE_CACHE?.put(this.buildCacheKey(key), value);
+		await process.env.__NEXT_ON_PAGES__KV_SUSPENSE_CACHE?.put(
+			this.buildCacheKey(key),
+			value,
+		);
 	}
 }

--- a/packages/next-on-pages/templates/cache/kv.ts
+++ b/packages/next-on-pages/templates/cache/kv.ts
@@ -1,0 +1,20 @@
+import { CacheAdaptor } from './adaptor';
+
+/** Suspense Cache adaptor for Workers KV. */
+export default class KVAdaptor extends CacheAdaptor {
+	constructor(ctx: Record<string, unknown> = {}) {
+		super(ctx);
+	}
+
+	public override async retrieve(key: string) {
+		const value = await process.env.KV_SUSPENSE_CACHE?.get(
+			this.buildCacheKey(key),
+		);
+
+		return value ?? null;
+	}
+
+	public override async update(key: string, value: string) {
+		await process.env.KV_SUSPENSE_CACHE?.put(this.buildCacheKey(key), value);
+	}
+}


### PR DESCRIPTION
This PR does the following:
- Builds the cache templates to the nop dist dir (and fixes the import extension in them since we're not bundling the adaptor code).
- Changes to lazy import internal cache adaptors.
- Adds KV cache adaptor.
- Automatically uses KV cache adaptor when the `KV_SUSPENSE_CACHE` binding is present.
- Updates docs.

Cache API demo: https://next-cache-demo.pages.dev/
KV binding demo: https://kv.next-cache-demo.pages.dev/

partially solves https://github.com/cloudflare/next-on-pages/issues/529
