### PR TITLE
Remove the `cache` property from calls to `new Request(...)` in React

### DIFF
--- a/.changeset/odd-buses-lay.md
+++ b/.changeset/odd-buses-lay.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Remove `cache` from React's `new Request(...)` cache.

--- a/.changeset/tame-islands-arrive.md
+++ b/.changeset/tame-islands-arrive.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Strip the `cache` property from our patched fetch.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -503,13 +503,13 @@ function fixFunctionContents(contents: string): string {
 	// https://github.com/vercel/next.js/blob/9ec37c12/packages/next/src/compiled/react/cjs/react.react-server.production.js#L87
 	contents = contents.replace(
 		/([\w$]+) instanceof URL\?new Request\([\w$]+,([\w$]+)\):[\w$]+;/gm,
-		`(() => {
-			if ($1 instanceof URL) {
-				const { cache, ...init } = $2 ?? {};
-				return new Request($1, init);
+		`((rawUrl, rawInit) => {
+			if (rawUrl instanceof URL) {
+				const { cache, ...init } = rawInit ?? {};
+				return new Request(rawUrl, init);
 			}
-			return $1;
-		})();`,
+			return rawUrl;
+		})($1, $2);`,
 	);
 
 	// TODO: Remove once https://github.com/vercel/next.js/issues/58265 is fixed.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -504,11 +504,16 @@ function fixFunctionContents(contents: string): string {
 	contents = contents.replace(
 		/([\w$]+) instanceof URL\?new Request\([\w$]+,([\w$]+)\):[\w$]+;/gm,
 		`((rawUrl, rawInit) => {
-			if (rawUrl instanceof URL) {
-				const { cache, ...init } = rawInit ?? {};
-				return new Request(rawUrl, init);
+			if (!(rawUrl instanceof URL)) {
+				return rawUrl;
 			}
-			return rawUrl;
+
+			if (!rawInit || rawInit instanceof Request) {
+				return new Request(rawUrl, rawInit);
+			}
+
+			const { cache, ...init } = rawInit ?? {};
+			return new Request(rawUrl, init);
 		})($1, $2);`,
 	);
 

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -17,8 +17,11 @@ export function patchFetch(): void {
 function applyPatch() {
 	const originalFetch = globalThis.fetch;
 
-	globalThis.fetch = async (...args) => {
-		const request = new Request(...args);
+	globalThis.fetch = async (input, requestInit) => {
+		// @ts-expect-error - `cache` exists on `RequestInit` in Node.js, but not workerd.
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const { cache, ...init } = requestInit ?? {};
+		const request = new Request(input, init);
 
 		let response = await handleInlineAssetRequest(request);
 		if (response) return response;


### PR DESCRIPTION
In the React server code, there is a ternary where they create a new Request object and forward all properties on `RequestInit` to it. This won't work in workerd due to the `cache` property being present. Therefore, we need to overwrite their ternary with a way for us to strip the `cache` property from the `RequestInit` object.

https://github.com/vercel/next.js/blob/9ec37c12/packages/next/src/compiled/react/cjs/react.react-server.production.js#L87

Additionally, once this patch has been added, it looks like the error can then happen in our patched fetch. Therefore, also adding similar logic there to strip out the `cache` property from the `RequestInit` object.

fixes #719