### PR TITLE
implement route scoping solution

### DIFF
--- a/.changeset/thirty-birds-build.md
+++ b/.changeset/thirty-birds-build.md
@@ -1,0 +1,32 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+fix: implement route specific global scoping strategy
+
+currently routes all share the same global scope, this can be problematic and cause
+race conditions and failures
+
+One example of this is the following code that is present in route function files:
+
+```ts
+self.webpackChunk_N_E = ...
+```
+
+and
+
+```ts
+self.webpackChunk_N_E.push(...)
+```
+
+this indicates that an in-memory global collection of the webpack chunks is shared by all routes,
+this combined with the fact that chunks can have their own module state this can easily cause routes
+to conflict with each other at runtime.
+
+So, in order to solve the above issue wrap every route function in a function wrapper which
+accepts as parameters, thus overrides, the `self`, `globalThis` and `global` symbols. The symbols
+are then to be resolved with proxies that redirect setters to route-scoped in-memory maps and
+getters to the above mentioned map's values and fallback to the original symbol values otherwise
+(i.e. `globalThis` will be overridden by a proxy that, when setting values, sets them in a separate
+location and, when getting values, gets them from said location if present there or from the real
+`globalThis` otherwise)

--- a/.changeset/thirty-birds-build.md
+++ b/.changeset/thirty-birds-build.md
@@ -20,12 +20,10 @@ self.webpackChunk_N_E.push(...)
 ```
 
 this indicates that an in-memory global collection of the webpack chunks is shared by all routes,
-this combined with the fact that chunks can have their own module state this can easily cause routes
-to conflict with each other at runtime.
+this combined with the fact that chunks can have their own module state this can easily cause routes to conflict with each other at runtime.
 
-So, in order to solve the above issue wrap every route function in a function wrapper which
-accepts as parameters, thus overrides, the `self`, `globalThis` and `global` symbols. The symbols
-are then to be resolved with proxies that redirect setters to route-scoped in-memory maps and
+So, in order to solve the above issue, all route functions are wrapped in a function which accepts as parameters, thus overrides, the `self`, `globalThis` and `global` symbols. The symbols
+will be resolved with proxies that redirect setters to route-scoped in-memory maps and
 getters to the above mentioned map's values and fallback to the original symbol values otherwise
 (i.e. `globalThis` will be overridden by a proxy that, when setting values, sets them in a separate
 location and, when getting values, gets them from said location if present there or from the real

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -350,7 +350,7 @@ async function prependWasmImportsToCodeBlocks(
 					relativeTo: nopDistDir,
 				});
 
-				let functionImports = '';
+				const functionImports: string[] = [];
 
 				for (const identifier of wasmImports) {
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -358,11 +358,14 @@ async function prependWasmImportsToCodeBlocks(
 					const wasmImportPath = normalizePath(
 						join(relativeImportPath, newDest as string),
 					);
-					functionImports += `import ${identifier} from "${wasmImportPath}";\n`;
+					functionImports.push(`import ${identifier} from "${wasmImportPath}"`);
 				}
 
 				const oldContents = await readFile(filePath);
-				await writeFile(filePath, `${functionImports}${oldContents}`);
+				await writeFile(
+					filePath,
+					`${functionImports.join(';')};${oldContents}`,
+				);
 			},
 		),
 	);

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -233,7 +233,7 @@ async function buildFunctionFile(
 	groupedImports.forEach((keys, path) => {
 		if (path.endsWith('.wasm')) {
 			// we don't need/want to apply any code transformation for wasm imports
-			functionImports += `import ${keys} from "${path}"`;
+			functionImports += `import ${keys} from "${path}";`;
 			return;
 		}
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -250,7 +250,7 @@ async function buildFunctionFile(
 
 	fnInfo.outputPath = relative(workerJsDir, newFnPath);
 
-	const finalFileContents = iffefyFunctionFile(
+	const finalFileContents = iifefyFunctionFile(
 		fileContents,
 		functionImports,
 		fnInfo,
@@ -283,7 +283,7 @@ type BuildFunctionFileOpts = {
  * @param chunksExportsMap a map containing getters and chunks identifiers being used by the function
  * @returns the updated/iifefied file content
  */
-function iffefyFunctionFile(
+function iifefyFunctionFile(
 	fileContents: string,
 	functionImports: string[],
 	fnInfo: FunctionInfo,

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -282,14 +282,14 @@ type BuildFunctionFileOpts = {
  *
  * @param fileContents the function file's contents
  * @param functionImports the imports that need to be added to the file
- * @param fnInfo the function's information
+ * @param functionInfo the function's information
  * @param chunksExportsMap a map containing getters and chunks identifiers being used by the function
  * @returns the updated/iifefied file content
  */
 function iifefyFunctionFile(
 	fileContents: string,
 	functionImports: string[],
-	fnInfo: FunctionInfo,
+	functionInfo: FunctionInfo,
 	chunksExportsMap: Map<string, Set<string>>,
 ): string {
 	const wrappedContent = `
@@ -307,7 +307,7 @@ function iifefyFunctionFile(
 	`;
 
 	const proxyCall = `const proxy = globalThis.__nextOnPagesRoutesIsolation.getProxyFor('${
-		fnInfo.route?.path ?? ''
+		functionInfo.route?.path ?? ''
 	}');`;
 
 	const chunksExtraction = [...chunksExportsMap.entries()].flatMap(

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -246,7 +246,7 @@ async function buildFunctionFile(
 		);
 
 		const namedExportsId = `getNamedExports_${chunkMapIdx++}`;
-		chunksExportsMap.set(namedExportsId, new Set([...keys.split(',')]));
+		chunksExportsMap.set(namedExportsId, new Set(keys.split(',')));
 		functionImports += `import { getNamedExports as ${namedExportsId} } from '${importPath}';\n`;
 	});
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -690,4 +690,4 @@ async function processBundledAssets(
  *
  * This is the name of the object used for such exports.
  */
-const namedExportsObjectName = '__next_on_pages__named_exports_object__';
+const namedExportsObjectName = '__nextOnPagesNamedExportsObject';

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -690,4 +690,4 @@ async function processBundledAssets(
  *
  * This is the name of the object used for such exports.
  */
-const namedExportsObjectName = '__next-on-pages-named_exports_object__';
+const namedExportsObjectName = '__next_on_pages__named_exports_object__';

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -190,7 +190,7 @@ async function functionifyFileContent(path: string) {
 	let fileContents = await readFile(path, 'utf8');
 	fileContents = `const namedExports = {};${fileContents}`;
 	fileContents = fileContents.replace(
-		/export const (\S+) =/g,
+		/export\s+const\s+(\S+)\s*=/g,
 		'namedExports["$1"] =',
 	);
 	fileContents = `

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -239,7 +239,7 @@ async function buildFunctionFile(
 			// if we're dealing with a wasm file there is a single default export to deal with
 			const defaultExport = exports;
 			// we don't need/want to apply any code transformation for wasm imports
-			functionImports.push(`import ${defaultExport} from "${path}"`);
+			functionImports.push(`import ${defaultExport} from '${path}';`);
 			return;
 		}
 
@@ -247,7 +247,7 @@ async function buildFunctionFile(
 		const exportKeys = exports.split(',');
 		chunksExportsMap.set(getNamedExportsFunctionWithId, new Set(exportKeys));
 		functionImports.push(
-			`import { ${getNamedExportsFunctionName} as ${getNamedExportsFunctionWithId} } from '${importPath}'`,
+			`import { ${getNamedExportsFunctionName} as ${getNamedExportsFunctionWithId} } from '${importPath}';`,
 		);
 	});
 
@@ -316,7 +316,7 @@ function iifefyFunctionFile(
 			return [
 				`const ${namedExportsObjectWithId} = ${getNamedExportsFunctionWithId}(proxy, proxy, proxy);`,
 				...[...keys.keys()].map(
-					key => `const ${key} = ${namedExportsObjectWithId}["${key}"]`,
+					key => `const ${key} = ${namedExportsObjectWithId}["${key}"];`,
 				),
 			];
 		},
@@ -327,7 +327,7 @@ function iifefyFunctionFile(
 		proxyCall,
 		...chunksExtraction,
 		wrappedContent,
-	].join(';');
+	].join('\n');
 }
 
 /**

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -191,12 +191,10 @@ async function functionifyFileContent(path: string) {
 	return `
 		const namedExports = {};
 		export const getNamedExports = ((self, globalThis, global) => {
-			${
-				originalFileContents.replace(
-					/export\s+const\s+(\S+)\s*=/g,
-					'namedExports["$1"] =',
-				)
-			}
+			${originalFileContents.replace(
+				/export\s+const\s+(\S+)\s*=/g,
+				'namedExports["$1"] =',
+			)}
 			return namedExports;
 		});
 	`;

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -296,7 +296,7 @@ function iffefyFunctionFile(
 				// we have to update all such references otherwise our proxying won't take effect on those
 				.replace(/([^.])_ENTRIES/g, '$1globalThis._ENTRIES')
 				// the default export needs to become the return value of the iife, which is then re-exported as default
-				.replace(/export default /g, 'return ')}
+				.replace(/export\s+default\s+/g, 'return ')}
 		})(proxy, proxy, proxy);
 	`;
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -308,11 +308,11 @@ function iffefyFunctionFile(
 		fnInfo.route?.path ?? ''
 	}');`;
 
-	const chunksExtraction = [...chunksExportsMap].flatMap(
+	const chunksExtraction = [...chunksExportsMap.entries()].flatMap(
 		([getNamedExportsId, keys]) => {
 			return [
 				`const exportsOf${getNamedExportsId} = ${getNamedExportsId}(proxy, proxy, proxy);`,
-				...[...keys].map(
+				...[...keys.entries()].map(
 					key => `const ${key} = exportsOf${getNamedExportsId}["${key}"]`,
 				),
 			];

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -187,19 +187,19 @@ async function processFunctionIdentifiers(
  * @returns the converted file content
  */
 async function functionifyFileContent(path: string) {
-	let fileContents = await readFile(path, 'utf8');
-	fileContents = `const namedExports = {};${fileContents}`;
-	fileContents = fileContents.replace(
-		/export\s+const\s+(\S+)\s*=/g,
-		'namedExports["$1"] =',
-	);
-	fileContents = `
+	const originalFileContents = await readFile(path, 'utf8');
+	return `
+		const namedExports = {};
 		export const getNamedExports = ((self, globalThis, global) => {
-			${fileContents};
+			${
+				originalFileContents.replace(
+					/export\s+const\s+(\S+)\s*=/g,
+					'namedExports["$1"] =',
+				)
+			}
 			return namedExports;
 		});
 	`;
-	return fileContents;
 }
 
 /**

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -314,7 +314,7 @@ function iffefyFunctionFile(
 		([getNamedExportsId, keys]) => {
 			return [
 				`const exportsOf${getNamedExportsId} = ${getNamedExportsId}(proxy, proxy, proxy);`,
-				...[...keys.entries()].map(
+				...[...keys.keys()].map(
 					key => `const ${key} = exportsOf${getNamedExportsId}["${key}"]`,
 				),
 			];

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -297,7 +297,10 @@ function iifefyFunctionFile(
 			${fileContents
 				// it looks like there can be direct references to _ENTRIES (i.e. `_ENTRIES` instead of `globalThis._ENTRIES` etc...)
 				// we have to update all such references otherwise our proxying won't take effect on those
-				.replace(/([^.])_ENTRIES/g, '$1globalThis._ENTRIES')
+				// (note: older versions of the Vercel CLI (v31 and older) used to declare _ENTRIES as "let _ENTRIES = {};", so we do
+				// need to make sure that we don't add `globalThis.` in these cases (if we were to drop support for those older versions
+				// the below line to: ".replace(/([^.])_ENTRIES/g, '$1globalThis._ENTRIES')")
+				.replace(/(?<!(let)\s*)([^.]|^)_ENTRIES/g, '$2globalThis._ENTRIES')
 				// the default export needs to become the return value of the iife, which is then re-exported as default
 				.replace(/export\s+default\s+/g, 'return ')}
 		})(proxy, proxy, proxy);

--- a/packages/next-on-pages/templates/_worker.js/index.ts
+++ b/packages/next-on-pages/templates/_worker.js/index.ts
@@ -1,5 +1,6 @@
 import { SUSPENSE_CACHE_URL } from '../cache';
 import { handleRequest } from './handleRequest';
+import { setupRoutesIsolation } from './routesIsolation';
 import {
 	adjustRequestForVercel,
 	handleImageResizingRequest,
@@ -22,6 +23,7 @@ declare const __ALSes_PROMISE__: Promise<null | {
 
 export default {
 	async fetch(request, env, ctx) {
+		setupRoutesIsolation();
 		patchFetch();
 
 		const asyncLocalStorages = await __ALSes_PROMISE__;

--- a/packages/next-on-pages/templates/_worker.js/routesIsolation.ts
+++ b/packages/next-on-pages/templates/_worker.js/routesIsolation.ts
@@ -1,0 +1,91 @@
+/**
+ * The next-on-pages worker needs to isolate the global scope for each route, they all sharing the same global scope
+ * allows for race conditions and incorrect behaviors (see: https://github.com/cloudflare/next-on-pages/issues/805)
+ *
+ * So we set up an isolation system in which each route can access a proxy to the global scope that is route-specific,
+ * they can do that by calling `globalThis.getProxyFor(route)`.
+ *
+ * The following function sets up such utility alongside a map that is used to store the various proxies.
+ */
+export function setupRoutesIsolation() {
+	globalThis.__nextOnPagesRoutesIsolation ??= {
+		_map: new Map(),
+		getProxyFor,
+	};
+}
+
+/**
+ * Utility to retrieve a route-specific proxy to the global scope, if the proxy doesn't yet exist it gets created
+ * by the function.
+ *
+ * @param route the target route
+ * @returns the proxy for the route
+ */
+function getProxyFor(route: string) {
+	const existingProxy = globalThis.__nextOnPagesRoutesIsolation._map.get(route);
+	if (existingProxy) {
+		return existingProxy;
+	}
+
+	const newProxy = createNewRouteProxy();
+	globalThis.__nextOnPagesRoutesIsolation._map.set(route, newProxy);
+	return newProxy;
+}
+
+/**
+ * Creates a new route-specific proxy to the global scope.
+ *
+ * How the proxy works: setters on the proxy don't set the values to the actual global scope but
+ * in an internal map specific to the proxy. getters retrieve values from such internal map, and
+ * fall back to the actual global scope for values not present in such map.
+ *
+ * This makes it so that routes trying to modify the global scope will, though this proxy, work
+ * exactly like if they were actually updating the global scope, but without actually doing so,
+ * thus not effecting any other route.
+ *
+ * Note: this does not account for routes trying to update already existing objects in the global
+ * scope (e.g. `globalScope.existing_field.x = 123`), fortunately such granular control doesn't
+ * seem necessary in next-on-pages.
+ *
+ * @returns the created proxy.
+ */
+function createNewRouteProxy() {
+	const overrides = new Map<string | symbol, unknown>();
+
+	return new Proxy(globalThis, {
+		get: (_, property) => {
+			if (overrides.has(property)) {
+				return overrides.get(property);
+			}
+			return Reflect.get(globalThis, property);
+		},
+		set: (_, property, value) => {
+			if (sharedGlobalProperties.has(property)) {
+				// this property should be shared across all routes
+				return Reflect.set(globalThis, property, value);
+			}
+			overrides.set(property, value);
+			return true;
+		},
+	});
+}
+
+/**
+ * There are some properties that do need to be shared across all different routes, so we collect
+ * them in this set and skip the global scope proxying for them
+ */
+const sharedGlobalProperties = new Set<string | symbol>([
+	'_nextOriginalFetch',
+	'fetch',
+	'__incrementalCache',
+]);
+
+type RoutesIsolation = {
+	_map: Map<string, unknown>;
+	getProxyFor: (route: string) => unknown;
+};
+
+declare global {
+	// eslint-disable-next-line no-var
+	var __nextOnPagesRoutesIsolation: RoutesIsolation;
+}

--- a/pages-e2e/features/_utils/getAssertVisible.ts
+++ b/pages-e2e/features/_utils/getAssertVisible.ts
@@ -19,7 +19,6 @@ async function assertVisible(
 	page: Page,
 	...[selector, options]: Parameters<Page['locator']>
 ): Promise<Locator | never> {
-	let isVisible = false;
 	for (const _attempt of [0, 1, 2, 3, 4, 5]) {
 		const locator = page.locator(selector, options);
 		try {

--- a/pages-e2e/features/customEntrypoint/assets/custom-entrypoint.ts
+++ b/pages-e2e/features/customEntrypoint/assets/custom-entrypoint.ts
@@ -1,3 +1,4 @@
+//@ts-nocheck
 import nextOnPagesHandler from '@cloudflare/next-on-pages/fetch-handler';
 
 export default {

--- a/pages-e2e/fixtures/app14.0.0/main.fixture
+++ b/pages-e2e/fixtures/app14.0.0/main.fixture
@@ -4,7 +4,6 @@
 		"appRouting",
 		"appConfigsTrailingSlashTrue",
 		"appWasm",
-		"appServerActions",
 		"appGetRequestContext"
 	],
 	"localSetup": "npm install",


### PR DESCRIPTION
currently routes all share the same global scope, this can be problematic and cause race conditions and failures, like the one presented in #805 that happens when various requests are handled in parallel (and the global scope ends up in an invalid state).

So, this PR solves the issue by wrapping each js file (functions and chunks included) in functions that override the `self`, `globalThis` and `global` symbols with proxies that try to make (as reasonably well as possible) each route's global scope as isolated as possible.
____

fixes #805