### PR TITLE
add assertions for making sure that the required `setupDevBindings` options are provided

### DIFF
--- a/.changeset/neat-rockets-perform.md
+++ b/.changeset/neat-rockets-perform.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+make sure that `setupDevBindings` can accept options without a `bindings` field

--- a/.changeset/neat-rockets-perform.md
+++ b/.changeset/neat-rockets-perform.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': patch
 ---
 
-make sure that `setupDevBindings` can accept options without a `bindings` field
+add assertions for making sure that the required `setupDevBindings` options are provided

--- a/internal-packages/next-dev/src/index.ts
+++ b/internal-packages/next-dev/src/index.ts
@@ -74,7 +74,7 @@ async function instantiateMiniflare(
 	};
 
 	const devBindingsDurableObjectOptions = Object.fromEntries(
-		Object.entries(options.bindings).filter(
+		Object.entries(options.bindings ?? {}).filter(
 			([, binding]) => binding.type === 'durable-object',
 		),
 	);


### PR DESCRIPTION
I just noticed that providing an `options` object without a `bindings` field results in a terminal error:
![Screenshot 2024-01-15 at 13 30 50](https://github.com/cloudflare/next-on-pages/assets/61631103/75769fef-e1a3-47a0-8746-0a080e93bce6)

The error is not really very clear so instead of it here I am simply adding assertions and throwing more clear errors for users:
![Screenshot 2024-01-15 at 17 43 13](https://github.com/cloudflare/next-on-pages/assets/61631103/72c79921-9bda-482a-a4fb-28df4da69c6c)
![Screenshot 2024-01-15 at 17 43 39](https://github.com/cloudflare/next-on-pages/assets/61631103/bd77efa5-7c9a-4511-96d8-c47713998c31)

> [!NOTE]
> Throwing makes the error show up in the console but does not kill the nodejs process, I don't think I can kill the dev server process from within `setupDevBindings`
