### PR TITLE
add `databaseId` to the `setupDevBindings` D1 binding type

### DIFF
--- a/.changeset/popular-guests-tell.md
+++ b/.changeset/popular-guests-tell.md
@@ -1,0 +1,12 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+add `databaseId` to the `setupDevBindings` D1 binding type
+
+D1 databases can only be referenced by their ID and not name, the current implementation
+wrongly accepts the database name and uses it as the database id, in order to amend this
+without introducing a breaking change we add an optional `databaseId` field to the D1 binding
+type and present a warning if the only the `databaseName` is used.
+
+When a better more stable/clear API will be decided for D1 bindings we can revisit this API.

--- a/internal-packages/next-dev/src/index.ts
+++ b/internal-packages/next-dev/src/index.ts
@@ -50,7 +50,7 @@ export type DevBindingsOptions = {
 export type Binding =
 	| { type: 'kv'; id: string }
 	| { type: 'r2'; bucketName: string }
-	| { type: 'd1'; databaseName: string }
+	| { type: 'd1'; databaseName: string; databaseId?: string }
 	| { type: 'durable-object'; className: string; service: ServiceDesignator }
 	| { type: 'service'; service: ServiceDesignator }
 	| { type: 'var'; value: string | Json };
@@ -230,6 +230,7 @@ async function getMiniflareBindingOptions(
 	bindings: DevBindingsOptions['bindings'],
 ): Promise<MiniflareBindingOptions> {
 	const bindingsEntries = Object.entries(bindings);
+	const d1DatabaseNamesUsedSet = new Set<string>();
 	const { varBindings, kvNamespaces, d1Databases, r2Buckets, services } =
 		bindingsEntries.reduce(
 			(allBindings, [bindingName, bindingDetails]) => {
@@ -261,11 +262,16 @@ async function getMiniflareBindingOptions(
 					};
 				}
 				if (bindingDetails.type === 'd1') {
+					let databaseId = bindingDetails.databaseId;
+					if (!databaseId) {
+						databaseId = bindingDetails.databaseName;
+						d1DatabaseNamesUsedSet.add(bindingDetails.databaseName);
+					}
 					return {
 						...allBindings,
 						d1Databases: {
 							...allBindings.d1Databases,
-							[bindingName]: bindingDetails.databaseName,
+							[bindingName]: databaseId,
 						},
 					};
 				}
@@ -297,6 +303,10 @@ async function getMiniflareBindingOptions(
 
 	const serviceBindings = await getServiceBindings(services);
 
+	if (d1DatabaseNamesUsedSet.size > 0) {
+		warnAboutD1Names(Array.from(d1DatabaseNamesUsedSet.values()));
+	}
+
 	return {
 		kvNamespaces,
 		r2Buckets,
@@ -304,4 +314,17 @@ async function getMiniflareBindingOptions(
 		bindings: varBindings,
 		serviceBindings,
 	};
+}
+
+export function warnAboutD1Names(d1DatabaseNamesUsed: string[]): void {
+	console.warn(
+		`\n\x1b[33mWarning:\n  D1 databases can currently only be referenced by their IDs so if you only specify\n  ` +
+			'a database name for a D1 binding that will be used as the database ID.\n  ' +
+			'To avoid this warning please provide both a database name and id for your D1 bindings.\n\n  ' +
+			`The following database names have been used as IDs:\n ${[
+				...d1DatabaseNamesUsed,
+			]
+				.map(dbName => `   - ${dbName}`)
+				.join('\n')}\x1b[0m\n\n`,
+	);
 }


### PR DESCRIPTION
Result in case only the `databaseName` is used:
![Screenshot 2024-01-17 at 16 10 08](https://github.com/cloudflare/next-on-pages/assets/61631103/acb02202-fbdb-49c7-9409-ba3a9279fc60)
