### PR TITLE
fix: match more chars for the next.js bug fix

### DIFF
--- a/.changeset/wicked-shoes-crash.md
+++ b/.changeset/wicked-shoes-crash.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': patch
 ---
 
-Update the matcher for the temp fix for a Next.js bug to match any non-whitespace chars.
+Update the matcher for the temp fix for a Next.js bug to match more chars.

--- a/.changeset/wicked-shoes-crash.md
+++ b/.changeset/wicked-shoes-crash.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Update the matcher for the temp fix for a Next.js bug to match any non-whitespace chars.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -488,7 +488,7 @@ function fixFunctionContents(contents: string): string {
 	// This resolves a critical issue in Next.js 14.0.2 that breaks edge runtime rendering due to the assumption
 	// that the the passed internal request is of type `NodeNextRequest` and never `WebNextRequest`.
 	contents = contents.replace(
-		/;let{originalRequest:(\w+)}=(\w+);/gm,
+		/;let{originalRequest:(\S+)}=(\S+);/gm,
 		';let{originalRequest:$1=$2}=$2;',
 	);
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -488,7 +488,7 @@ function fixFunctionContents(contents: string): string {
 	// This resolves a critical issue in Next.js 14.0.2 that breaks edge runtime rendering due to the assumption
 	// that the the passed internal request is of type `NodeNextRequest` and never `WebNextRequest`.
 	contents = contents.replace(
-		/;let{originalRequest:([\w\$]+)}=([\w\$]+);/gm,
+		/;let{originalRequest:([\w$]+)}=([\w$]+);/gm,
 		';let{originalRequest:$1=$2}=$2;',
 	);
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -488,7 +488,7 @@ function fixFunctionContents(contents: string): string {
 	// This resolves a critical issue in Next.js 14.0.2 that breaks edge runtime rendering due to the assumption
 	// that the the passed internal request is of type `NodeNextRequest` and never `WebNextRequest`.
 	contents = contents.replace(
-		/;let{originalRequest:(\S+)}=(\S+);/gm,
+		/;let{originalRequest:([\w\$]+)}=([\w\$]+);/gm,
 		';let{originalRequest:$1=$2}=$2;',
 	);
 


### PR DESCRIPTION
Apparently, the variable can be `$` which wasn't getting hit by the regex.

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/c418273b-58d1-4cea-89eb-3e1044412845)
