### PR TITLE
fix shared tsconfig file

### DIFF
--- a/internal-packages/next-on-pages-tsconfig/tsconfig.json
+++ b/internal-packages/next-on-pages-tsconfig/tsconfig.json
@@ -11,6 +11,8 @@
 		"resolveJsonModule": true,
 		"checkJs": false,
 
-		"exactOptionalPropertyTypes": false
+		"exactOptionalPropertyTypes": false,
+
+		"outDir": "dist"
 	}
 }


### PR DESCRIPTION
fix the shared tsconfig file in the next-on-pages-tsconfig internal package by adding a missing outDir value to its compilerOptions

___

without the `outDir` the `tsconfig.json` files extending the shared one provide this error/warning:
![Screenshot 2024-03-19 at 16 38 36](https://github.com/cloudflare/next-on-pages/assets/61631103/15c26788-7d96-4670-a620-67b632affffd)

I think this happens because, if no `outDir` is provided typescript assumes that that current directory is also where the files are going to be saved, does any `.js`/`.mjs` files there could produce an infinite loop
