### PR TITLE
Fix `x-vercel-ip-country-region` header's value

### DIFF
--- a/.changeset/curly-weeks-sin.md
+++ b/.changeset/curly-weeks-sin.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Use `request.cf.regionCode` for `x-vercel-ip-country-region` for keeping behavior consistent with documentation

--- a/packages/next-on-pages/templates/_worker.js/utils/request.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/request.ts
@@ -17,7 +17,7 @@ export function adjustRequestForVercel(request: Request): Request {
 		adjustedHeaders.set('x-vercel-ip-country', request.cf.country as string);
 		adjustedHeaders.set(
 			'x-vercel-ip-country-region',
-			request.cf.region as string,
+			request.cf.regionCode as string,
 		);
 		adjustedHeaders.set('x-vercel-ip-latitude', request.cf.latitude as string);
 		adjustedHeaders.set(


### PR DESCRIPTION
Fix #839 

~~Just like what @marcojakob observed on city names in #788, we should also encode region and country names for the location of the requester's public IP address.~~

`request.cf.region` is the full name of the region the user is in, however according to the doc, [x-vercel-ip-country-region](https://vercel.com/docs/edge-network/headers#x-vercel-ip-country-region) should be an [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) code, and I believe `request.cf.regionCode` is the correct value to be used here.

So that problems like what I met:

```
✘ [ERROR] Problematic header name or value: "Västra Götaland County" (raw bytes: "\x56\xe4\x73\x74\x72\x61\x20\x47\xf6\x74\x61\x6c\x61\x6e\x64\x20\x43\x6f\x75\x6e\x74\x79"). This string contains 8-bit characters in the range 0x80 - 0xFF. As a quirk to support Unicode, we encode header strings in UTF-8, meaning the actual header name/value on the wire will be "\x56\xc3\xa4\x73\x74\x72\x61\x20\x47\xc3\xb6\x74\x61\x6c\x61\x6e\x64\x20\x43\x6f\x75\x6e\x74\x79". Consider encoding this string in ASCII for compatibility with browser implementations of the Fetch specifications.
```

won't occur anymore.