### PR TITLE
Prevent invalid path name

### DIFF
--- a/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
+++ b/packages/next-on-pages/templates/_worker.js/routes-matcher.ts
@@ -361,6 +361,9 @@ export class RoutesMatcher {
 			this.path = this.path.replace(/\.rsc/i, '');
 		}
 
+		// Prevent `//` in path names.
+		this.path = this.path.replace(/\/\//g, '/')
+
 		// Merge search params for later use when serving a response.
 		const destUrl = new URL(this.path, this.url);
 		applySearchParams(this.searchParams, destUrl.searchParams);


### PR DESCRIPTION
Suggested fix for [issue #792](https://github.com/cloudflare/next-on-pages/issues/792), where `//` exists in this.path, causing an exception to break the page.

___

fixes #792 