### PR TITLE
Add expiry to suspense cache based on revalidate

### DIFF
--- a/.changeset/purple-rocks-pump.md
+++ b/.changeset/purple-rocks-pump.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Invalidate fetch/suspense cache with next revalidate fetch options

--- a/.changeset/purple-rocks-pump.md
+++ b/.changeset/purple-rocks-pump.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': minor
 ---
 
-Invalidate fetch/suspense cache with next revalidate fetch options
+add support for the `revalidate` option in fetch

--- a/packages/next-on-pages/templates/cache/adaptor.ts
+++ b/packages/next-on-pages/templates/cache/adaptor.ts
@@ -37,8 +37,12 @@ export class CacheAdaptor {
 	 * @param key Key for the item.
 	 * @param value The value to update.
 	 */
-	public async update(key: string, value: string): Promise<void> {
-		throw new Error(`Method not implemented - ${key}, ${value}`);
+	public async update(
+		key: string,
+		value: string,
+		revalidate?: number,
+	): Promise<void> {
+		throw new Error(`Method not implemented - ${key}, ${value}, ${revalidate}`);
 	}
 
 	/**
@@ -54,7 +58,11 @@ export class CacheAdaptor {
 		};
 
 		// Update the cache entry.
-		const updateOp = this.update(key, JSON.stringify(newEntry));
+		const updateOp = this.update(
+			key,
+			JSON.stringify(newEntry),
+			value.revalidate,
+		);
 
 		switch (newEntry.value?.kind) {
 			case 'FETCH': {

--- a/packages/next-on-pages/templates/cache/cache-api.ts
+++ b/packages/next-on-pages/templates/cache/cache-api.ts
@@ -16,12 +16,14 @@ export default class CacheApiAdaptor extends CacheAdaptor {
 		return response ? response.text() : null;
 	}
 
-	public override async update(key: string, value: string) {
+	public override async update(
+		key: string,
+		value: string,
+		revalidate?: number,
+	) {
 		const cache = await caches.open(this.cacheName);
 
-		// The max-age to use for the cache entry.
-		const maxAge = '31536000'; // 1 year
-
+		const maxAge = revalidate ?? '31536000'; // 1 year
 		const response = new Response(value, {
 			headers: new Headers({
 				'cache-control': `max-age=${maxAge}`,

--- a/packages/next-on-pages/templates/cache/kv.ts
+++ b/packages/next-on-pages/templates/cache/kv.ts
@@ -14,10 +14,21 @@ export default class KVAdaptor extends CacheAdaptor {
 		return value ?? null;
 	}
 
-	public override async update(key: string, value: string) {
+	public override async update(
+		key: string,
+		value: string,
+		revalidate?: number,
+	) {
+		const expiry = revalidate
+			? {
+					expirationTtl: revalidate,
+			  }
+			: {};
+
 		await process.env.__NEXT_ON_PAGES__KV_SUSPENSE_CACHE?.put(
 			this.buildCacheKey(key),
 			value,
+			expiry,
 		);
 	}
 }


### PR DESCRIPTION
fixes https://github.com/cloudflare/next-on-pages/issues/757

This PR sets the expiry parameters of the next suspense cache based on the revalidation parameter.

[The aim of this PR is to support revalidation tags of the kind](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#time-based-revalidation):

```
await fetch('/path', {
  next: {
    revalidate: 900,
  }
);
```

In K-V, this is implemented as `expirationTtl`, in cache api as the cache control `max-age` header.

The `revalidate` parameter needs to be optional to support setting tags in the adaptor - will this work with the tags manifest operations at the same time?