### PR TITLE
Fix Durable Object bindings proxy with new Miniflare versions

### DIFF
--- a/.changeset/orange-buttons-add.md
+++ b/.changeset/orange-buttons-add.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+fix: ensure Durable Object stub proxies fetch Durable Objects and not their containing Worker
+
+Previously, calling `DurableObjectStub#fetch()` would dispatch a `fetch` event to the Worker containing the target Durable Object, not the Durable Object itself. This change ensures the `fetch` event is dispatched directly to the Durable Object.

--- a/.changeset/witty-kids-repair.md
+++ b/.changeset/witty-kids-repair.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+chore: bump to `miniflare@3.20231218.1`

--- a/internal-packages/next-dev/package.json
+++ b/internal-packages/next-dev/package.json
@@ -20,7 +20,7 @@
 		"devBindingsOptions.ts"
 	],
 	"dependencies": {
-		"miniflare": "3.20231002.0",
+		"miniflare": "^3.20231218.1",
 		"node-fetch": "^3.3.2"
 	},
 	"devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 			"name": "@cloudflare/next-on-pages-next-dev",
 			"version": "0.0.1",
 			"dependencies": {
-				"miniflare": "3.20231002.0",
+				"miniflare": "^3.20231218.1",
 				"node-fetch": "^3.3.2"
 			},
 			"devDependencies": {
@@ -52,81 +52,6 @@
 				"tsconfig": "*",
 				"typescript": "^5.0.4",
 				"vitest": "^0.32.2"
-			}
-		},
-		"internal-packages/next-dev/node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231002.0.tgz",
-			"integrity": "sha512-sgtjzVO/wtI/6S7O0bk4zQAv2xlvqOxB18AXzlit6uXgbYFGeQedRHjhKVMOacGmWEnM4C3ir/fxJGsc3Pyxng==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"internal-packages/next-dev/node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231002.0.tgz",
-			"integrity": "sha512-dv8nztYFaTYYgBpyy80vc4hdMYv9mhyNbvBsZywm8S7ivcIpzogi0UKkGU4E/G0lYK6W3WtwTBqwRe+pXJ1+Ww==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"internal-packages/next-dev/node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231002.0.tgz",
-			"integrity": "sha512-UG8SlLcGzaQDSSw6FR4+Zf408925wkLOCAi8w5qEoFYu3g4Ef7ZenstesCOsyWL7qBDKx0/iwk6+a76W5IHI0Q==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"internal-packages/next-dev/node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231002.0.tgz",
-			"integrity": "sha512-GPaa66ZSq1gK09r87c5CJbHIApcIU//LVHz3rnUxK0//00YCwUuGUUK1dn/ylg+fVqDQxIDmH+ABnobBanvcDA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"internal-packages/next-dev/node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231002.0.tgz",
-			"integrity": "sha512-ybIy+sCme0VO0RscndXvqWNBaRMUOc8vhi+1N2h/KDsKfNLsfEQph+XWecfKzJseUy1yE2rV1xei3BaNmaa6vg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"internal-packages/next-dev/node_modules/data-uri-to-buffer": {
@@ -492,28 +417,6 @@
 				"node": ">=12"
 			}
 		},
-		"internal-packages/next-dev/node_modules/miniflare": {
-			"version": "3.20231002.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231002.0.tgz",
-			"integrity": "sha512-Qw1JfGwx1ZuaoumE9DpzPm78b9RD+qP/k+iAPaCIay9iQfcf7ri7rX6Zper2rReawuL+DdNxXJmhB4cfwn5Glw==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.22.1",
-				"workerd": "1.20231002.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
 		"internal-packages/next-dev/node_modules/node-fetch": {
 			"version": "3.3.2",
 			"license": "MIT",
@@ -528,45 +431,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/node-fetch"
-			}
-		},
-		"internal-packages/next-dev/node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"internal-packages/next-dev/node_modules/undici": {
-			"version": "5.28.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-			"integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.0"
-			}
-		},
-		"internal-packages/next-dev/node_modules/workerd": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231002.0.tgz",
-			"integrity": "sha512-NFuUQBj30ZguDoPZ6bL40hINiu8aP2Pvxr/3xAdhWOwVFLuObPOiSdQ8qm4JYZ7jovxWjWE4Z7VR2avjIzEksQ==",
-			"hasInstallScript": true,
-			"bin": {
-				"workerd": "bin/workerd"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20231002.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20231002.0",
-				"@cloudflare/workerd-linux-64": "1.20231002.0",
-				"@cloudflare/workerd-linux-arm64": "1.20231002.0",
-				"@cloudflare/workerd-windows-64": "1.20231002.0"
 			}
 		},
 		"internal-packages/next-on-pages-tsconfig": {
@@ -2207,9 +2071,9 @@
 			"link": true
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20231030.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231030.0.tgz",
-			"integrity": "sha512-J4PQ9utPxLya9yHdMMx3AZeC5M/6FxcoYw6jo9jbDDFTy+a4Gslqf4Im9We3aeOEdPXa3tgQHVQOSelJSZLhIw==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231218.0.tgz",
+			"integrity": "sha512-547gOmTIVmRdDy7HNAGJUPELa+fSDm2Y0OCxqAtQOz0GLTDu1vX61xYmsb2rn91+v3xW6eMttEIpbYokKjtfJA==",
 			"cpu": [
 				"x64"
 			],
@@ -2222,9 +2086,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20231030.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231030.0.tgz",
-			"integrity": "sha512-WSJJjm11Del4hSneiNB7wTXGtBXI4QMCH9l5qf4iT5PAW8cESGcCmdHtWDWDtGAAGcvmLT04KNvmum92vRKKQQ==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231218.0.tgz",
+			"integrity": "sha512-b39qrU1bKolCfmKFDAnX4vXcqzISkEUVE/V8sMBsFzxrIpNAbcUHBZAQPYmS/OHIGB94KjOVokvDi7J6UNurPw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2237,9 +2101,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20231030.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231030.0.tgz",
-			"integrity": "sha512-2HUeRTvoCC17fxE0qdBeR7J9dO8j4A8ZbdcvY8pZxdk+zERU6+N03RTbk/dQMU488PwiDvcC3zZqS4gwLfVT8g==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231218.0.tgz",
+			"integrity": "sha512-dMUF1wA+0mybm6hHNOCgY/WMNMwomPPs4I7vvYCgwHSkch0Q2Wb7TnxQZSt8d1PK/myibaBwadrlIxpjxmpz3w==",
 			"cpu": [
 				"x64"
 			],
@@ -2252,9 +2116,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20231030.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231030.0.tgz",
-			"integrity": "sha512-4/GK5zHh+9JbUI6Z5xTCM0ZmpKKHk7vu9thmHjUxtz+o8Ne9DoD7DlDvXQWgMF6XGaTubDWyp3ttn+Qv8jDFuQ==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231218.0.tgz",
+			"integrity": "sha512-2s5uc8IHt0QmWyKxAr1Fy+4b8Xy0b/oUtlPnm5MrKi2gDRlZzR7JvxENPJCpCnYENydS8lzvkMiAFECPBccmyQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2267,9 +2131,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20231030.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231030.0.tgz",
-			"integrity": "sha512-fb/Jgj8Yqy3PO1jLhk7mTrHMkR8jklpbQFud6rL/aMAn5d6MQbaSrYOCjzkKGp0Zng8D2LIzSl+Fc0C9Sggxjg==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231218.0.tgz",
+			"integrity": "sha512-oN5hz6TXUDB5YKUN5N3QWAv6cYz9JjTZ9g16HVyoegVFEL6/zXU3tV19MBX2IvlE11ab/mRogEv9KXVIrHfKmA==",
 			"cpu": [
 				"x64"
 			],
@@ -10446,19 +10310,19 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "3.20231030.2",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231030.2.tgz",
-			"integrity": "sha512-+DYdMqWlUaY4wBylIjewNu8OVsPFquYjQkxoSb2jGIMBmlKaef65Hn2Bu8sub5tQzQ8tLO0FRklmD2Upx0HCCQ==",
+			"version": "3.20231218.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231218.1.tgz",
+			"integrity": "sha512-rl/wADgaRLpbl7EMobwbAt6BgVqkOoWsVQJAliIIUCRzC0s0xg7ZVeoV+DuQD4ffN4RySXsPnP97hp7ksc7ylA==",
 			"dependencies": {
+				"@cspotcode/source-map-support": "0.8.1",
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
 				"capnp-ts": "^0.7.0",
 				"exit-hook": "^2.2.1",
 				"glob-to-regexp": "^0.4.1",
-				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.22.1",
-				"workerd": "1.20231030.0",
+				"workerd": "1.20231218.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
@@ -10468,14 +10332,6 @@
 			},
 			"engines": {
 				"node": ">=16.13"
-			}
-		},
-		"node_modules/miniflare/node_modules/source-map-support": {
-			"version": "0.5.21",
-			"license": "MIT",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/miniflare/node_modules/undici": {
@@ -13630,26 +13486,52 @@
 			}
 		},
 		"node_modules/turbo": {
-			"version": "1.10.15",
-			"resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.15.tgz",
-			"integrity": "sha512-mKKkqsuDAQy1wCCIjCdG+jOCwUflhckDMSRoeBPcIL/CnCl7c5yRDFe7SyaXloUUkt4tUR0rvNIhVCcT7YeQpg==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo/-/turbo-1.11.3.tgz",
+			"integrity": "sha512-RCJOUFcFMQNIGKSjC9YmA5yVP1qtDiBA0Lv9VIgrXraI5Da1liVvl3VJPsoDNIR9eFMyA/aagx1iyj6UWem5hA==",
 			"dev": true,
 			"bin": {
 				"turbo": "bin/turbo"
 			},
 			"optionalDependencies": {
-				"turbo-darwin-64": "1.10.15",
-				"turbo-darwin-arm64": "1.10.15",
-				"turbo-linux-64": "1.10.15",
-				"turbo-linux-arm64": "1.10.15",
-				"turbo-windows-64": "1.10.15",
-				"turbo-windows-arm64": "1.10.15"
+				"turbo-darwin-64": "1.11.3",
+				"turbo-darwin-arm64": "1.11.3",
+				"turbo-linux-64": "1.11.3",
+				"turbo-linux-arm64": "1.11.3",
+				"turbo-windows-64": "1.11.3",
+				"turbo-windows-arm64": "1.11.3"
 			}
 		},
+		"node_modules/turbo-darwin-64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.11.3.tgz",
+			"integrity": "sha512-IsOOg2bVbIt3o/X8Ew9fbQp5t1hTHN3fGNQYrPQwMR2W1kIAC6RfbVD4A9OeibPGyEPUpwOH79hZ9ydFH5kifw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/turbo-darwin-arm64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.11.3.tgz",
+			"integrity": "sha512-FsJL7k0SaPbJzI/KCnrf/fi3PgCDCjTliMc/kEFkuWVA6Httc3Q4lxyLIIinz69q6JTx8wzh6yznUMzJRI3+dg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
 		"node_modules/turbo-linux-64": {
-			"version": "1.10.15",
-			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.15.tgz",
-			"integrity": "sha512-dM07SiO3RMAJ09Z+uB2LNUSkPp3I1IMF8goH5eLj+d8Kkwoxd/+qbUZOj9RvInyxU/IhlnO9w3PGd3Hp14m/nA==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.11.3.tgz",
+			"integrity": "sha512-SvW7pvTVRGsqtSkII5w+wriZXvxqkluw5FO/MNAdFw0qmoov+PZ237+37/NgArqE3zVn1GX9P6nUx9VO+xcQAg==",
 			"cpu": [
 				"x64"
 			],
@@ -13657,6 +13539,45 @@
 			"optional": true,
 			"os": [
 				"linux"
+			]
+		},
+		"node_modules/turbo-linux-arm64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.11.3.tgz",
+			"integrity": "sha512-YhUfBi1deB3m+3M55X458J6B7RsIS7UtM3P1z13cUIhF+pOt65BgnaSnkHLwETidmhRh8Dl3GelaQGrB3RdCDw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/turbo-windows-64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.11.3.tgz",
+			"integrity": "sha512-s+vEnuM2TiZuAUUUpmBHDr6vnNbJgj+5JYfnYmVklYs16kXh+EppafYQOAkcRIMAh7GjV3pLq5/uGqc7seZeHA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/turbo-windows-arm64": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.11.3.tgz",
+			"integrity": "sha512-ZR5z5Zpc7cASwfdRAV5yNScCZBsgGSbcwiA/u3farCacbPiXsfoWUkz28iyrx21/TRW0bi6dbsB2v17swa8bjw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
 			]
 		},
 		"node_modules/type-check": {
@@ -14659,9 +14580,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20231030.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231030.0.tgz",
-			"integrity": "sha512-+FSW+d31f8RrjHanFf/R9A+Z0csf3OtsvzdPmAKuwuZm/5HrBv83cvG9fFeTxl7/nI6irUUXIRF9xcj/NomQzQ==",
+			"version": "1.20231218.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231218.0.tgz",
+			"integrity": "sha512-AGIsDvqCrcwhoA9kb1hxOhVAe53/xJeaGZxL4FbYI9FvO17DZwrnqGq+6eqItJ6Cfw1ZLmf3BM+QdMWaL2bFWQ==",
 			"hasInstallScript": true,
 			"bin": {
 				"workerd": "bin/workerd"
@@ -14670,11 +14591,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20231030.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20231030.0",
-				"@cloudflare/workerd-linux-64": "1.20231030.0",
-				"@cloudflare/workerd-linux-arm64": "1.20231030.0",
-				"@cloudflare/workerd-windows-64": "1.20231030.0"
+				"@cloudflare/workerd-darwin-64": "1.20231218.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20231218.0",
+				"@cloudflare/workerd-linux-64": "1.20231218.0",
+				"@cloudflare/workerd-linux-arm64": "1.20231218.0",
+				"@cloudflare/workerd-windows-64": "1.20231218.0"
 			}
 		},
 		"node_modules/wrangler": {
@@ -15501,7 +15422,7 @@
 			}
 		},
 		"packages/eslint-plugin-next-on-pages": {
-			"version": "1.8.3",
+			"version": "1.8.5",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree-jsx": "^1.0.0",
@@ -15539,7 +15460,7 @@
 		},
 		"packages/next-on-pages": {
 			"name": "@cloudflare/next-on-pages",
-			"version": "1.8.3",
+			"version": "1.8.5",
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -15550,7 +15471,7 @@
 				"cookie": "^0.5.0",
 				"esbuild": "^0.15.3",
 				"js-yaml": "^4.1.0",
-				"miniflare": "3.20231002.0",
+				"miniflare": "^3.20231218.1",
 				"package-manager-manager": "^0.2.0",
 				"pcre-to-regexp": "^1.1.0",
 				"semver": "^7.5.2"
@@ -15581,81 +15502,6 @@
 			"peerDependencies": {
 				"vercel": ">=30.0.0",
 				"wrangler": "^3.0.0"
-			}
-		},
-		"packages/next-on-pages/node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231002.0.tgz",
-			"integrity": "sha512-sgtjzVO/wtI/6S7O0bk4zQAv2xlvqOxB18AXzlit6uXgbYFGeQedRHjhKVMOacGmWEnM4C3ir/fxJGsc3Pyxng==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"packages/next-on-pages/node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231002.0.tgz",
-			"integrity": "sha512-dv8nztYFaTYYgBpyy80vc4hdMYv9mhyNbvBsZywm8S7ivcIpzogi0UKkGU4E/G0lYK6W3WtwTBqwRe+pXJ1+Ww==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"packages/next-on-pages/node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231002.0.tgz",
-			"integrity": "sha512-UG8SlLcGzaQDSSw6FR4+Zf408925wkLOCAi8w5qEoFYu3g4Ef7ZenstesCOsyWL7qBDKx0/iwk6+a76W5IHI0Q==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"packages/next-on-pages/node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231002.0.tgz",
-			"integrity": "sha512-GPaa66ZSq1gK09r87c5CJbHIApcIU//LVHz3rnUxK0//00YCwUuGUUK1dn/ylg+fVqDQxIDmH+ABnobBanvcDA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"packages/next-on-pages/node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231002.0.tgz",
-			"integrity": "sha512-ybIy+sCme0VO0RscndXvqWNBaRMUOc8vhi+1N2h/KDsKfNLsfEQph+XWecfKzJseUy1yE2rV1xei3BaNmaa6vg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"packages/next-on-pages/node_modules/@types/node": {
@@ -15998,28 +15844,6 @@
 				"node": ">=12"
 			}
 		},
-		"packages/next-on-pages/node_modules/miniflare": {
-			"version": "3.20231002.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231002.0.tgz",
-			"integrity": "sha512-Qw1JfGwx1ZuaoumE9DpzPm78b9RD+qP/k+iAPaCIay9iQfcf7ri7rX6Zper2rReawuL+DdNxXJmhB4cfwn5Glw==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.22.1",
-				"workerd": "1.20231002.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
 		"packages/next-on-pages/node_modules/prettier": {
 			"version": "2.8.8",
 			"dev": true,
@@ -16032,45 +15856,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"packages/next-on-pages/node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"packages/next-on-pages/node_modules/undici": {
-			"version": "5.28.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-			"integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.0"
-			}
-		},
-		"packages/next-on-pages/node_modules/workerd": {
-			"version": "1.20231002.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231002.0.tgz",
-			"integrity": "sha512-NFuUQBj30ZguDoPZ6bL40hINiu8aP2Pvxr/3xAdhWOwVFLuObPOiSdQ8qm4JYZ7jovxWjWE4Z7VR2avjIzEksQ==",
-			"hasInstallScript": true,
-			"bin": {
-				"workerd": "bin/workerd"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20231002.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20231002.0",
-				"@cloudflare/workerd-linux-64": "1.20231002.0",
-				"@cloudflare/workerd-linux-arm64": "1.20231002.0",
-				"@cloudflare/workerd-windows-64": "1.20231002.0"
 			}
 		},
 		"pages-e2e": {

--- a/packages/next-on-pages/package.json
+++ b/packages/next-on-pages/package.json
@@ -53,7 +53,7 @@
 		"cookie": "^0.5.0",
 		"esbuild": "^0.15.3",
 		"js-yaml": "^4.1.0",
-		"miniflare": "3.20231002.0",
+		"miniflare": "^3.20231218.1",
 		"package-manager-manager": "^0.2.0",
 		"pcre-to-regexp": "^1.1.0",
 		"semver": "^7.5.2"


### PR DESCRIPTION
Hey! 👋 Tried to debug #621 this afternoon. I think PR this should fix things. I'm still a bit confused why this issue was only exposed with new Miniflare versions, but this seems to be working for me locally.

The issue was that `createClass()` was being called with a class name like `<workerName>_<className>` as opposed to just `<className>`. This meant in the target `wrangler dev` session containing the Durable Object, we were trying to `env["<workerName>_<className>"]` instead of `env["<className>"]` resulting in the `Cannot read properties of undefined` error.

___

resolves #621 