### PR TITLE
some support for suspense cache soft/implicit tags

### DIFF
--- a/.changeset/good-squids-join.md
+++ b/.changeset/good-squids-join.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Improved support for newer version of Next.js with the suspense cache through trying to handle soft/implicit tags properly

--- a/.changeset/shaggy-wombats-happen.md
+++ b/.changeset/shaggy-wombats-happen.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix old version of Next.js not updating a cache entry properly due to not receving the correct shape they expected.

--- a/packages/next-on-pages/templates/cache/adaptor.ts
+++ b/packages/next-on-pages/templates/cache/adaptor.ts
@@ -76,6 +76,7 @@ export class CacheAdaptor {
 	 * Retrieves an entry from the suspense cache.
 	 *
 	 * @param key Key for the item in the suspense cache.
+	 * @param opts Soft cache tags used when checking if an entry is stale.
 	 * @returns The cached value, or null if no entry exists.
 	 */
 	public async get(


### PR DESCRIPTION
This PR does the following:
- Fixes old Next.js versions not updating cache entry properly because they didn't receive the tags how they expected. Sorry, this is my fault since I suggested to delete that property.
- Adds some support for soft/implicit tags that were introduced by https://github.com/vercel/next.js/pull/53321.

Fwiw, I think there might still be some more work potentially to improve support for newer versions of the suspense cache, but this PR should bring us to a good spot.

I did actually notice that Next.js deciding when it needs to update a stale entry was more reliable on older Next.js versions before they made these changes over the past few months, but that would be something that might need looking into separately, but I don't think there's anything we can really do in that department.

🙃