### PR TITLE
Improve/fix `next-dev` types support

### DIFF
--- a/.changeset/slimy-toys-lie.md
+++ b/.changeset/slimy-toys-lie.md
@@ -1,0 +1,9 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+update `package.json` to properly export the typescript types
+
+the current types are declared in the `package.json` via `typesVersions`
+such don't seem to get picked up correctly by all package managers, to for
+the types use the `package.json` `exports` field instead

--- a/.changeset/swift-garlics-flash.md
+++ b/.changeset/swift-garlics-flash.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+fix the `setupDevPlatform`'s `options` parameter not being optional

--- a/internal-packages/next-dev/src/index.ts
+++ b/internal-packages/next-dev/src/index.ts
@@ -12,7 +12,7 @@ export * from './deprecated';
  * @param options options how the function should operate and if/where to persist the platform data
  */
 export async function setupDevPlatform(
-	options: GetPlatformProxyOptions,
+	options?: GetPlatformProxyOptions,
 ): Promise<void> {
 	const continueSetup = shouldSetupContinue();
 	if (!continueSetup) return;

--- a/packages/next-on-pages/package.json
+++ b/packages/next-on-pages/package.json
@@ -3,17 +3,14 @@
 	"version": "1.11.0",
 	"bin": "./bin/index.js",
 	"exports": {
-		".": "./dist/api/index.js",
-		"./next-dev": "./dist/next-dev/index.cjs"
-	},
-	"typesVersions": {
-		"*": {
-			".": [
-				"./dist/api/index.d.ts"
-			],
-			"next-dev": [
-				"./dist/next-dev/index.d.ts"
-			]
+		".": {
+			"import": "./dist/api/index.js",
+			"types": "./dist/api/index.d.ts"
+		},
+		"./next-dev": {
+			"import": "./dist/next-dev/index.cjs",
+			"require": "./dist/next-dev/index.cjs",
+			"types": "./dist/next-dev/index.d.ts"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
## Changes in this PR
 - fixes the `setupDevPlatform`'s options parameter not being optional
 - updates `package.json` to properly export the typescript types

## Related info
[discord discussion about the types being broken with pnpm](https://discord.com/channels/595317990191398933/1222961811528089632)