### PR TITLE
fix: Falling back to header if cache tags are not given from fetched object

### DIFF
--- a/.changeset/empty-cups-pull.md
+++ b/.changeset/empty-cups-pull.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Falling back to header if cache tags are not given from fetched CachedFetchValue object. The change was introduced from Next.js 13.5+.

--- a/packages/next-on-pages/templates/_worker.js/utils/cache.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/cache.ts
@@ -2,6 +2,9 @@ import type { CacheAdaptor, IncrementalCacheValue } from '../../cache';
 import { SUSPENSE_CACHE_URL } from '../../cache';
 import { CacheApiAdaptor } from '../../cache/cache-api';
 
+// https://github.com/vercel/next.js/blob/48a566bc4fcfc48d8489f096a87e792912c4989f/packages/next/src/server/lib/incremental-cache/fetch-cache.ts#L19
+const CACHE_TAGS_HEADER = 'x-vercel-cache-tags';
+
 /**
  * Handles an internal request to the suspense cache.
  *
@@ -51,6 +54,9 @@ export async function handleSuspenseCacheRequest(request: Request) {
 			case 'POST': {
 				// Update the value in the cache.
 				const body = await request.json<IncrementalCacheValue>();
+				// Falling back to the cache tags header for Next.js 13.5+
+				body.tags = body.tags ?? body.data.tags ?? request.headers.get(CACHE_TAGS_HEADER)?.split(',') ?? [];
+
 				await cache.set(cacheKey, body);
 
 				return new Response(null, { status: 200 });

--- a/packages/next-on-pages/templates/_worker.js/utils/cache.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/cache.ts
@@ -56,7 +56,7 @@ export async function handleSuspenseCacheRequest(request: Request) {
 				const body = await request.json<IncrementalCacheValue>();
 				// Falling back to the cache tags header for Next.js 13.5+
 				if (body.data.tags === undefined) {
-					body.tags = body.tags ?? request.headers.get(CACHE_TAGS_HEADER)?.split(',')?.filter(Boolean) ?? [];
+					body.tags ??= request.headers.get(CACHE_TAGS_HEADER)?.split(',')?.filter(Boolean) ?? [];
 				} else {
 					body.tags = body.data.tags;
 					delete body.data.tags;

--- a/packages/next-on-pages/templates/_worker.js/utils/cache.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/cache.ts
@@ -2,7 +2,7 @@ import type { CacheAdaptor, IncrementalCacheValue } from '../../cache';
 import { SUSPENSE_CACHE_URL } from '../../cache';
 import { CacheApiAdaptor } from '../../cache/cache-api';
 
-// https://github.com/vercel/next.js/blob/48a566bc4fcfc48d8489f096a87e792912c4989f/packages/next/src/server/lib/incremental-cache/fetch-cache.ts#L19
+// https://github.com/vercel/next.js/blob/48a566bc/packages/next/src/server/lib/incremental-cache/fetch-cache.ts#L19
 const CACHE_TAGS_HEADER = 'x-vercel-cache-tags';
 
 /**

--- a/packages/next-on-pages/templates/_worker.js/utils/cache.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/cache.ts
@@ -55,7 +55,12 @@ export async function handleSuspenseCacheRequest(request: Request) {
 				// Update the value in the cache.
 				const body = await request.json<IncrementalCacheValue>();
 				// Falling back to the cache tags header for Next.js 13.5+
-				body.tags = body.tags ?? body.data.tags ?? request.headers.get(CACHE_TAGS_HEADER)?.split(',') ?? [];
+				if (body.data.tags === undefined) {
+					body.tags = body.tags ?? request.headers.get(CACHE_TAGS_HEADER)?.split(',')?.filter(Boolean) ?? [];
+				} else {
+					body.tags = body.data.tags;
+					delete body.data.tags;
+				}
 
 				await cache.set(cacheKey, body);
 

--- a/packages/next-on-pages/templates/_worker.js/utils/cache.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/cache.ts
@@ -56,7 +56,11 @@ export async function handleSuspenseCacheRequest(request: Request) {
 				const body = await request.json<IncrementalCacheValue>();
 				// Falling back to the cache tags header for Next.js 13.5+
 				if (body.data.tags === undefined) {
-					body.tags ??= request.headers.get(CACHE_TAGS_HEADER)?.split(',')?.filter(Boolean) ?? [];
+					body.tags ??=
+						request.headers
+							.get(CACHE_TAGS_HEADER)
+							?.split(',')
+							?.filter(Boolean) ?? [];
 				} else {
 					body.tags = body.data.tags;
 					delete body.data.tags;

--- a/packages/next-on-pages/templates/cache/adaptor.ts
+++ b/packages/next-on-pages/templates/cache/adaptor.ts
@@ -88,7 +88,7 @@ export class CacheAdaptor {
 
 				// Check if the cache entry is stale or fresh based on the tags.
 				const tags = getDerivedTags(
-					data.value.tags ?? data.value.data.tags ?? []
+					data.value.tags ?? data.value.data.tags ?? [],
 				);
 				const isStale = tags.some(tag => {
 					// If a revalidation has been triggered, the current entry is stale.

--- a/packages/next-on-pages/templates/cache/adaptor.ts
+++ b/packages/next-on-pages/templates/cache/adaptor.ts
@@ -196,7 +196,7 @@ export type CachedFetchValue = {
 		body: string;
 		url: string;
 		status?: number;
-		// old version; https://github.com/vercel/next.js/blob/fda1ecc/packages/next/src/server/response-cache/types.ts#L16
+		// field used by older versions of Next.js (see: https://github.com/vercel/next.js/blob/fda1ecc/packages/next/src/server/response-cache/types.ts#L23)
 		tags?: string[];
 	};
 	// tags are only present with file-system-cache

--- a/packages/next-on-pages/templates/cache/adaptor.ts
+++ b/packages/next-on-pages/templates/cache/adaptor.ts
@@ -87,7 +87,9 @@ export class CacheAdaptor {
 				await this.loadTagsManifest();
 
 				// Check if the cache entry is stale or fresh based on the tags.
-				const tags = getDerivedTags(data.value.tags ?? []);
+				const tags = getDerivedTags(
+					data.value.tags ?? data.value.data.tags ?? []
+				);
 				const isStale = tags.some(tag => {
 					// If a revalidation has been triggered, the current entry is stale.
 					if (revalidatedTags.has(tag)) return true;
@@ -186,7 +188,7 @@ export type TagsManifest = {
 };
 export type TagsManifestItem = { keys: string[]; revalidatedAt?: number };
 
-// https://github.com/vercel/next.js/blob/df4c2aa8ecf25737356d9bf7aaa8a9e5122c0b72/packages/next/src/server/response-cache/types.ts#L24
+// https://github.com/vercel/next.js/blob/df4c2aa8/packages/next/src/server/response-cache/types.ts#L24
 export type CachedFetchValue = {
 	kind: 'FETCH';
 	data: {

--- a/packages/next-on-pages/templates/cache/adaptor.ts
+++ b/packages/next-on-pages/templates/cache/adaptor.ts
@@ -54,7 +54,7 @@ export class CacheAdaptor {
 		switch (newEntry.value?.kind) {
 			case 'FETCH': {
 				// Update the tags with the cache key.
-				const tags = newEntry.value.data.tags ?? [];
+				const tags = newEntry.value.tags ?? [];
 				await this.setTags(tags, { cacheKey: key });
 
 				getDerivedTags(tags).forEach(tag => revalidatedTags.delete(tag));
@@ -87,7 +87,7 @@ export class CacheAdaptor {
 				await this.loadTagsManifest();
 
 				// Check if the cache entry is stale or fresh based on the tags.
-				const tags = getDerivedTags(data.value.data.tags ?? []);
+				const tags = getDerivedTags(data.value.tags ?? []);
 				const isStale = tags.some(tag => {
 					// If a revalidation has been triggered, the current entry is stale.
 					if (revalidatedTags.has(tag)) return true;
@@ -186,7 +186,7 @@ export type TagsManifest = {
 };
 export type TagsManifestItem = { keys: string[]; revalidatedAt?: number };
 
-// https://github.com/vercel/next.js/blob/fda1ecc/packages/next/src/server/response-cache/types.ts#L16
+// https://github.com/vercel/next.js/blob/df4c2aa8ecf25737356d9bf7aaa8a9e5122c0b72/packages/next/src/server/response-cache/types.ts#L24
 export type CachedFetchValue = {
 	kind: 'FETCH';
 	data: {
@@ -194,8 +194,12 @@ export type CachedFetchValue = {
 		body: string;
 		url: string;
 		status?: number;
+		// old version; https://github.com/vercel/next.js/blob/fda1ecc/packages/next/src/server/response-cache/types.ts#L16
 		tags?: string[];
 	};
+	// tags are only present with file-system-cache
+	// fetch cache stores tags outside of cache entry
+	tags?: string[];
 	revalidate: number;
 };
 


### PR DESCRIPTION
- Updated `CachedFetchValue` type introduced in Next.js 13.5.
- When retrieving cache tags, falling back to `x-vercel-cache-tags` header if cache tags are not given from fetched `CachedFetchValue` object.

fixes #556