### PR TITLE
fix: bundled wasm assets not found during build

### DIFF
--- a/.changeset/fresh-years-tap.md
+++ b/.changeset/fresh-years-tap.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix bundled wasm imports that are not located inside the function's directory.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/edgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/edgeFunctions.ts
@@ -99,13 +99,16 @@ async function ensureBundledAssetsExist({ edgeFunctions }: CollectedFunctions) {
 			const currentAssetPath = resolve(assetLocation);
 			const newAssetPath = join(path, relativeAssetPath);
 
-			if (!(await validateFile(currentAssetPath))) {
-				cliError(`Could not find bundled asset file: ${assetLocation}`);
-				process.exit(1);
-			}
+			// only create the symlink when no file exists at the expected path
+			if (!(await validateFile(newAssetPath))) {
+				if (!(await validateFile(currentAssetPath))) {
+					cliError(`Could not find bundled asset file: ${assetLocation}`);
+					process.exit(1);
+				}
 
-			await mkdir(dirname(newAssetPath), { recursive: true });
-			await symlink(currentAssetPath, newAssetPath, 'file');
+				await mkdir(dirname(newAssetPath), { recursive: true });
+				await symlink(currentAssetPath, newAssetPath, 'file');
+			}
 		}
 	}
 }

--- a/packages/next-on-pages/vercel.types.d.ts
+++ b/packages/next-on-pages/vercel.types.d.ts
@@ -12,6 +12,7 @@ type VercelFunctionConfig = {
 	assets?: { name: string; path: string }[];
 	regions?: string | string[];
 	framework?: { slug: string; version?: string };
+	filePathMap?: { [key: string]: string };
 };
 
 type VercelPrerenderConfig = {


### PR DESCRIPTION
This PR does the following:
- Introduces some support for the `filePathMap` option in a function config file.
- Symlinks assets to the function's folder, so that they can be found during the build process.

fixes #676
fixes #672

Example of this in a function's `.vc-config.json`:

![image](https://github.com/cloudflare/next-on-pages/assets/10815538/460ed020-e1c9-4711-9f2a-bff5f88eba9c)
