### PR TITLE
add new `no-app-nodejs-dynamic-ssg` eslint rule

### DIFF
--- a/.changeset/fuzzy-turkeys-try.md
+++ b/.changeset/fuzzy-turkeys-try.md
@@ -1,0 +1,9 @@
+---
+'eslint-plugin-next-on-pages': minor
+---
+
+add new `no-app-nodejs-dynamic-ssg` rule
+
+add the new `no-app-nodejs-dynamic-ssg` rule that makes sure that
+developers using `generateStaticParams` also export either the `runtime`
+variable set to `edge` or the `dynamicParams` one set to `false`

--- a/packages/eslint-plugin-next-on-pages/docs/rules/no-app-nodejs-dynamic-ssg.md
+++ b/packages/eslint-plugin-next-on-pages/docs/rules/no-app-nodejs-dynamic-ssg.md
@@ -1,0 +1,43 @@
+# `next-on-pages/no-app-nodejs-dynamic-ssg`
+
+When using [`generateStaticParams`](https://nextjs.org/docs/app/api-reference/functions/generate-static-params) you need to either:
+
+- export [`dynamicParams`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams) set to `false`
+- export [`runtime`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) set to `true`
+
+This rule makes sure that if you're using `generateStaticParams` at least one of the two export is present.
+
+For more details refer to the [official Cloudflare Next.js docs](https://developers.cloudflare.com/pages/framework-guides/nextjs/deploy-a-nextjs-site/#generatestaticparams).
+
+## ❌ Invalid Code
+
+```js
+export async function generateStaticParams() {
+                      ~~~~~~~~~~~~~~~~~~~~
+  // ...
+}
+
+// ...
+```
+
+## ✅ Valid Code
+
+```js
+export const runtime = 'edge';
+
+export async function generateStaticParams() {
+	// ...
+}
+
+// ...
+```
+
+```js
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+	// ...
+}
+
+// ...
+```

--- a/packages/eslint-plugin-next-on-pages/src/index.ts
+++ b/packages/eslint-plugin-next-on-pages/src/index.ts
@@ -1,5 +1,6 @@
 import noNodeJsRuntime from './rules/no-nodejs-runtime';
 import noUnsupportedConfigs from './rules/no-unsupported-configs';
+import noAppNodejsDynamicSSG from './rules/no-app-nodejs-dynamic-ssg';
 
 import type { ESLint } from 'eslint';
 
@@ -7,6 +8,8 @@ const config: ESLint.Plugin = {
 	rules: {
 		'no-nodejs-runtime': noNodeJsRuntime,
 		'no-unsupported-configs': noUnsupportedConfigs,
+		'no-app-nodejs-dynamic-ssg': noAppNodejsDynamicSSG,
+
 		// the following rule is no longer needed/applicable, it has been converted into a noop (so that it doesn't introduce a breaking change)
 		// it should be removed in the next package major release
 		'no-app-not-found-runtime': () => ({}),
@@ -17,6 +20,7 @@ const config: ESLint.Plugin = {
 			rules: {
 				'next-on-pages/no-nodejs-runtime': 'error',
 				'next-on-pages/no-unsupported-configs': 'error',
+				'next-on-pages/no-app-nodejs-dynamic-ssg': 'error',
 			},
 		},
 	},

--- a/packages/eslint-plugin-next-on-pages/src/rules/no-app-nodejs-dynamic-ssg.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-app-nodejs-dynamic-ssg.ts
@@ -1,0 +1,82 @@
+import type { Rule } from 'eslint';
+import type { Node } from 'estree';
+import { getProgramNode, traverseAST } from '../utils/ast-traversal';
+
+const rule: Rule.RuleModule = {
+	create: context => {
+		const insideAppRouter = context.filename.includes('/app/');
+		const insideAppApiRoute = context.filename.includes('/app/api');
+		const isPage = context.filename.match(/page\.[jt]sx/);
+
+		if (!insideAppRouter || !isPage || insideAppApiRoute) {
+			// The rule applies only to pages inside the app router, for all
+			// other files not linting should be applied here
+			return {};
+		}
+
+		// flag indicating whether we've found an `export runtime = 'edge'` in the file or not
+		let exportRuntimeEdgeFound = false;
+
+		// flag indicating whether we've found an `export dynamicParams = false` in the file or not
+		let dynamicParamsFalseFound = false;
+
+		return {
+			ExportNamedDeclaration: node => {
+				const declaration = node.declaration;
+				if (
+					declaration?.type === 'FunctionDeclaration' &&
+					declaration.id?.name === 'generateStaticParams'
+				) {
+					const program = getProgramNode(node);
+
+					if (!program) {
+						// for some reason we could not get the AST for the whole program, so let's bail
+						return;
+					}
+
+					traverseAST(context.sourceCode.visitorKeys, program, (node: Node) => {
+						if (node.type === 'ExportNamedDeclaration') {
+							if (
+								node.declaration?.type === 'VariableDeclaration' &&
+								node.declaration.declarations.length === 1 &&
+								node.declaration.declarations[0]?.id.type === 'Identifier' &&
+								node.declaration.declarations[0].id.name === 'runtime' &&
+								node.declaration.declarations[0].init?.type === 'Literal' &&
+								node.declaration.declarations[0].init?.value === 'edge'
+							) {
+								exportRuntimeEdgeFound = true;
+							}
+
+							if (
+								node.declaration?.type === 'VariableDeclaration' &&
+								node.declaration.declarations.length === 1 &&
+								node.declaration.declarations[0]?.id.type === 'Identifier' &&
+								node.declaration.declarations[0].id.name === 'dynamicParams' &&
+								node.declaration.declarations[0].init?.type === 'Literal' &&
+								node.declaration.declarations[0].init.value === false
+							) {
+								dynamicParamsFalseFound = true;
+							}
+						}
+					});
+
+					if (!exportRuntimeEdgeFound && !dynamicParamsFalseFound) {
+						context.report({
+							message:
+								'`generateStaticParams` cannot be used without opting in to the edge runtime or opting out from the Dynamic segment handling',
+							node: declaration.id,
+						});
+					}
+				}
+			},
+		};
+	},
+	meta: {
+		fixable: 'code',
+		docs: {
+			url: 'https://github.com/cloudflare/next-on-pages/blob/main/packages/eslint-plugin-next-on-pages/docs/rules/no-app-nodejs-dynamic-ssg.md',
+		},
+	},
+};
+
+export = rule;

--- a/packages/eslint-plugin-next-on-pages/src/rules/no-app-nodejs-dynamic-ssg.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-app-nodejs-dynamic-ssg.ts
@@ -63,7 +63,7 @@ const rule: Rule.RuleModule = {
 					if (!exportRuntimeEdgeFound && !dynamicParamsFalseFound) {
 						context.report({
 							message:
-								'`generateStaticParams` cannot be used without opting in to the edge runtime or opting out from the Dynamic segment handling',
+								'`generateStaticParams` cannot be used without opting in to the edge runtime or opting out of Dynamic segment handling',
 							node: declaration.id,
 						});
 					}

--- a/packages/eslint-plugin-next-on-pages/src/utils/ast-traversal.ts
+++ b/packages/eslint-plugin-next-on-pages/src/utils/ast-traversal.ts
@@ -1,0 +1,76 @@
+import type { Rule } from 'eslint';
+import type { Node, Program } from 'estree';
+
+type NodeWithParent = Node & { parent?: Node };
+
+/**
+ * Traverses an AST upwards by following the nodes' parents to search for the root Program node
+ *
+ * @param node the node to start the search from
+ * @returns the Program node or null if none was found
+ */
+export function getProgramNode(node: NodeWithParent): Program | null {
+	let currentNode: NodeWithParent = node;
+
+	if (currentNode.type === 'Program') {
+		return currentNode;
+	}
+
+	while (currentNode.parent) {
+		currentNode = currentNode.parent;
+		if (currentNode.type === 'Program') {
+			return currentNode;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Utility to traverse and AST and run a visitor logic on all the node of said AST
+ *
+ * @note The function comes from https://github.com/discord/eslint-traverse/blob/master/index.js
+ *       (plus some minor tweaks/simplifications and types support)
+ *
+ * @param allVisitorKeys all the visitor keys for the AST traversal
+ * @param node the node from where to start traversing the AST
+ * @param visitor callback that gets run against each visited node
+ */
+export function traverseAST(
+	allVisitorKeys: Rule.RuleContext['sourceCode']['visitorKeys'],
+	node: Node,
+	visitor: (node: Node) => void,
+): void {
+	const queue: Node[] = [node];
+
+	while (queue.length) {
+		const currentNode = queue.shift();
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		visitor(currentNode!);
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const visitorKeys = allVisitorKeys[currentNode!.type];
+		if (!visitorKeys) {
+			continue;
+		}
+
+		visitorKeys.forEach(visitorKey => {
+			const child = (currentNode as unknown as Record<string, Node>)[
+				visitorKey
+			];
+			if (!child) {
+				return;
+			}
+
+			if (Array.isArray(child)) {
+				for (const item of child) {
+					queue.push(item);
+				}
+				return;
+			}
+
+			queue.push(child);
+		});
+	}
+}

--- a/packages/eslint-plugin-next-on-pages/tests/rules/no-app-nodejs-dynamic-ssg.test.ts
+++ b/packages/eslint-plugin-next-on-pages/tests/rules/no-app-nodejs-dynamic-ssg.test.ts
@@ -1,0 +1,326 @@
+import { RuleTester } from 'eslint';
+
+import rule from '../../src/rules/no-app-nodejs-dynamic-ssg';
+import { describe, test } from 'vitest';
+
+const tester = new RuleTester({
+	parser: require.resolve('@typescript-eslint/parser'),
+});
+
+const error = {
+	message:
+		'`generateStaticParams` cannot be used without opting in to the edge runtime or opting out from the Dynamic segment handling',
+};
+
+describe('no-app-nodejs-dynamic-ssg', () => {
+	test('should work with a standard page', () => {
+		tester.run('', rule, {
+			valid: [
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export const runtime = 'edge';
+
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+				},
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+
+                    export const dynamicParams = false;
+                    `,
+				},
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export const dynamicParams = false;
+
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+				},
+			],
+			invalid: [
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+					errors: [error],
+				},
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+
+                    export const dynamicParams = true;
+                    `,
+					errors: [error],
+				},
+			],
+		});
+	});
+
+	test('should work on both js and ts files', () => {
+		tester.run('', rule, {
+			valid: [],
+			invalid: [
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+					errors: [error],
+				},
+				{
+					filename: '/app/dynamic/[...slug]/page.jsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+					errors: [error],
+				},
+			],
+		});
+	});
+
+	test('should not consider commented out exports as real exports', () => {
+		tester.run('', rule, {
+			valid: [],
+			invalid: [
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    // export const runtime = 'edge';
+
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+
+                    // export const dynamicParams = false;
+                    `,
+					errors: [error],
+				},
+			],
+		});
+	});
+
+	test('should not consider exports only similar to the real ones', () => {
+		tester.run('', rule, {
+			valid: [],
+			invalid: [
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export const runtimeToUse = 'edge';
+
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+					errors: [error],
+				},
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+
+                    export const dynamicParam = false;
+                    `,
+					errors: [error],
+				},
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export const runTime = 'edge';
+
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+
+                    export const myDynamicParams = false;
+                    `,
+					errors: [error],
+				},
+			],
+		});
+	});
+
+	test('should work with let variables (instead of const)', () => {
+		tester.run('', rule, {
+			valid: [
+				{
+					filename: '/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export let runtime = 'edge';
+
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+				},
+			],
+			invalid: [],
+		});
+	});
+
+	test('should work with a standard page inside /src/app', () => {
+		tester.run('', rule, {
+			valid: [
+				{
+					filename: 'src/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export const runtime = 'edge';
+
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+				},
+			],
+			invalid: [
+				{
+					filename: '/src/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+					errors: [error],
+				},
+			],
+		});
+	});
+
+	test('should not apply in a non-page (utility) file in the app router', () => {
+		tester.run('', rule, {
+			valid: [
+				{
+					filename: '/app/utils/ssg.ts',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+                    `,
+				},
+			],
+			invalid: [
+				{
+					filename: '/src/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+					errors: [error],
+				},
+			],
+		});
+	});
+
+	test('should not apply in files outside the app router', () => {
+		tester.run('', rule, {
+			valid: [
+				{
+					filename: '/pages/my-page/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+                    `,
+				},
+			],
+			invalid: [
+				{
+					filename: '/src/app/dynamic/[...slug]/page.tsx',
+					code: `
+                    export async function generateStaticParams() {
+                        return ["a", "b", "c"].map((char) => ({ slug: char }));
+                    }
+
+                    export default function Page({params: { slug }}) {
+                        return <div>{slug}</div>;
+                    }
+                    `,
+					errors: [error],
+				},
+			],
+		});
+	});
+});

--- a/packages/eslint-plugin-next-on-pages/tests/rules/no-app-nodejs-dynamic-ssg.test.ts
+++ b/packages/eslint-plugin-next-on-pages/tests/rules/no-app-nodejs-dynamic-ssg.test.ts
@@ -9,7 +9,7 @@ const tester = new RuleTester({
 
 const error = {
 	message:
-		'`generateStaticParams` cannot be used without opting in to the edge runtime or opting out from the Dynamic segment handling',
+		'`generateStaticParams` cannot be used without opting in to the edge runtime or opting out of Dynamic segment handling',
 };
 
 describe('no-app-nodejs-dynamic-ssg', () => {

--- a/packages/eslint-plugin-next-on-pages/tests/utils/ast-traversal.test.ts
+++ b/packages/eslint-plugin-next-on-pages/tests/utils/ast-traversal.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'vitest';
+import { traverseAST, getProgramNode } from '../../src/utils/ast-traversal';
+import type { Node } from 'estree';
+
+describe('traverseAst', () => {
+	test('traverses an AST and correctly invokes the visitor callback', () => {
+		const allVisitorKeys = {
+			NodeA: ['NodeB', 'NodeC'],
+			NodeB: [],
+			NodeC: ['NodeD'],
+		};
+		const ast = {
+			type: 'NodeA',
+			NodeB: {
+				type: 'NodeB',
+			},
+			NodeC: {
+				type: 'NodeC',
+				NodeD: {
+					type: 'NodeD',
+				},
+			},
+		} as unknown as Node;
+
+		const visitedNodeTypes: string[] = [];
+
+		traverseAST(allVisitorKeys, ast, node => {
+			visitedNodeTypes.push(node.type);
+		});
+
+		expect(visitedNodeTypes).toEqual(['NodeA', 'NodeB', 'NodeC', 'NodeD']);
+	});
+
+	test("doesn't traverse anything if no visitor key is provided", () => {
+		const allVisitorKeys = {};
+		const ast = {
+			type: 'NodeA',
+			NodeB: {
+				type: 'NodeB',
+			},
+			NodeC: {
+				type: 'NodeC',
+				NodeD: {
+					type: 'NodeD',
+				},
+			},
+		} as unknown as Node;
+
+		const visitedNodeTypes: string[] = [];
+
+		traverseAST(allVisitorKeys, ast, node => {
+			visitedNodeTypes.push(node.type);
+		});
+
+		expect(visitedNodeTypes).toEqual(['NodeA']);
+	});
+
+	test("doesn't traverse nodes not accessible via visitor keys", () => {
+		const allVisitorKeys = {
+			NodeA: ['NodeB', 'NodeC'],
+			NodeB: [],
+			NodeC: [],
+		};
+		const ast = {
+			type: 'NodeA',
+			NodeB: {
+				type: 'NodeB',
+			},
+			NodeC: {
+				type: 'NodeC',
+				NodeD: {
+					type: 'NodeD',
+				},
+			},
+		} as unknown as Node;
+
+		const visitedNodeTypes: string[] = [];
+
+		traverseAST(allVisitorKeys, ast, node => {
+			visitedNodeTypes.push(node.type);
+		});
+
+		expect(visitedNodeTypes).not.toContain('NodeD');
+		expect(visitedNodeTypes).toEqual(['NodeA', 'NodeB', 'NodeC']);
+	});
+});
+
+describe('getProgramNode', () => {
+	test('returns null if a non-program node without a parent is provided', () => {
+		const ast = {
+			type: 'NodeA',
+			NodeB: {
+				type: 'NodeB',
+			},
+		};
+
+		expect(getProgramNode(ast as unknown as Node)).toBeNull();
+	});
+
+	test("returns null if an ast doesn't include a program node at all", () => {
+		const ast = {
+			type: 'NodeA',
+			NodeB: {
+				type: 'NodeB',
+				NodeC: {
+					type: 'NodeC',
+				},
+			},
+		};
+
+		expect(getProgramNode(ast.NodeB.NodeC as unknown as Node)).toBeNull();
+	});
+
+	test('returns the root program node if present', () => {
+		const ast = {
+			type: 'NodeA',
+			NodeB: {
+				type: 'NodeB',
+				NodeC: {
+					type: 'NodeC',
+				},
+			},
+		};
+		const program = {
+			type: 'Program',
+			NodeA: ast,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any;
+
+		program.NodeA.NodeB.NodeC.parent = program.NodeA.NodeB;
+		program.NodeA.NodeB.parent = program.NodeA;
+		program.NodeA.parent = program;
+
+		expect(getProgramNode(program.NodeA.NodeB.NodeC)).toEqual(program);
+	});
+});


### PR DESCRIPTION
this PR adds the new `no-app-nodejs-dynamic-ssg` eslint rule that makes sure that developers using `generateStaticParams` also export either the `runtime` variable set to `edge` or the `dynamicParams` one set to `false`
