### PR TITLE
Update failing e2es (in regards to slugs rendering)

### DIFF
--- a/pages-e2e/features/appRouting/ssr-dynamic.test.ts
+++ b/pages-e2e/features/appRouting/ssr-dynamic.test.ts
@@ -32,15 +32,15 @@ describe('ssr dynamic pages', () => {
 			});
 
 			await assertVisible('li', {
-				hasText: '0 - dog'
+				hasText: '0 - dog',
 			});
 
 			await assertVisible('li', {
-				hasText: '1 - cat'
+				hasText: '1 - cat',
 			});
 
 			await assertVisible('li', {
-				hasText: '2 - iguana'
+				hasText: '2 - iguana',
 			});
 		});
 
@@ -72,15 +72,15 @@ describe('ssr dynamic pages', () => {
 			});
 
 			await assertVisible('li', {
-				hasText: '0 - dog'
+				hasText: '0 - dog',
 			});
 
 			await assertVisible('li', {
-				hasText: '1 - cat'
+				hasText: '1 - cat',
 			});
 
 			await assertVisible('li', {
-				hasText: '2 - iguana'
+				hasText: '2 - iguana',
 			});
 		});
 
@@ -112,15 +112,15 @@ describe('ssr dynamic pages', () => {
 			});
 
 			await assertVisible('li', {
-				hasText: '0 - red'
+				hasText: '0 - red',
 			});
 
 			await assertVisible('li', {
-				hasText: '1 - green'
+				hasText: '1 - green',
 			});
 
 			await assertVisible('li', {
-				hasText: '2 - blue'
+				hasText: '2 - blue',
 			});
 		});
 

--- a/pages-e2e/features/appRouting/ssr-dynamic.test.ts
+++ b/pages-e2e/features/appRouting/ssr-dynamic.test.ts
@@ -31,25 +31,17 @@ describe('ssr dynamic pages', () => {
 				hasText: 'The provided pets are:',
 			});
 
-			// This is how slugs currently work with next-on-pages
-			// see: https://github.com/cloudflare/next-on-pages/issues/515
 			await assertVisible('li', {
-				hasText: '0 - dog%2Fcat%2Figuana',
+				hasText: '0 - dog'
 			});
 
-			// the following checks indicate how it should work instead
+			await assertVisible('li', {
+				hasText: '1 - cat'
+			});
 
-			// await assertVisible('li', {
-			// 	hasText: '0 - dog'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '1 - cat'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '2 - iguana'
-			// });
+			await assertVisible('li', {
+				hasText: '2 - iguana'
+			});
 		});
 
 		test('visiting / (without providing the required pets)', async () => {
@@ -79,25 +71,17 @@ describe('ssr dynamic pages', () => {
 				hasText: 'The provided pets are:',
 			});
 
-			// This is how slugs currently work with next-on-pages
-			// see: https://github.com/cloudflare/next-on-pages/issues/515
 			await assertVisible('li', {
-				hasText: '0 - dog%2Fcat%2Figuana',
+				hasText: '0 - dog'
 			});
 
-			// the following checks indicate how it should work instead
+			await assertVisible('li', {
+				hasText: '1 - cat'
+			});
 
-			// await assertVisible('li', {
-			// 	hasText: '0 - dog'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '1 - cat'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '2 - iguana'
-			// });
+			await assertVisible('li', {
+				hasText: '2 - iguana'
+			});
 		});
 
 		test('visiting / (without providing the required pets)', async () => {
@@ -127,25 +111,17 @@ describe('ssr dynamic pages', () => {
 				hasText: 'The provided colors are:',
 			});
 
-			// This is how slugs currently work with next-on-pages
-			// see: https://github.com/cloudflare/next-on-pages/issues/515
 			await assertVisible('li', {
-				hasText: '0 - red%2Fgreen%2Fblue',
+				hasText: '0 - red'
 			});
 
-			// the following checks indicate how it should work instead
+			await assertVisible('li', {
+				hasText: '1 - green'
+			});
 
-			// await assertVisible('li', {
-			// 	hasText: '0 - red'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '1 - green'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '2 - blue'
-			// });
+			await assertVisible('li', {
+				hasText: '2 - blue'
+			});
 		});
 
 		test('visiting / (without providing the colors)', async () => {

--- a/pages-e2e/features/appRoutingSsrDynamicCatchAll/assets/app/ssr-dynamic-catch-all/catch-all/[...pets]/page.js
+++ b/pages-e2e/features/appRoutingSsrDynamicCatchAll/assets/app/ssr-dynamic-catch-all/catch-all/[...pets]/page.js
@@ -1,0 +1,15 @@
+export const runtime = 'edge';
+
+export default function SSRDynamicCatchAllPage({ params }) {
+	return (
+		<div>
+			<p>The provided pets are:</p>
+			<ul>
+				{params.pets.map((pet, i) => {
+					const text = `${i} - ${pet}`;
+					return <li key={pet}>{text}</li>;
+				})}
+			</ul>
+		</div>
+	);
+}

--- a/pages-e2e/features/appRoutingSsrDynamicCatchAll/assets/app/ssr-dynamic-catch-all/optional-catch-all/[[...colors]]/page.jsx
+++ b/pages-e2e/features/appRoutingSsrDynamicCatchAll/assets/app/ssr-dynamic-catch-all/optional-catch-all/[[...colors]]/page.jsx
@@ -1,0 +1,22 @@
+export const runtime = 'edge';
+
+export default function SSRDynamicOptionalCatchAllPage({ params }) {
+	return (
+		<div>
+			{!params.colors ? (
+				<p>No color provided</p>
+			) : (
+				<>
+					<p>The provided colors are:</p>
+					<ul>
+						{params.colors.map((color, i) => (
+							<li key={color}>
+								{i} - {color}
+							</li>
+						))}
+					</ul>
+				</>
+			)}
+		</div>
+	);
+}

--- a/pages-e2e/features/appRoutingSsrDynamicCatchAll/main.feature
+++ b/pages-e2e/features/appRoutingSsrDynamicCatchAll/main.feature
@@ -1,0 +1,3 @@
+{
+	"setup": "node --loader tsm setup.ts"
+}

--- a/pages-e2e/features/appRoutingSsrDynamicCatchAll/setup.ts
+++ b/pages-e2e/features/appRoutingSsrDynamicCatchAll/setup.ts
@@ -1,0 +1,2 @@
+import { copyWorkspaceAssets } from '../_utils/copyWorkspaceAssets';
+await copyWorkspaceAssets();

--- a/pages-e2e/features/appRoutingSsrDynamicCatchAll/ssr-dynamic-catch-all.test.ts
+++ b/pages-e2e/features/appRoutingSsrDynamicCatchAll/ssr-dynamic-catch-all.test.ts
@@ -1,26 +1,10 @@
 import { describe, test } from 'vitest';
 import { getAssertVisible } from '@features-utils/getAssertVisible';
 
-describe('ssr dynamic pages', () => {
-	describe('standard [pageName] route', () => {
-		['page-abc', 'page-xyz', 'page-123'].forEach(route => {
-			const path = `/ssr-dynamic/page/${route}`;
-			test(`visiting ${path}`, async () => {
-				const page = await BROWSER.newPage();
-				const assertVisible = getAssertVisible(page);
-
-				await page.goto(`${DEPLOYMENT_URL}${path}`);
-
-				await assertVisible('p', {
-					hasText: `This Page's name is: ${route}`,
-				});
-			});
-		});
-	});
-
-	describe('standard [...pets] catch all route (basic functionality)', () => {
+describe('ssr dynamic catch-all pages', () => {
+	describe('standard [...pets] catch all route', () => {
 		test('visiting /dog/cat/iguana', async () => {
-			const path = '/ssr-dynamic/catch-all/dog/cat/iguana';
+			const path = '/ssr-dynamic-catch-all/catch-all/dog/cat/iguana';
 
 			const page = await BROWSER.newPage();
 			const assertVisible = getAssertVisible(page);
@@ -31,14 +15,21 @@ describe('ssr dynamic pages', () => {
 				hasText: 'The provided pets are:',
 			});
 
-			// Note: the slugs rendering is not tested here as it has not been
-			//       working properly in next-on-pages until Next.js v14.0.4
-			//       (for later versions of Next.js we do test the slugs in
-			//       the appRoutingSsrDynamicCatchAll feature)
+			await assertVisible('li', {
+				hasText: '0 - dog',
+			});
+
+			await assertVisible('li', {
+				hasText: '1 - cat',
+			});
+
+			await assertVisible('li', {
+				hasText: '2 - iguana',
+			});
 		});
 
 		test('visiting / (without providing the required pets)', async () => {
-			const path = '/ssr-dynamic/catch-all/';
+			const path = '/ssr-dynamic-catch-all/catch-all/';
 
 			const page = await BROWSER.newPage();
 			const assertVisible = getAssertVisible(page);
@@ -51,9 +42,9 @@ describe('ssr dynamic pages', () => {
 		});
 	});
 
-	describe('catch-all [...pets] route (basic functionality)', () => {
+	describe('catch-all [...pets] route', () => {
 		test('visiting /dog/cat/iguana', async () => {
-			const path = '/ssr-dynamic/catch-all/dog/cat/iguana';
+			const path = '/ssr-dynamic-catch-all/catch-all/dog/cat/iguana';
 
 			const page = await BROWSER.newPage();
 			const assertVisible = getAssertVisible(page);
@@ -64,14 +55,21 @@ describe('ssr dynamic pages', () => {
 				hasText: 'The provided pets are:',
 			});
 
-			// Note: the slugs rendering is not tested here as it has not been
-			//       working properly in next-on-pages until Next.js v14.0.4
-			//       (for later versions of Next.js we do test the slugs in
-			//       the appRoutingSsrDynamicCatchAll feature)
+			await assertVisible('li', {
+				hasText: '0 - dog',
+			});
+
+			await assertVisible('li', {
+				hasText: '1 - cat',
+			});
+
+			await assertVisible('li', {
+				hasText: '2 - iguana',
+			});
 		});
 
 		test('visiting / (without providing the required pets)', async () => {
-			const path = '/ssr-dynamic/catch-all/';
+			const path = '/ssr-dynamic-catch-all/catch-all/';
 
 			const page = await BROWSER.newPage();
 			const assertVisible = getAssertVisible(page);
@@ -84,9 +82,9 @@ describe('ssr dynamic pages', () => {
 		});
 	});
 
-	describe('optional catch-all [[...pets]] route (basic functionality)', () => {
+	describe('optional catch-all [[...pets]] route', () => {
 		test('visiting /red/green/blue', async () => {
-			const path = '/ssr-dynamic/optional-catch-all/red/green/blue';
+			const path = '/ssr-dynamic-catch-all/optional-catch-all/red/green/blue';
 
 			const page = await BROWSER.newPage();
 			const assertVisible = getAssertVisible(page);
@@ -97,14 +95,21 @@ describe('ssr dynamic pages', () => {
 				hasText: 'The provided colors are:',
 			});
 
-			// Note: the slugs rendering is not tested here as it has not been
-			//       working properly in next-on-pages until Next.js v14.0.4
-			//       (for later versions of Next.js we do test the slugs in
-			//       the appRoutingSsrDynamicCatchAll feature)
+			await assertVisible('li', {
+				hasText: '0 - red',
+			});
+
+			await assertVisible('li', {
+				hasText: '1 - green',
+			});
+
+			await assertVisible('li', {
+				hasText: '2 - blue',
+			});
 		});
 
 		test('visiting / (without providing the colors)', async () => {
-			const path = '/ssr-dynamic/optional-catch-all';
+			const path = '/ssr-dynamic-catch-all/optional-catch-all';
 
 			const page = await BROWSER.newPage();
 			const assertVisible = getAssertVisible(page);
@@ -118,7 +123,7 @@ describe('ssr dynamic pages', () => {
 	});
 
 	['foo/bar', 'non-existent'].forEach(route => {
-		const path = `/ssr-dynamic/${route}`;
+		const path = `/ssr-dynamic-catch-all/${route}`;
 		test(`visiting an invalid / ${path} page`, async () => {
 			const page = await BROWSER.newPage();
 			const assertVisible = getAssertVisible(page);

--- a/pages-e2e/features/pagesRouting/ssr-dynamic.test.ts
+++ b/pages-e2e/features/pagesRouting/ssr-dynamic.test.ts
@@ -25,7 +25,7 @@ describe.skipIf(skipTests)('ssr dynamic pages', () => {
 		});
 	});
 
-	describe('catch-all [...pets] route', () => {
+	describe('catch-all [...pets] route (basic functionality)', () => {
 		test('visiting /dog/cat/iguana', async () => {
 			const path = '/ssr-dynamic/catch-all/dog/cat/iguana';
 
@@ -38,25 +38,10 @@ describe.skipIf(skipTests)('ssr dynamic pages', () => {
 				hasText: 'The provided pets are:',
 			});
 
-			// This is how slugs currently work with next-on-pages
-			// see: https://github.com/cloudflare/next-on-pages/issues/515
-			await assertVisible('li', {
-				hasText: '0 - dog/cat/iguana',
-			});
-
-			// the following checks indicate how it should work instead
-
-			// await assertVisible('li', {
-			// 	hasText: '0 - dog'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '1 - cat'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '2 - iguana'
-			// });
+			// Note: the slugs rendering is not tested here as it has not been
+			//       working properly in next-on-pages until Next.js v14.0.4
+			//       (for later versions of Next.js we do test the slugs in
+			//       the pagesRoutingSsrDynamicCatchAll feature)
 		});
 
 		test('visiting / (without providing the required pets)', async () => {
@@ -73,7 +58,7 @@ describe.skipIf(skipTests)('ssr dynamic pages', () => {
 		});
 	});
 
-	describe('optional catch-all [[...pets]] route', () => {
+	describe('optional catch-all [[...pets]] route (basic functionality)', () => {
 		test('visiting /red/green/blue', async () => {
 			const path = '/ssr-dynamic/optional-catch-all/red/green/blue';
 
@@ -86,25 +71,10 @@ describe.skipIf(skipTests)('ssr dynamic pages', () => {
 				hasText: 'The provided colors are:',
 			});
 
-			// This is how slugs currently work with next-on-pages
-			// see: https://github.com/cloudflare/next-on-pages/issues/515
-			await assertVisible('li', {
-				hasText: '0 - red/green/blue',
-			});
-
-			// the following checks indicate how it should work instead
-
-			// await assertVisible('li', {
-			// 	hasText: '0 - red'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '1 - green'
-			// });
-
-			// await assertVisible('li', {
-			// 	hasText: '2 - blue'
-			// });
+			// Note: the slugs rendering is not tested here as it has not been
+			//       working properly in next-on-pages until Next.js v14.0.4
+			//       (for later versions of Next.js we do test the slugs in
+			//       the pagesRoutingSsrDynamicCatchAll feature)
 		});
 
 		test('visiting / (without providing the colors)', async () => {

--- a/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/assets/pages/ssr-dynamic-catch-all/catch-all/[...pets].jsx
+++ b/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/assets/pages/ssr-dynamic-catch-all/catch-all/[...pets].jsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/router';
+
+export const runtime = 'experimental-edge';
+
+export default function SSRDynamicCatchAllPage() {
+	const router = useRouter();
+
+	return (
+		<div>
+			<p>The provided pets are:</p>
+			<ul>
+				{router.query.pets?.map((pet, i) => (
+					<li key={pet}>
+						{i} - {pet}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/assets/pages/ssr-dynamic-catch-all/optional-catch-all/[[...colors]].jsx
+++ b/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/assets/pages/ssr-dynamic-catch-all/optional-catch-all/[[...colors]].jsx
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router';
+
+export const runtime = 'experimental-edge';
+
+export default function SSRDynamicCatchAllPage() {
+	const router = useRouter();
+
+	return (
+		<div>
+			{!router.query.colors ? (
+				<p>No color provided</p>
+			) : (
+				<>
+					<p>The provided colors are:</p>
+					<ul>
+						{router.query.colors.map((color, i) => (
+							<li key={color}>
+								{i} - {color}
+							</li>
+						))}
+					</ul>
+				</>
+			)}
+		</div>
+	);
+}

--- a/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/main.feature
+++ b/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/main.feature
@@ -1,0 +1,3 @@
+{
+	"setup": "node --loader tsm setup.ts"
+}

--- a/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/setup.ts
+++ b/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/setup.ts
@@ -1,0 +1,2 @@
+import { copyWorkspaceAssets } from '../_utils/copyWorkspaceAssets';
+await copyWorkspaceAssets();

--- a/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/ssr-dynamic-catch-all.test.ts
+++ b/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/ssr-dynamic-catch-all.test.ts
@@ -39,15 +39,15 @@ describe.skipIf(skipTests)('ssr dynamic pages', () => {
 			});
 
 			await assertVisible('li', {
-				hasText: '0 - dog'
+				hasText: '0 - dog',
 			});
 
 			await assertVisible('li', {
-				hasText: '1 - cat'
+				hasText: '1 - cat',
 			});
 
 			await assertVisible('li', {
-				hasText: '2 - iguana'
+				hasText: '2 - iguana',
 			});
 		});
 
@@ -79,15 +79,15 @@ describe.skipIf(skipTests)('ssr dynamic pages', () => {
 			});
 
 			await assertVisible('li', {
-				hasText: '0 - red'
+				hasText: '0 - red',
 			});
 
 			await assertVisible('li', {
-				hasText: '1 - green'
+				hasText: '1 - green',
 			});
 
 			await assertVisible('li', {
-				hasText: '2 - blue'
+				hasText: '2 - blue',
 			});
 		});
 

--- a/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/ssr-dynamic-catch-all.test.ts
+++ b/pages-e2e/features/pagesRoutingSsrDynamicCatchAll/ssr-dynamic-catch-all.test.ts
@@ -1,7 +1,14 @@
 import { describe, test } from 'vitest';
 import { getAssertVisible } from '@features-utils/getAssertVisible';
 
-describe('ssr dynamic pages', () => {
+const frameworkVersion = await fetch(`${DEPLOYMENT_URL}/api/version`).then(
+	resp => (resp.status === 200 ? resp.text() : ''),
+);
+
+// This doesn't work in next 12
+const skipTests = frameworkVersion.startsWith('12');
+
+describe.skipIf(skipTests)('ssr dynamic pages', () => {
 	describe('standard [pageName] route', () => {
 		['page-abc', 'page-xyz', 'page-123'].forEach(route => {
 			const path = `/ssr-dynamic/page/${route}`;
@@ -18,7 +25,7 @@ describe('ssr dynamic pages', () => {
 		});
 	});
 
-	describe('standard [...pets] catch all route (basic functionality)', () => {
+	describe('catch-all [...pets] route', () => {
 		test('visiting /dog/cat/iguana', async () => {
 			const path = '/ssr-dynamic/catch-all/dog/cat/iguana';
 
@@ -31,10 +38,17 @@ describe('ssr dynamic pages', () => {
 				hasText: 'The provided pets are:',
 			});
 
-			// Note: the slugs rendering is not tested here as it has not been
-			//       working properly in next-on-pages until Next.js v14.0.4
-			//       (for later versions of Next.js we do test the slugs in
-			//       the appRoutingSsrDynamicCatchAll feature)
+			await assertVisible('li', {
+				hasText: '0 - dog'
+			});
+
+			await assertVisible('li', {
+				hasText: '1 - cat'
+			});
+
+			await assertVisible('li', {
+				hasText: '2 - iguana'
+			});
 		});
 
 		test('visiting / (without providing the required pets)', async () => {
@@ -51,40 +65,7 @@ describe('ssr dynamic pages', () => {
 		});
 	});
 
-	describe('catch-all [...pets] route (basic functionality)', () => {
-		test('visiting /dog/cat/iguana', async () => {
-			const path = '/ssr-dynamic/catch-all/dog/cat/iguana';
-
-			const page = await BROWSER.newPage();
-			const assertVisible = getAssertVisible(page);
-
-			await page.goto(`${DEPLOYMENT_URL}${path}`);
-
-			await assertVisible('p', {
-				hasText: 'The provided pets are:',
-			});
-
-			// Note: the slugs rendering is not tested here as it has not been
-			//       working properly in next-on-pages until Next.js v14.0.4
-			//       (for later versions of Next.js we do test the slugs in
-			//       the appRoutingSsrDynamicCatchAll feature)
-		});
-
-		test('visiting / (without providing the required pets)', async () => {
-			const path = '/ssr-dynamic/catch-all/';
-
-			const page = await BROWSER.newPage();
-			const assertVisible = getAssertVisible(page);
-
-			await page.goto(`${DEPLOYMENT_URL}${path}`);
-
-			await assertVisible('h1', {
-				hasText: '404',
-			});
-		});
-	});
-
-	describe('optional catch-all [[...pets]] route (basic functionality)', () => {
+	describe('optional catch-all [[...pets]] route', () => {
 		test('visiting /red/green/blue', async () => {
 			const path = '/ssr-dynamic/optional-catch-all/red/green/blue';
 
@@ -97,10 +78,17 @@ describe('ssr dynamic pages', () => {
 				hasText: 'The provided colors are:',
 			});
 
-			// Note: the slugs rendering is not tested here as it has not been
-			//       working properly in next-on-pages until Next.js v14.0.4
-			//       (for later versions of Next.js we do test the slugs in
-			//       the appRoutingSsrDynamicCatchAll feature)
+			await assertVisible('li', {
+				hasText: '0 - red'
+			});
+
+			await assertVisible('li', {
+				hasText: '1 - green'
+			});
+
+			await assertVisible('li', {
+				hasText: '2 - blue'
+			});
 		});
 
 		test('visiting / (without providing the colors)', async () => {

--- a/pages-e2e/fixtures/appLatest/main.fixture
+++ b/pages-e2e/fixtures/appLatest/main.fixture
@@ -5,6 +5,7 @@
 		"simpleAppStaticRoutesAndAssets",
 		"appMiddleware",
 		"appRouting",
+		"appRoutingSsrDynamicCatchAll",
 		"appConfigsTrailingSlashFalse",
 		"appConfigsRewritesRedirectsHeaders"
 	],

--- a/pages-e2e/fixtures/pagesLatest/main.fixture
+++ b/pages-e2e/fixtures/pagesLatest/main.fixture
@@ -5,6 +5,7 @@
 		"simplePagesStaticRoutesAndAssets",
 		"pagesMiddleware",
 		"pagesRouting",
+		"pagesRoutingSsrDynamicCatchAll",
 		"pagesConfigsRewritesRedirectsHeaders"
 	],
 	"localSetup": "./setup.sh",


### PR DESCRIPTION
The e2es were checking for a incorrect rendering of slugs for catch-all routes, that seems to have been fixed upstream by Next making the `appLatest` and `pagesLatest` e2es failing.

So this PR changes the e2es so that we check for the correct rendering of slugs now, but only for the latest fixtures (the older fixtures do not check for the incorrect rendering anymore as that would overcomplicate the `(app|pages)Routing` features and is also actually not too useful of a check).

> PS: So we can sometimes get lucky and get fixes (and not only new bugs) from upstream! 🤯 😄 🥳 