### PR TITLE
fix fetch patch hanging promise by moving symbol to globalThis

### DIFF
--- a/.changeset/itchy-cheetahs-design.md
+++ b/.changeset/itchy-cheetahs-design.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix hanging promise caused by fetch patch symbol

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -5,13 +5,13 @@ import { handleSuspenseCacheRequest } from './cache';
  * to work
  */
 export function patchFetch(): void {
-	const alreadyPatched = (globalThis.fetch as Fetch)[patchFlagSymbol];
+	const alreadyPatched = (globalThis as GlobalWithPatchSymbol)[patchFlagSymbol];
 
 	if (alreadyPatched) return;
 
 	applyPatch();
 
-	(globalThis.fetch as Fetch)[patchFlagSymbol] = true;
+	(globalThis as GlobalWithPatchSymbol)[patchFlagSymbol] = true;
 }
 
 function applyPatch() {
@@ -117,4 +117,4 @@ function setRequestUserAgentIfNeeded(
 
 const patchFlagSymbol = Symbol.for('next-on-pages fetch patch');
 
-type Fetch = typeof globalThis.fetch & { [patchFlagSymbol]: boolean };
+type GlobalWithPatchSymbol = typeof globalThis & { [patchFlagSymbol]: boolean };


### PR DESCRIPTION
fixes #769

See the issue for context.