### PR TITLE
update e2es to handle `next.config.mjs` files and update `next-dev` README

### DIFF
--- a/.github/actions/node-setup/action.yaml
+++ b/.github/actions/node-setup/action.yaml
@@ -8,10 +8,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Node.js 20.x
+    - name: Setup Node.js 20.10.0
       uses: actions/setup-node@v3
       with:
-        node-version: 20.x
+        node-version: 20.10.0
 
     - name: Get current node version
       id: node-version

--- a/docs/technical/routing.md
+++ b/docs/technical/routing.md
@@ -30,7 +30,7 @@ At the start of the routing process, there is typically a series of source route
 
 During this phase, a number of events may happen. Some of the Next.js features that it handles are as follows.
 
-- `next.config.js`
+- `next.config.mjs`
   - Applying [`headers`](https://nextjs.org/docs/pages/api-reference/next-config-js/headers).
   - Applying [`redirects`](https://nextjs.org/docs/pages/api-reference/next-config-js/redirects).
   - Applying `beforeFiles` [`rewrites`](https://nextjs.org/docs/pages/api-reference/next-config-js/rewrites).
@@ -43,7 +43,7 @@ When checking that routes exist in the build output, it only looks for static as
 
 If a file is not found in the build output at the start of routing (after the `none` phase), the system enters the `filesystem` phase. Here, it will handle another Next.js feature.
 
-- `next.config.js`
+- `next.config.mjs`
   - Applying `afterFiles` [`rewrites`](https://nextjs.org/docs/pages/api-reference/next-config-js/rewrites).
 
 The only routes checked in the build output with this phase are those that result from `afterFiles` `rewrites`.
@@ -69,7 +69,7 @@ This could be considered the penultimate stage in the routing system, as it is t
 
 The `resource` phase handles any remaining user-specified rewrites, and then checks the build output for any remaining routes. Further, it sets the status to 404 for any other routes that have not had a match yet.
 
-- `next.config.js`
+- `next.config.mjs`
   - Applying `fallback` [`rewrites`](https://nextjs.org/docs/pages/api-reference/next-config-js/rewrites).
 
 ### `miss`

--- a/internal-packages/docs-scraper/scripts/createOrUpdateIssue.ts
+++ b/internal-packages/docs-scraper/scripts/createOrUpdateIssue.ts
@@ -52,7 +52,7 @@ void (async function (): Promise<void> {
 			owner: context.repo.owner,
 			repo: context.repo.repo,
 			labels: [label],
-			title: '⚠️📄 The `next.config.js` supported doc is out of date 📄⚠️',
+			title: '⚠️📄 The `next.config.mjs` supported doc is out of date 📄⚠️',
 			body: issueBody,
 		});
 	} else {
@@ -74,18 +74,18 @@ function generateIssueBody(
 	documentedNonNextConfigs: string[],
 ): string {
 	let issueBody =
-		'### The next-on-pages documentation of the next.config.js options is out of date\n';
+		'### The next-on-pages documentation of the next.config.mjs options is out of date\n';
 
 	if (undocumentedNextConfigs.length > 0) {
 		issueBody += `\n\n${generateMdList(
-			'The following next.config.js configs are not documented in our supported doc',
+			'The following next.config.mjs configs are not documented in our supported doc',
 			undocumentedNextConfigs,
 		)}`;
 	}
 
 	if (documentedNonNextConfigs.length > 0) {
 		issueBody += `\n\n${generateMdList(
-			'The following configs present in our supported doc are not present in the next.config.js documentation pages',
+			'The following configs present in our supported doc are not present in the next.config.mjs documentation pages',
 			documentedNonNextConfigs,
 		)}`;
 	}

--- a/internal-packages/next-dev/README.md
+++ b/internal-packages/next-dev/README.md
@@ -6,23 +6,23 @@ IMPORTANT: As mentioned above the module allows you to run the standard Next.js 
 
 ## How to use the module
 
-The module is part of the `@cloudflare/next-on-pages` package so it does not need installation, it exports the `setupDevBindings` function which you need to import and call in your `next.config.js` file to declare what bindings your application is using and need to be made available in the development server.
+The module is part of the `@cloudflare/next-on-pages` package so it does not need installation, it exports the `setupDevBindings` function which you need to import and call in your `next.config.mjs` file to declare what bindings your application is using and need to be made available in the development server.
 
-After having added the `setupDevBindings` call to the `next.config.js` you can simply run `next dev` and inside your edge routes you will be able to access your bindings via `process.env` in the exact same way as you would in your production code.
+After having added the `setupDevBindings` call to the `next.config.mjs` you can simply run `next dev` and inside your edge routes you will be able to access your bindings via `process.env` in the exact same way as you would in your production code.
 
 ### Example
 
 Let's see an example of how to use the utility, in a Next.js application built in TypeScript using the App router.
 
-Firstly we need to update the `next.config.js` file:
+Firstly we need to update the `next.config.mjs` file:
 
 ```js
-// file: next.config.js
+// file: next.config.mjs
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-module.exports = nextConfig;
+export default nextConfig;
 
 // we only need to use the utility during development so we can check NODE_ENV
 // (note: this check is recommended but completely optional)

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
 		},
 		"internal-packages/next-dev": {
 			"name": "@cloudflare/next-on-pages-next-dev",
-			"version": "0.0.1",
 			"dependencies": {
 				"miniflare": "^3.20231218.1",
 				"node-fetch": "^3.3.2"
@@ -5750,7 +5749,9 @@
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
-			"license": "MIT"
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/builtins": {
 			"version": "5.0.1",
@@ -11782,7 +11783,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -13690,7 +13690,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13706,7 +13705,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13722,7 +13720,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13738,7 +13735,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13754,7 +13750,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13770,7 +13765,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13786,7 +13780,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13802,7 +13795,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13818,7 +13810,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13834,7 +13825,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13850,7 +13840,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13866,7 +13855,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13882,7 +13870,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13898,7 +13885,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13914,7 +13900,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13930,7 +13915,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13946,7 +13930,6 @@
 			"os": [
 				"netbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13962,7 +13945,6 @@
 			"os": [
 				"openbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13978,7 +13960,6 @@
 			"os": [
 				"sunos"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -13994,7 +13975,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -14010,7 +13990,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -14026,7 +14005,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -14075,7 +14053,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -15053,7 +15030,7 @@
 			}
 		},
 		"packages/eslint-plugin-next-on-pages": {
-			"version": "1.8.5",
+			"version": "1.8.6",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree-jsx": "^1.0.0",
@@ -15091,7 +15068,7 @@
 		},
 		"packages/next-on-pages": {
 			"name": "@cloudflare/next-on-pages",
-			"version": "1.8.5",
+			"version": "1.8.6",
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -15495,6 +15472,7 @@
 				"playwright": "^1.36.1",
 				"recast": "^0.23.4",
 				"vercel": "latest",
+				"vitest": "0.32.4",
 				"wrangler": "^3.22.4"
 			}
 		},

--- a/packages/eslint-plugin-next-on-pages/docs/rules/no-unsupported-configs.md
+++ b/packages/eslint-plugin-next-on-pages/docs/rules/no-unsupported-configs.md
@@ -1,6 +1,6 @@
 # `next-on-pages/no-unsupported-configs`
 
-`@cloudflare/next-on-pages` doesn't support all config options that are supported by Next in their `next.config.js` file.
+`@cloudflare/next-on-pages` doesn't support all config options that are supported by Next in their `next.config.mjs` file.
 
 As documented in the [support documentation](https://github.com/cloudflare/next-on-pages/blob/main/docs/supported.md#nextconfigjs-properties) there are config options that: we support, we don't currently support, we support and don't plan to.
 
@@ -20,14 +20,14 @@ This rule helps you making sure that your code is not using config options that 
 "next-on-pages/no-unsupported-configs": "error"
 
 
-// next.config.js
+// next.config.mjs
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   compress: true,
   ~~~~~~~~
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 ```js
@@ -35,14 +35,14 @@ module.exports = nextConfig
 "next-on-pages/no-unsupported-configs": "error"
 
 
-// next.config.js
+// next.config.mjs
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   trailingSlash: true,
   ~~~~~~~~~~~~~
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 ```js
@@ -52,14 +52,14 @@ module.exports = nextConfig
 ]
 
 
-// next.config.js
+// next.config.mjs
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   nonExistingConfig: 'test',
   ~~~~~~~~~~~~~~~~~
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 ## ✅ Valid Code
@@ -69,13 +69,13 @@ module.exports = nextConfig
 "next-on-pages/no-unsupported-configs": "error"
 
 
-// next.config.js
+// next.config.mjs
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['page.tsx'],
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 ```js
@@ -85,13 +85,13 @@ module.exports = nextConfig
 ]
 
 
-// next.config.js
+// next.config.mjs
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   trailingSlash: true,
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 ```js
@@ -99,11 +99,11 @@ module.exports = nextConfig
 "next-on-pages/no-unsupported-configs": "error"
 
 
-// next.config.js
+// next.config.mjs
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   nonExistingConfig: 'test',
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```

--- a/packages/eslint-plugin-next-on-pages/src/rules/no-unsupported-configs.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-unsupported-configs.ts
@@ -204,7 +204,7 @@ function checkConfigPropsRecursively(
 }
 
 /**
- * Gets the name of the config variable defined in next.config.js
+ * Gets the name of the config variable defined in next.config.mjs
  *
  * It does that by trying two different strategies:
  *  - First it tries to take the config's name from the `module.exports = ...` line

--- a/packages/next-on-pages/docs/supported.md
+++ b/packages/next-on-pages/docs/supported.md
@@ -73,7 +73,7 @@ To check the latest state of the routers and possible missing features you can c
 
 - _1_ - **images**: If you want to use `next/image`, there are two options; allow the library to take care of incoming requests, or using a custom loader. Requests are intercepted in the router and image resizing is attempted to be used (due to limitations with Pages, it is not currently possible to use image resizing) - if image resizing is not available, it falls back to fetching the normal image URL. Alternatively, you can provide your own [custom loader](https://nextjs.org/docs/api-reference/next/image#loader) and use Cloudflare Image Resizing, as per [Cloudflare's Image Resizing documentation](https://developers.cloudflare.com/images/image-resizing/integration-with-frameworks/#nextjs).
 
-### next.config.js Properties
+### next.config.mjs Properties
 
 > The following options have been gathered from the Next.js' next.config.js [app](https://nextjs.org/docs/app/api-reference/next-config-js) and [pages](https://nextjs.org/docs/pages/api-reference/next-config-js) documentations.
 

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -609,7 +609,7 @@ export class RoutesMatcher {
 		let pathExistsInOutput = this.path in this.output;
 
 		// paths could incorrectly not be detected as existing in the output due to the `trailingSlash` setting
-		// in `next.config.js`, so let's check for that here and update the path in such case
+		// in `next.config.mjs`, so let's check for that here and update the path in such case
 		if (!pathExistsInOutput && this.path.endsWith('/')) {
 			const newPath = this.path.replace(/\/$/, '');
 			pathExistsInOutput = newPath in this.output;

--- a/pages-e2e/features/appConfigsRewritesRedirectsHeaders/headers.test.ts
+++ b/pages-e2e/features/appConfigsRewritesRedirectsHeaders/headers.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'vitest';
 
-describe('next.config.js Headers', () => {
+describe('next.config.mjs Headers', () => {
 	test('addition of headers to api response', async ({ expect }) => {
 		const response = await fetch(
 			`${DEPLOYMENT_URL}/api/configs-headers/to-apply/some-route`,
@@ -9,10 +9,10 @@ describe('next.config.js Headers', () => {
 			'api/configs-headers/to-apply/some-route route',
 		);
 		expect(response.headers.get('x-custom-configs-header')).toEqual(
-			'my custom header value (from next.config.js)',
+			'my custom header value (from next.config.mjs)',
 		);
 		expect(response.headers.get('x-another-custom-configs-header')).toEqual(
-			'my other custom header value (from next.config.js)',
+			'my other custom header value (from next.config.mjs)',
 		);
 	});
 

--- a/pages-e2e/features/appConfigsRewritesRedirectsHeaders/headers.ts
+++ b/pages-e2e/features/appConfigsRewritesRedirectsHeaders/headers.ts
@@ -5,11 +5,11 @@ export function headers() {
 			headers: [
 				{
 					key: 'x-custom-configs-header',
-					value: 'my custom header value (from next.config.js)',
+					value: 'my custom header value (from next.config.mjs)',
 				},
 				{
 					key: 'x-another-custom-configs-header',
-					value: 'my other custom header value (from next.config.js)',
+					value: 'my other custom header value (from next.config.mjs)',
 				},
 			],
 		},

--- a/pages-e2e/features/appConfigsRewritesRedirectsHeaders/redirects.test.ts
+++ b/pages-e2e/features/appConfigsRewritesRedirectsHeaders/redirects.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'vitest';
 
-describe('next.config.js Redirects', () => {
+describe('next.config.mjs Redirects', () => {
 	test('basic non-permanent redirects', async ({ expect }) => {
 		const response = await fetch(
 			`${DEPLOYMENT_URL}/permanent-config-redirect`,

--- a/pages-e2e/features/appConfigsRewritesRedirectsHeaders/rewrites.test.ts
+++ b/pages-e2e/features/appConfigsRewritesRedirectsHeaders/rewrites.test.ts
@@ -1,7 +1,7 @@
 import { getAssertVisible } from '@features-utils/getAssertVisible';
 import { describe, test } from 'vitest';
 
-describe('next.config.js Rewrites', () => {
+describe('next.config.mjs Rewrites', () => {
 	// Note: in next you can have basic rewrites or rewrites categorized under "beforeFiles", "afterFiles"
 	//       and "fallbacks", since you can have both and categorized rewrites here we choose to test
 	//       categorized ones (if this works it should imply that also t he basic ones do)

--- a/pages-e2e/features/appConfigsRewritesRedirectsHeaders/setup.ts
+++ b/pages-e2e/features/appConfigsRewritesRedirectsHeaders/setup.ts
@@ -11,7 +11,7 @@ await copyWorkspaceAssets();
 
 const { WORKSPACE_DIR } = process.env;
 
-const nextConfigJsPath = join(WORKSPACE_DIR, 'next.config.js');
+const nextConfigJsPath = join(WORKSPACE_DIR, 'next.config.mjs');
 
 const nextConfigJsSource = await readFile(nextConfigJsPath, 'utf-8');
 

--- a/pages-e2e/features/appConfigsTrailingSlashTrue/setup.ts
+++ b/pages-e2e/features/appConfigsTrailingSlashTrue/setup.ts
@@ -8,7 +8,7 @@ await copyWorkspaceAssets();
 
 const { WORKSPACE_DIR } = process.env;
 
-const nextConfigJsPath = join(WORKSPACE_DIR, 'next.config.js');
+const nextConfigJsPath = join(WORKSPACE_DIR, 'next.config.mjs');
 
 const nextConfigJsSource = await readFile(nextConfigJsPath, 'utf-8');
 

--- a/pages-e2e/features/pagesConfigsI18n/next.config.i18n.test.ts
+++ b/pages-e2e/features/pagesConfigsI18n/next.config.i18n.test.ts
@@ -20,7 +20,7 @@ const pages = {
 	},
 } as const;
 
-describe('Pages next.config.js i18n', () => {
+describe('Pages next.config i18n', () => {
 	Object.values(pages).forEach(({ path, pageName }) => {
 		it(`should view the "${pageName}" page on the default locale`, async () => {
 			const page = await BROWSER.newPage();

--- a/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/headers.test.ts
+++ b/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/headers.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'vitest';
 
-describe('next.config.js Headers', () => {
+describe('next.config.mjs Headers', () => {
 	test('addition of headers to api response', async ({ expect }) => {
 		const response = await fetch(
 			`${DEPLOYMENT_URL}/api/configs-headers/to-apply/some-route`,
@@ -9,10 +9,10 @@ describe('next.config.js Headers', () => {
 			'api/configs-headers/to-apply/some-route route',
 		);
 		expect(response.headers.get('x-custom-configs-header')).toEqual(
-			'my custom header value (from next.config.js)',
+			'my custom header value (from next.config.mjs)',
 		);
 		expect(response.headers.get('x-another-custom-configs-header')).toEqual(
-			'my other custom header value (from next.config.js)',
+			'my other custom header value (from next.config.mjs)',
 		);
 	});
 

--- a/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/headers.ts
+++ b/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/headers.ts
@@ -5,11 +5,11 @@ export function headers() {
 			headers: [
 				{
 					key: 'x-custom-configs-header',
-					value: 'my custom header value (from next.config.js)',
+					value: 'my custom header value (from next.config.mjs)',
 				},
 				{
 					key: 'x-another-custom-configs-header',
-					value: 'my other custom header value (from next.config.js)',
+					value: 'my other custom header value (from next.config.mjs)',
 				},
 			],
 		},

--- a/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/redirects.test.ts
+++ b/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/redirects.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'vitest';
 
-describe('next.config.js Redirects', () => {
+describe('next.config.mjs Redirects', () => {
 	test('basic non-permanent redirects', async ({ expect }) => {
 		const response = await fetch(
 			`${DEPLOYMENT_URL}/permanent-config-redirect`,

--- a/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/rewrites.test.ts
+++ b/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/rewrites.test.ts
@@ -2,7 +2,7 @@ import { getAssertVisible } from '@features-utils/getAssertVisible';
 import { runWithHardNavigationsChecking } from '@features-utils/runWithHardNavigationsChecking';
 import { describe, test } from 'vitest';
 
-describe('next.config.js Rewrites', () => {
+describe('next.config.mjs Rewrites', () => {
 	// Note: in next you can have basic rewrites or rewrites categorized under "beforeFiles", "afterFiles"
 	//       and "fallbacks", since you can have both and categorized rewrites here we choose to test
 	//       categorized ones (if this works it should imply that also t he basic ones do)

--- a/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/setup.ts
+++ b/pages-e2e/features/pagesConfigsRewritesRedirectsHeaders/setup.ts
@@ -11,7 +11,7 @@ await copyWorkspaceAssets();
 
 const { WORKSPACE_DIR } = process.env;
 
-const nextConfigJsPath = join(WORKSPACE_DIR, 'next.config.js');
+const nextConfigJsPath = join(WORKSPACE_DIR, 'next.config.mjs');
 
 const nextConfigJsSource = await readFile(nextConfigJsPath, 'utf-8');
 

--- a/pages-e2e/fixtures/app13.4.0/next.config.mjs
+++ b/pages-e2e/fixtures/app13.4.0/next.config.mjs
@@ -8,4 +8,4 @@ const nextConfig = {
 	},
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/pages-e2e/fixtures/app14.0.0/next.config.mjs
+++ b/pages-e2e/fixtures/app14.0.0/next.config.mjs
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/pages-e2e/fixtures/appStaticNotFoundWithEdgeLayout/next.config.mjs
+++ b/pages-e2e/fixtures/appStaticNotFoundWithEdgeLayout/next.config.mjs
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/pages-e2e/fixtures/issue593App/next.config.mjs
+++ b/pages-e2e/fixtures/issue593App/next.config.mjs
@@ -4,4 +4,4 @@ const nextConfig = {
 	reactStrictMode: true,
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/pages-e2e/fixtures/issue593Pages/next.config.mjs
+++ b/pages-e2e/fixtures/issue593Pages/next.config.mjs
@@ -4,4 +4,4 @@ const nextConfig = {
 	reactStrictMode: true,
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/pages-e2e/fixtures/pages12.3.0/next.config.mjs
+++ b/pages-e2e/fixtures/pages12.3.0/next.config.mjs
@@ -1,5 +1,5 @@
 /** @type {import('next').NextConfig} */
-module.exports = {
+const nextConfig = {
 	reactStrictMode: true,
 	experimental: {
 		runtime: 'experimental-edge',
@@ -9,3 +9,5 @@ module.exports = {
 		frameworkVersion: '12.3.0',
 	},
 };
+
+export default nextConfig;

--- a/pages-e2e/fixtures/pages13.0.0/next.config.mjs
+++ b/pages-e2e/fixtures/pages13.0.0/next.config.mjs
@@ -7,4 +7,4 @@ const nextConfig = {
 	},
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/pages-e2e/fixtures/pages14.0.0_i18n/next.config.mjs
+++ b/pages-e2e/fixtures/pages14.0.0_i18n/next.config.mjs
@@ -10,4 +10,4 @@ const nextConfig = {
 	},
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/pages-e2e/fixtures/pages14.0.0_i18n/tsconfig.json
+++ b/pages-e2e/fixtures/pages14.0.0_i18n/tsconfig.json
@@ -15,6 +15,6 @@
 		"jsx": "preserve",
 		"incremental": true
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.js"],
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.mjs"],
 	"exclude": ["node_modules"]
 }

--- a/pages-e2e/fixtures/pagesIssue578/next.config.mjs
+++ b/pages-e2e/fixtures/pagesIssue578/next.config.mjs
@@ -7,4 +7,4 @@ const nextConfig = {
 	},
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/pages-e2e/package.json
+++ b/pages-e2e/package.json
@@ -11,6 +11,7 @@
 		"recast": "^0.23.4",
 		"playwright": "^1.36.1",
 		"wrangler": "^3.22.4",
-		"vercel": "latest"
+		"vercel": "latest",
+		"vitest": "0.32.4"
 	}
 }


### PR DESCRIPTION
since 14.1.0 `create-next-app` generates a next.config.mjs file as the default config one (instead of next.config.js), thus the e2es need to be accordingly updated

also the `next-dev` readme needs to be updated

___

resolves #651 