### PR TITLE
fix `process.env` not giving access to bindings during local development (in `next-dev`)

### DIFF
--- a/.changeset/proud-coats-raise.md
+++ b/.changeset/proud-coats-raise.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+fix `process.env` not giving access to bindings during local development (in `next-dev`)

--- a/internal-packages/next-dev/src/shared.ts
+++ b/internal-packages/next-dev/src/shared.ts
@@ -35,7 +35,7 @@ export function monkeyPatchVmModule({ env, cf, ctx, caches }: PlatformProxy) {
 
 	const originalRunInContext = vmModule.runInContext.bind(vmModule);
 
-	vmModule.runInContext = (...args: [string, RuntimeContext, ...[unknown]]) => {
+	vmModule.runInContext = (...args: [string, RuntimeContext, ...unknown[]]) => {
 		const runtimeContext = args[1];
 
 		runtimeContext[cloudflareRequestContextSymbol] ??= {

--- a/internal-packages/next-dev/src/shared.ts
+++ b/internal-packages/next-dev/src/shared.ts
@@ -59,7 +59,7 @@ function monkeyPatchProcessEnv(
 		runtimeContext.process?.env &&
 		!runtimeContext.process.env[processEnvIsPatched]
 	) {
-		if (runtimeContext.process?.env) {
+		if (runtimeContext.process.env) {
 			for (const [name, binding] of Object.entries(env)) {
 				runtimeContext.process.env[name] = binding;
 			}

--- a/internal-packages/next-dev/src/shared.ts
+++ b/internal-packages/next-dev/src/shared.ts
@@ -4,6 +4,20 @@ const cloudflareRequestContextSymbol = Symbol.for(
 	'__cloudflare-request-context__',
 );
 
+const processEnvIsPatched = Symbol('PROCESS.ENV_IS_PATCHED');
+
+const globalsArePatched = Symbol('GLOBALS_ARE_PATCHED');
+
+type RuntimeContext = Record<string, unknown> & {
+	process?: { env?: Record<string | symbol, unknown> };
+	[cloudflareRequestContextSymbol]?: {
+		env: unknown;
+		ctx: unknown;
+		cf: unknown;
+	};
+	[globalsArePatched]?: boolean;
+};
+
 /**
  * Next.js uses the Node.js vm module's `runInContext()` function to evaluate the edge functions
  * in a runtime context that tries to simulate as accurately as possible the actual production runtime
@@ -21,54 +35,62 @@ export function monkeyPatchVmModule({ env, cf, ctx, caches }: PlatformProxy) {
 
 	const originalRunInContext = vmModule.runInContext.bind(vmModule);
 
-	vmModule.runInContext = (
-		...args: [
-			string,
-			Record<string, unknown> & {
-				process?: { env?: Record<string, unknown> };
-				[cloudflareRequestContextSymbol]?: {
-					env: unknown;
-					ctx: unknown;
-					cf: unknown;
-				};
-			},
-			...[unknown],
-		]
-	) => {
+	vmModule.runInContext = (...args: [string, RuntimeContext, ...[unknown]]) => {
 		const runtimeContext = args[1];
 
-		if (!runtimeContext[cloudflareRequestContextSymbol]) {
-			runtimeContext[cloudflareRequestContextSymbol] = {
-				env,
-				ctx,
-				cf,
-			};
-			if (runtimeContext.process?.env) {
-				for (const [name, binding] of Object.entries(env)) {
-					runtimeContext.process.env[name] = binding;
-				}
-			}
+		runtimeContext[cloudflareRequestContextSymbol] ??= {
+			env,
+			ctx,
+			cf,
+		};
 
-			runtimeContext['caches'] = caches;
-
-			runtimeContext['Request'] = new Proxy(Request, {
-				construct(target, args, newTarget) {
-					if (
-						args.length >= 2 &&
-						typeof args[1] === 'object' &&
-						args[1].duplex === undefined
-					) {
-						args[1].duplex = 'half';
-					}
-					return Reflect.construct(target, args, newTarget);
-				},
-			});
-			runtimeContext['Response'] = Response;
-			runtimeContext['Headers'] = Headers;
-		}
+		monkeyPatchProcessEnv(runtimeContext, env);
+		monkeyPatchAuxiliaryGlobals(runtimeContext, caches);
 
 		return originalRunInContext(...args);
 	};
+}
+
+function monkeyPatchProcessEnv(
+	runtimeContext: RuntimeContext,
+	env: Record<string, unknown>,
+) {
+	if (
+		runtimeContext.process?.env &&
+		!runtimeContext.process.env[processEnvIsPatched]
+	) {
+		if (runtimeContext.process?.env) {
+			for (const [name, binding] of Object.entries(env)) {
+				runtimeContext.process.env[name] = binding;
+			}
+		}
+		runtimeContext.process.env[processEnvIsPatched] = true;
+	}
+}
+
+function monkeyPatchAuxiliaryGlobals(
+	runtimeContext: RuntimeContext,
+	caches: PlatformProxy['caches'],
+) {
+	if (!runtimeContext[globalsArePatched]) {
+		runtimeContext['caches'] = caches;
+		runtimeContext['Request'] = new Proxy(Request, {
+			construct(target, args, newTarget) {
+				if (
+					args.length >= 2 &&
+					typeof args[1] === 'object' &&
+					args[1].duplex === undefined
+				) {
+					args[1].duplex = 'half';
+				}
+				return Reflect.construct(target, args, newTarget);
+			},
+		});
+		runtimeContext['Response'] = Response;
+		runtimeContext['Headers'] = Headers;
+
+		runtimeContext[globalsArePatched] = true;
+	}
 }
 
 /**


### PR DESCRIPTION
This PR fixes the fact that `process.env` doesn't contain the proper bindings during dev mode

You can see a reproduction of the issue here: https://github.com/dario-piotrowicz/next-on-pages-local-process.env-issue-repro

This is a regression introduced in https://github.com/cloudflare/next-on-pages/pull/659

There I removed the `bindingsProxyHasBeenSetSymbol` flag used to see if `process.env` was properly patched and just relied on the existence of `runtimeContext[cloudflareRequestContextSymbol]` instead.

Unfortunately this doesn't work since Next.js itself creates/updates the `process.env` object thus we cannot/should not use external flags to see if it was patched but the flag has to be part of the `process.env` object itself. So that if Next.js has replaced the object we can see that and re-patch it.