### PR TITLE
indent `setupDevBindings` warnings

### DIFF
--- a/.changeset/polite-rice-grab.md
+++ b/.changeset/polite-rice-grab.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+indent `setupDevBindings` warnings

--- a/internal-packages/next-dev/src/utils.ts
+++ b/internal-packages/next-dev/src/utils.ts
@@ -3,13 +3,13 @@ export function warnAboutExternalBindingsNotFound(
 	typeOfBinding: 'Durable Objects' | 'Service Bindings',
 ): void {
 	console.warn(
-		`\n\x1b[33mWarning:\nYou have requested ${typeOfBinding} but no local instance of such` +
-			` has been found.\nIn order to access your ${typeOfBinding} please start the relevant workers locally\n` +
-			'with `wrangler dev` and then restart the next dev server.\n\n' +
+		`\n\x1b[33mWarning:\n  You have requested ${typeOfBinding} but no local instance of such` +
+			` has been found.\n  In order to access your ${typeOfBinding} please start the relevant workers locally\n  ` +
+			'with `wrangler dev` and then restart the next dev server.\n\n  ' +
 			`The following bindings won't be accessible until then:\n ${[
 				...bindingsNotFound,
 			]
-				.map(notFound => ` - ${notFound}`)
+				.map(notFound => `   - ${notFound}`)
 				.join('\n')}\x1b[0m\n\n`,
 	);
 }


### PR DESCRIPTION
Very minor change, I just noticed that the warnings in `setupDevBindings` could use a small indentation

| Before | After |
|--------|--------|
| ![Screenshot 2024-01-17 at 16 26 56](https://github.com/cloudflare/next-on-pages/assets/61631103/fb339230-baeb-4552-8687-751ab91c8df1) | ![Screenshot 2024-01-17 at 16 24 59](https://github.com/cloudflare/next-on-pages/assets/61631103/ff036aa0-b77e-46cd-8f28-70adfe1c3fc2) | 

> [!NOTE]
> I've applied the same indentation in the D1 warning in #642