### PR TITLE
Update warning syntax in docs-scraper message

### DIFF
--- a/internal-packages/docs-scraper/scripts/createOrUpdateIssue.ts
+++ b/internal-packages/docs-scraper/scripts/createOrUpdateIssue.ts
@@ -120,7 +120,7 @@ function generateMdList(listDescription: string, items: string[]): string {
 function generateRememberToUpdateSection(): string {
 	let rememberToUpdateSection = '';
 
-	rememberToUpdateSection += '\n> **Warning**\n';
+	rememberToUpdateSection += '\n> [!WARNING]\n';
 	rememberToUpdateSection += '> Remember to update:\n';
 	rememberToUpdateSection +=
 		'> - [The supported documentation](https://github.com/cloudflare/next-on-pages/blob/main/packages/next-on-pages/docs/supported.md#nextconfigjs-properties)\n';


### PR DESCRIPTION
The github markdown for warning has changed: https://github.com/orgs/community/discussions/16925

Causing the warning markdown not to be displayed as intended (see: https://github.com/cloudflare/next-on-pages/issues/463):
![warning screenshot](https://github.com/cloudflare/next-on-pages/assets/61631103/4e43272d-afd6-4bc2-8ce4-96892249a22e)

The changes here just update the markdown so that it shows the warning properly:
![Screenshot 2023-12-11 at 14 10 46](https://github.com/cloudflare/next-on-pages/assets/61631103/67b9eca9-df50-490c-afab-fe3f3615fb61)
