### PR TITLE
Improve the `getRequestContext`/`getOptionalRequestContext`'s behavior in the Node.js runtime

### DIFF
--- a/.changeset/brave-jeans-wait.md
+++ b/.changeset/brave-jeans-wait.md
@@ -1,0 +1,19 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Improve the `getRequestContext`/`getOptionalRequestContext`'s behavior in the Node.js runtime
+
+Currently if users run `getRequestContext` or `getOptionalRequestContext` in the Node.js runtime
+they get a generic error saying that the request context could not be found, these changes
+improve such situation by making it much clearer to the user that the error lies in the runtime
+being used.
+
+These changes make it so that when either function is used:
+
+- if we can detect for a high level of certainty that the code is running in the Node.js runtime
+  throw an error clearly stating that the wrong runtime is being used
+- if we are not completely sure what runtime is being used (and the request context could not be
+  retrieved) add a hint in the error message prompting the developer to double check that they
+  are using the correct runtime (only applies to `getRequestContext`)
+- if the (correct) edge runtime is being used we don't include this information at all.

--- a/packages/next-on-pages/src/api/getRequestContext.ts
+++ b/packages/next-on-pages/src/api/getRequestContext.ts
@@ -19,6 +19,12 @@ const cloudflareRequestContextSymbol = Symbol.for(
 	'__cloudflare-request-context__',
 );
 
+const notEdgeRuntimeErrorMessage = dedent`
+\`getRequestContext\` and \`getOptionalRequestContext\` can only be run inside the edge runtime,
+so please make sure to have included \`export const runtime = 'edge'\`
+in all the routes using such function (regardless of whether they are used directly or through imports).
+`;
+
 export function getOptionalRequestContext<
 	CfProperties extends Record<string, unknown> = IncomingRequestCfProperties,
 	Context = ExecutionContext,
@@ -30,6 +36,14 @@ export function getOptionalRequestContext<
 				| undefined;
 		}
 	)[cloudflareRequestContextSymbol];
+
+	const insideEdge = isInsideEdgeRuntime();
+	if (insideEdge === false) {
+		// no matter what, we want to throw if either
+		// `getRequestContext` or `getOptionalRequestContext`
+		// is run in the Node.js runtime
+		throw new Error(notEdgeRuntimeErrorMessage);
+	}
 
 	return cloudflareRequestContext;
 }
@@ -54,9 +68,15 @@ export function getRequestContext<
 				dedent`
 					For local development (using the Next.js dev server) remember to include
 					a call to the \`setupDevPlatform\` function in your config file.
-
+				` +
+				(isInsideEdgeRuntime() === 'maybe'
+					? dedent`\n
+				Please also keep in mind that ${notEdgeRuntimeErrorMessage}
+				`
+					: '') +
+				dedent`\n
 					For more details visit:
-					  https://github.com/cloudflare/next-on-pages/tree/3846730c/internal-packages/next-dev
+					https://github.com/cloudflare/next-on-pages/tree/3846730c/internal-packages/next-dev
 				` +
 				'\n\n';
 		}
@@ -65,4 +85,37 @@ export function getRequestContext<
 	}
 
 	return cloudflareRequestContext;
+}
+
+/**
+ * detects whether the current code is running inside the (local) edge runtime or not
+ *
+ * @returns a boolean indicating whether the code is running inside the edge runtime if that can be accurately detected,
+ * 			'maybe' if the code is likely being run inside the edge runtime but we're not 100% sure of that
+ */
+function isInsideEdgeRuntime(): boolean | 'maybe' {
+	try {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		process.cwd();
+	} catch (error) {
+		if (error instanceof Error) {
+			// When certain Node.js APIs are being used the Next dev server errors with a message such as:
+			//    "A Node.js API is used (...) which is not supported in the Edge Runtime"
+			// we can rely on such error in order to discern accurately if we are or not in the edge runtime
+			// (source: https://github.com/vercel/next.js/blob/0fe68736/packages/next/src/server/web/sandbox/context.ts#L118-L122)
+			const notSupportedInEdgeError = error.message.includes(
+				'is not supported in the Edge Runtime',
+			);
+			if (!notSupportedInEdgeError) {
+				return true;
+			}
+		}
+		// an error was thrown... likely we are in the edge runtime, but there's no real guarantee
+		return 'maybe';
+	}
+
+	// for the time being we can safely assume that if `process.cwd()` doesn't error
+	// than that means that we're in the Node.js runtime
+	return false;
 }


### PR DESCRIPTION
Currently if users run `getRequestContext` or `getOptionalRequestContext` in the Node.js runtime they get a generic error saying that the request context could not be found, these changes improve such situation by making it much clearer to the user that the error lies in the runtime being used.

These changes make it so that when either function is used:

- if we can detect for a high level of certainty that the code is running in the Node.js runtime throw an error clearly stating that the wrong runtime is being used
- if we are not completely sure what runtime is being used (and the request context could not be retrieved) add a hint in the error message prompting the developer to double check that they are using the correct runtime (only applies to `getRequestContext`)
- if the (correct) edge runtime is being used we don't include this information at all.