### PR TITLE
fix: set `x-vercel-sc-host` for older versions of Next.js

### DIFF
--- a/.changeset/brown-insects-protect.md
+++ b/.changeset/brown-insects-protect.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Set `x-vercel-sc-host` request header for older versions of Next.js for the suspense cache.

--- a/packages/next-on-pages/templates/_worker.js/utils/request.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/request.ts
@@ -1,3 +1,5 @@
+import { SUSPENSE_CACHE_URL } from '../../cache';
+
 /**
  * Adjusts the request so that it is formatted as if it were provided by Vercel
  *
@@ -20,6 +22,8 @@ export function adjustRequestForVercel(request: Request): Request {
 			request.cf.longitude as string,
 		);
 	}
+
+	adjustedHeaders.set('x-vercel-sc-host', SUSPENSE_CACHE_URL);
 
 	return new Request(request, { headers: adjustedHeaders });
 }


### PR DESCRIPTION
Older versions of Next.js only use the `x-vercel-sc-host` request header and not the `SUSPENSE_CACHE_URL` env variable, therefore set the request header.