### PR TITLE
feat: add the `cf` object to the request object

### DIFF
--- a/.changeset/proud-zebras-remember.md
+++ b/.changeset/proud-zebras-remember.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Add the `cf` object to the `request` object that is passed to API routes.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -492,6 +492,16 @@ function fixFunctionContents(contents: string): string {
 		';let{originalRequest:$1=$2}=$2;',
 	);
 
+	// This adds the `cf` object back to the `request` object used in API routes.
+	contents = contents.replace(
+		/(ip:(\w+)\.request\.ip)/gm,
+		'$1,cf:$2.request.cf',
+	);
+	contents = contents.replace(
+		/(ip:\w+\((\w+)\.headers,\w+\.Ip\))/gm,
+		'$1,cf:$2.cf',
+	);
+
 	return contents;
 }
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -494,11 +494,11 @@ function fixFunctionContents(contents: string): string {
 
 	// This adds the `cf` object back to the `request` object used in API routes.
 	contents = contents.replace(
-		/(ip:(\w+)\.request\.ip)/gm,
+		/(ip: ?(\w+)\.request\.ip)/gm,
 		'$1,cf:$2.request.cf',
 	);
 	contents = contents.replace(
-		/(ip:\w+\((\w+)\.headers,\w+\.Ip\))/gm,
+		/(ip: ?\w+\((\w+)\.headers,\w+\.Ip\))/gm,
 		'$1,cf:$2.cf',
 	);
 


### PR DESCRIPTION
This PR does the following:
- Adds the `cf` object to the request object that is accessible in API routes and middleware and so on.

Demo: https://purple-waterfall-0bcc.pages.dev/api/hello

Usage: https://github.com/james-elicx/nop-req-cf/blob/main/app/api/hello/route.ts
TypeScript Types: https://github.com/james-elicx/nop-req-cf/blob/main/env.d.ts

The value is added to the following two objects in the generated function's code, which results in it being on the request object passed to a route handler.

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/20b237ed-00c9-4840-80d4-e62bba71ae9e)

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/ec223a13-4221-46b0-b0f9-10999295320f)

