### PR TITLE
Cache loading and update optimization

### DIFF
--- a/.changeset/fast-points-count.md
+++ b/.changeset/fast-points-count.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Optimized cache tags manifest loading; cache updates do not block responses

--- a/packages/next-on-pages/templates/cache/adaptor.ts
+++ b/packages/next-on-pages/templates/cache/adaptor.ts
@@ -75,6 +75,7 @@ export class CacheAdaptor {
 			}
 		}
 
+        // Make sure the cache has been updated before returning
 		await updateOp;
 	}
 
@@ -92,7 +93,7 @@ export class CacheAdaptor {
 		// Get entry from the cache.
 		const entryPromise = this.retrieve(key);
 
-		// And start loading the tags manifest.
+		// Start loading the tags manifest.
 		const tagsManifestLoad = this.loadTagsManifest();
 
 		const entry = await entryPromise;


### PR DESCRIPTION
Parallelizes operations while loading the cache tags manifest, and locally caches them for up to a second to avoid refresh on each cache request. On cache update, uses `ctx.waitUntil` instead of blocking the response while update is in progress.

I don't have real-life test numbers, but on our website where some pages require a 3 API request waterfall to render, I easily was seeing 400ms "wasted" by writing data to the cache. These changes solved my issue.