### PR TITLE
make sure that the original request headers are not passed along when fetching external images

### DIFF
--- a/.changeset/lazy-avocados-swim.md
+++ b/.changeset/lazy-avocados-swim.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+don't pass the original request headers when fetching external images

--- a/.changeset/lazy-avocados-swim.md
+++ b/.changeset/lazy-avocados-swim.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': patch
 ---
 
-don't pass the original request headers when fetching external images
+make sure that the original request headers are not passed along when fetching external images

--- a/packages/next-on-pages/templates/_worker.js/utils/images.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/images.ts
@@ -158,11 +158,12 @@ export async function handleImageResizingRequest(
 
 	// TODO: implement proper image resizing
 
-	const imageReq = new Request(imageUrl, { headers: request.headers });
 	const imageResp =
 		isRelative && imageUrl.pathname in buildOutput
-			? await assetsFetcher.fetch(imageReq)
-			: await fetch(imageReq);
+			? await assetsFetcher.fetch(
+					new Request(imageUrl, { headers: request.headers }),
+			  )
+			: await fetch(imageUrl);
 
 	return formatResp(imageResp, imageUrl, imagesConfig);
 }

--- a/packages/next-on-pages/templates/_worker.js/utils/images.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/images.ts
@@ -158,12 +158,12 @@ export async function handleImageResizingRequest(
 
 	// TODO: implement proper image resizing
 
-	const imageResp =
+	const imgFetch =
 		isRelative && imageUrl.pathname in buildOutput
-			? await assetsFetcher.fetch(
-					new Request(imageUrl, { headers: request.headers }),
-			  )
-			: await fetch(imageUrl);
+			? assetsFetcher.fetch.bind(assetsFetcher)
+			: fetch;
+
+	const imageResp = await imgFetch(imageUrl);
 
 	return formatResp(imageResp, imageUrl, imagesConfig);
 }


### PR DESCRIPTION
The Next.js server doesn't pass the request headers when fetching external images but fetches using solely the image's url  ([source](https://github.com/vercel/next.js/blob/39340ab42428606685be8bf8a01b080f385c3eb1/packages/next/src/server/next-server.ts#L585))

We're instead passing the original request headers as well, which generates security risks, this PR addressed such issue

Thanks a lot @gabrielf to bringing this to my attention 🙂🙏 