### PR TITLE
fix: broken rewrites for __index.prefetch.rsc

### DIFF
--- a/.changeset/sixty-wolves-type.md
+++ b/.changeset/sixty-wolves-type.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix broken `__index.prefetch.rsc` rewrites.

--- a/.changeset/sixty-wolves-type.md
+++ b/.changeset/sixty-wolves-type.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': patch
 ---
 
-Fix broken `__index.prefetch.rsc` rewrites.
+Fix broken `/__index.prefetch.rsc` rewrites that were being rewritten to `/__index` (and 404ing) due to to rsc suffix stripping that we do.

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -315,7 +315,10 @@ export class RoutesMatcher {
 
 		// NOTE: Special handling for `/index` RSC routes. Sometimes the Vercel build output config
 		// has a record to rewrite `^/` to `/index.rsc`, however, this will hit requests to pages
-		// that aren't `/`. In this case, we should check that the previous path is `/`.
+		// that aren't `/`. In this case, we should check that the previous path is `/`. This should
+		// not match requests to `/__index.prefetch.rsc` as Vercel handles those requests missing in
+		// later phases.
+		// https://github.com/vercel/vercel/blob/31daff/packages/next/src/utils.ts#L3321
 		const isRscIndex = /\/index\.rsc$/i.test(this.path);
 		const isPrevAbsoluteIndex = /^\/(?:index)?$/i.test(prevPath);
 		const isPrevPrefetchRscIndex = /^\/__index\.prefetch\.rsc$/i.test(prevPath);

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -316,17 +316,22 @@ export class RoutesMatcher {
 		// NOTE: Special handling for `/index` RSC routes. Sometimes the Vercel build output config
 		// has a record to rewrite `^/` to `/index.rsc`, however, this will hit requests to pages
 		// that aren't `/`. In this case, we should check that the previous path is `/`.
-		if (/\/index\.rsc$/i.test(this.path) && !/^\/(?:index)?$/i.test(prevPath)) {
+		const isRscIndex = /\/index\.rsc$/i.test(this.path);
+		const isPrevAbsoluteIndex = /^\/(?:index)?$/i.test(prevPath);
+		const isPrevPrefetchRscIndex = /^\/__index\.prefetch\.rsc$/i.test(prevPath);
+		if (isRscIndex && !isPrevAbsoluteIndex && !isPrevPrefetchRscIndex) {
 			this.path = prevPath;
 		}
 
-		// NOTE: Special handling for `.rsc` and `.prefetch.rsc` requests. If the Vercel CLI failed to
-		// generate an RSC version of the page and the build output config has a record mapping the request
-		// to the RSC variant, we should strip the `.rsc` (or `.prefetch.rsc`) extension from the path.
-		const isRsc = /(\.prefetch)?\.rsc$/i.test(this.path);
+		// NOTE: Special handling for `.rsc` requests. If the Vercel CLI failed to generate an RSC version
+		// of the page and the build output config has a record mapping the request to the RSC variant, we
+		// should strip the `.rsc` extension from the path. We do not strip the extension if the request is
+		// to a `.prefetch.rsc` file as Vercel handles those requests missing in later phases.
+		const isRsc = /\.rsc$/i.test(this.path);
+		const isPrefetchRsc = /\.prefetch\.rsc$/i.test(this.path);
 		const pathExistsInOutput = this.path in this.output;
-		if (isRsc && !pathExistsInOutput) {
-			this.path = this.path.replace(/(\.prefetch)?\.rsc/i, '');
+		if (isRsc && !isPrefetchRsc && !pathExistsInOutput) {
+			this.path = this.path.replace(/\.rsc/i, '');
 		}
 
 		// Merge search params for later use when serving a response.


### PR DESCRIPTION
This PR does the following:
- Fixes the logic for rewriting rsc requests so that it correctly handles `/__index.prefetch.rsc` -- it was previously rewriting those requests to `/__index` which resulted in a 404.
- Stops stripping the `.prefetch.rsc` suffix as these are correctly stripped by Vercel at a later phase in the build output config.

fixes #542