### PR TITLE
Try to fix not_found routes only when the app router is used

### DIFF
--- a/.changeset/pretty-buttons-join.md
+++ b/.changeset/pretty-buttons-join.md
@@ -2,11 +2,11 @@
 '@cloudflare/next-on-pages': patch
 ---
 
-Do not fix `_not-found` functions for applications only using the Pages Router
+Fix `_not-found` functions only for applications using the App Router
 
 In https://github.com/cloudflare/next-on-pages/pull/418 we introduced a workaround
-that would delete invalid (nodejs) `not-found` functions during the build process
+that would delete invalid (nodejs) `_not-found` functions during the build process
 
 Although the workaround is valid for applications using the App Router it is not
-for applications only using the Pages Router, so make sure that it is not applied
-in applications only using the latter
+for applications only using the Pages Router, so make sure that it is only applied
+when the former is used

--- a/.changeset/pretty-buttons-join.md
+++ b/.changeset/pretty-buttons-join.md
@@ -1,0 +1,12 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Do not fix `_not-found` functions for applications only using the Pages Router
+
+In https://github.com/cloudflare/next-on-pages/pull/418 we introduced a workaround
+that would delete invalid (nodejs) `not-found` functions during the build process
+
+Although the workaround is valid for applications using the App Router it is not
+for applications only using the Pages Router, so make sure that it is not applied
+in applications only using the latter

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
@@ -9,6 +9,7 @@ import {
 import type { CollectedFunctions, FunctionInfo } from './configs';
 import { join } from 'path';
 import type { ProcessVercelFunctionsOpts } from '.';
+import { isUsingAppRouter } from '../getVercelConfig';
 
 type InvalidFunctionsOpts = Pick<
 	ProcessVercelFunctionsOpts,
@@ -30,7 +31,9 @@ export async function checkInvalidFunctions(
 	collectedFunctions: CollectedFunctions,
 	opts: InvalidFunctionsOpts,
 ): Promise<void> {
-	await tryToFixNotFoundRoute(collectedFunctions);
+	if(isUsingAppRouter(opts.vercelConfig)) {
+		await tryToFixAppRouterNotFoundRoute(collectedFunctions);
+	}
 
 	await tryToFixI18nFunctions(collectedFunctions, opts);
 
@@ -62,7 +65,7 @@ export async function checkInvalidFunctions(
  *
  * @param collectedFunctions Collected functions from the Vercel build output.
  */
-async function tryToFixNotFoundRoute({
+async function tryToFixAppRouterNotFoundRoute({
 	invalidFunctions,
 	ignoredFunctions,
 }: CollectedFunctions): Promise<void> {

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
@@ -31,7 +31,7 @@ export async function checkInvalidFunctions(
 	collectedFunctions: CollectedFunctions,
 	opts: InvalidFunctionsOpts,
 ): Promise<void> {
-	if(isUsingAppRouter(opts.vercelConfig)) {
+	if (isUsingAppRouter(opts.vercelConfig)) {
 		await tryToFixAppRouterNotFoundRoute(collectedFunctions);
 	}
 


### PR DESCRIPTION
resolves #528 

___

This PR implements the `isUsingAppRouter` which can then be used to tackle #413 automatically for the user without asking them to manually ignore invalid routes (as suggested in #497)