### PR TITLE
fix: runBuild should exit with 1 on unexpected errors (when watch mode is disabled)

### DIFF
--- a/.changeset/loud-owls-remember.md
+++ b/.changeset/loud-owls-remember.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+runBuild should exit with 1 on unexpected errors (when watch mode is disabled)

--- a/.changeset/loud-owls-remember.md
+++ b/.changeset/loud-owls-remember.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': patch
 ---
 
-runBuild should exit with 1 on unexpected errors (when watch mode is disabled)
+exit with exit status 1 on build unexpected errors (when watch mode is disabled)

--- a/packages/next-on-pages/src/index.ts
+++ b/packages/next-on-pages/src/index.ts
@@ -65,6 +65,9 @@ function runBuild(options: CliOptions) {
 		const errorMessage =
 			error instanceof Error ? error.message : JSON.stringify(error);
 		cliError(`Unexpected error: ${errorMessage}`);
+		if (!options.watch) {
+			process.exit(1);
+		}
 	});
 }
 


### PR DESCRIPTION
~(Maybe) partially addresses: #740.~ (EDIT: OP seems to have a different issue, the build does go through without errors even though the worker is somehow malformed).

I've encountered a similar issue on my own, we had an import of a file with multiple locale-specific characters, and it was causing the `.vercel/output/functions/<page-name>.func/index.js` to contain a blurb like
```
Ş:"Scedil",ß:"szlig",𝔱:"tfr",𝓉:"tscr",𝕥:"topf",𝒯:"Tscr",𝔗:"Tfr",𝕋:"Topf",ť:"tcaron",Ť:"Tcaron",ţ:"tcedil",Ţ:"Tcedil","™":"trade",ŧ:"tstrok",Ŧ:"Tstrok",𝓊:"uscr",𝕦:"uopf",𝔲:"ufr",𝕌:"Uopf",𝔘:"Ufr",𝒰:"Uscr",ú:"uacute",Ú:"Uacute",ù:"ugrave",Ù:"Ugrave",ŭ:"ubreve",Ŭ:"Ubreve",û:"ucirc",Û:"Ucirc",ů:"uring",Ů:"Uring",ü:"uuml",Ü:"Uuml",ű:"udblac",Ű:"Udblac",ũ:"utilde",Ũ:"Utilde",ų:"uogon",Ų:"Uogon",ū:"umacr",Ū:"Umacr",𝔳:"vfr",𝕧:"vopf",𝓋:"vscr",𝔙:"Vfr",𝕍:"Vopf",𝒱:"Vscr",𝕨:"wopf",𝓌:"wscr"
```
which caused the build logs to output
```
▲  Collected static files (public/, static/, .next/static): 59.326ms
▲  Build Completed in .vercel/output [4m]
⚡️ Completed `pnpm dlx vercel build`.
⚡️ Unexpected error: Unexpected character '�' (8036:87743)
```

I wasn't able to come up with a simple repro on this specific issue (and it looks more like something our project was doing wrong), but it's fairly simple to test that if `acorn's parse()` throws inside `getFunctionIdentifiers()`, the deploy fails and the exit code is 0 (which means CI or a command that does `&& pnpm run:deploy` would carry on with a broken build).
![CleanShot 2024-04-22 at 09 16 05@2x](https://github.com/cloudflare/next-on-pages/assets/8507996/5e9d1ad6-cbc6-4cde-855f-e2e192bc479b)

In our case, it was creating the same defect as OP has on #740, a deployment successfully goes out but all paths return 404 (even homepage) as something goes wrong building the worker's code.

**I'm assuming there might be N different reasons why a build can fail at this stage**, but if they're all going through the unexpected error path, I'd assume we'll always want to signal exit 1 to prevent deployments to continue broken.