### PR TITLE
Fix prerendered dynamic ISR functions change in Vercel CLI

### DIFF
--- a/.changeset/warm-rivers-reply.md
+++ b/.changeset/warm-rivers-reply.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Account for the Vercel CLI no longer generating prerender configs for dynamic ISR functions.

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/configs.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/configs.ts
@@ -88,6 +88,7 @@ export type CollectedFunctions = {
 export type FunctionInfo = {
 	relativePath: string;
 	config: VercelFunctionConfig;
+	sourcePath?: string;
 	outputPath?: string;
 	outputByteSize?: number;
 	route?: {

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/prerenderFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/prerenderFunctions.ts
@@ -46,6 +46,7 @@ export async function processPrerenderFunctions(
 				headers: config.initialHeaders,
 				overrides: getRouteOverrides(destRoute),
 			};
+			fnInfo.sourcePath = config.sourcePath;
 		} else {
 			invalidFunctions.set(path, fnInfo);
 			prerenderedFunctions.delete(path);

--- a/packages/next-on-pages/src/utils/fs.ts
+++ b/packages/next-on-pages/src/utils/fs.ts
@@ -178,3 +178,13 @@ export function getFileHash(path: string): Buffer | undefined {
 		return undefined;
 	}
 }
+
+/**
+ * Add a trailing slash to a path name if it doesn't already have one.
+ *
+ * @param path Path name to add a trailing slash to.
+ * @returns Path name with a trailing slash added.
+ */
+export function addTrailingSlash(path: string) {
+	return path.endsWith('/') ? path : `${path}/`;
+}

--- a/packages/next-on-pages/tests/_helpers/index.ts
+++ b/packages/next-on-pages/tests/_helpers/index.ts
@@ -304,11 +304,14 @@ export function createInvalidFuncDir(
  * Create a fake prerender config file for testing.
  *
  * @param path Path name for the file in the build output.
- * @param ext File extension for the fallback file in the build output.
+ * @param opts File extension for the fallback in the build output and prerender config options.
  * @returns The stringified prerender config file contents.
  */
-export function mockPrerenderConfigFile(path: string, ext?: string): string {
-	const extension = ext || (path.endsWith('.rsc') ? 'rsc' : 'html');
+export function mockPrerenderConfigFile(
+	path: string,
+	opts: { ext?: string; sourcePath?: string } = {},
+): string {
+	const extension = opts.ext || (path.endsWith('.rsc') ? 'rsc' : 'html');
 	const fsPath = `${path}.prerender-fallback.${extension}`;
 
 	const config: VercelPrerenderConfig = {
@@ -318,6 +321,7 @@ export function mockPrerenderConfigFile(path: string, ext?: string): string {
 			mode: 0,
 			fsPath,
 		},
+		sourcePath: opts.sourcePath,
 		initialHeaders: {
 			...((path.endsWith('.rsc') || path.endsWith('.json')) && {
 				'content-type': 'text/x-component',

--- a/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/prerenderFunctions.test.ts
+++ b/packages/next-on-pages/tests/src/buildApplication/processVercelFunctions/prerenderFunctions.test.ts
@@ -77,7 +77,7 @@ describe('processPrerenderFunctions', () => {
 				'favicon.ico.func': prerenderFuncDir,
 				'favicon.ico.prerender-config.json': mockPrerenderConfigFile(
 					'favicon.ico',
-					'body',
+					{ ext: 'body' },
 				),
 				'favicon.ico.prerender-fallback.body': 'favicon.ico',
 			},
@@ -123,7 +123,7 @@ describe('processPrerenderFunctions', () => {
 						'data.json.func': prerenderFuncDir,
 						'data.json.prerender-config.json': mockPrerenderConfigFile(
 							'data.json',
-							'json',
+							{ ext: 'json' },
 						),
 						'data.json.prerender-fallback.json': 'data.json',
 					},


### PR DESCRIPTION
new vercel cli update no longer generates prerender configs for dynamic ISR functions when it generates valid children for the route.

this pr does the following:
- checks if invalid func is a dynamic isr function
- if it is, it checks if there is prerendered function for the dynamic routes sourcepath
- if there are, it marks the dynamic function as ignored.

fixes #833

source path in prerender config for reference:

<img width="313" alt="image" src="https://github.com/user-attachments/assets/9ee0e347-eaa2-406d-bafd-ec0c4809abb4">

<img width="568" alt="image" src="https://github.com/user-attachments/assets/3a1c2514-ea91-4d93-8283-11ccce0b9a6f">
