### PR TITLE
fix: route intercepts causing 404s + missing params

### DIFF
--- a/.changeset/brave-cougars-melt.md
+++ b/.changeset/brave-cougars-melt.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix route intercepts causing 404s for the non-intercepted route.

--- a/.changeset/dull-wolves-arrive.md
+++ b/.changeset/dull-wolves-arrive.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix route intercept modals not getting all the parameters for a route.

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
 	"printWidth": 80,
 	"singleQuote": true,
 	"arrowParens": "avoid",
-	"semi": true
+	"semi": true,
+	"trailingComma": "all"
 }


### PR DESCRIPTION
This PR does the following:
- Fixes an issue where route intercepts would cause 404s for the non-intercepted route.
- Fixes an issue where route intercepts would not have all the correct parameters for the route.

See the comments in the code for more context.

Reproduction that this fixes is available at https://github.com/Karibash/nextjs-dynamic-interception-parallel-routes

fixes https://github.com/cloudflare/next-on-pages/issues/558