### PR TITLE
fix `trailingSlash` set to `true` alongside `i18n` enabled causing incorrect `404`s

### DIFF
--- a/.changeset/funny-berries-beg.md
+++ b/.changeset/funny-berries-beg.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+fix `trailingSlash` set to `true` alongside `i18n` enabled causing incorrect `404`s

--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -525,7 +525,10 @@ export class RoutesMatcher {
 				// When in the `miss` phase, enter `filesystem` if the file is not in the build output. This
 				// avoids rewrites in `none` that do the opposite of those in `miss`, and would cause infinite
 				// loops (e.g. i18n). If it is in the build output, remove a potentially applied `404` status.
-				if (!(this.path in this.output)) {
+				if (
+					!(this.path in this.output) &&
+					!(this.path.replace(/\/$/, '') in this.output)
+				) {
 					return this.checkPhase('filesystem');
 				}
 


### PR DESCRIPTION
Partially fixes #665 (it fixes the `404` results described in the issue)

> [!NOTE]
> It would be great to add an e2e test for this, but due to time constraints on my part and the fact that this issue is quite edge case (and also relies on the Pages router being used, which is not recommended), I'm thinking not to add such e2e