### PR TITLE
replace regex replacemend logic in `iifefyFunctionFile` and handle `_ENTRIES` declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,12 +142,11 @@
 		},
 		"internal-packages/next-dev/node_modules/esbuild-darwin-arm64": {
 			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1074,11 +1073,10 @@
 		},
 		"node_modules/@cfpreview/pages-e2e-test-runner-cli/node_modules/@esbuild/darwin-arm64": {
 			"version": "0.16.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
-			"integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1366,9 +1364,7 @@
 		},
 		"node_modules/@cfpreview/pages-e2e-test-runner-cli/node_modules/fsevents": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -2039,76 +2035,15 @@
 			"resolved": "internal-packages/next-on-pages-tsconfig",
 			"link": true
 		},
-		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20240129.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240129.0.tgz",
-			"integrity": "sha512-DfVVB5IsQLVcWPJwV019vY3nEtU88c2Qu2ST5SQxqcGivZ52imagLRK0RHCIP8PK4piSiq90qUC6ybppUsw8eg==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
 			"version": "1.20240129.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240129.0.tgz",
-			"integrity": "sha512-t0q8ABkmumG1zRM/MZ/vIv/Ysx0vTAXnQAPy/JW5aeQi/tqrypXkO9/NhPc0jbF/g/hIPrWEqpDgEp3CB7Da7Q==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20240129.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240129.0.tgz",
-			"integrity": "sha512-sFV1uobHgDI+6CKBS/ZshQvOvajgwl6BtiYaH4PSFSpvXTmRx+A9bcug+6BnD+V4WgwxTiEO2iR97E1XuwDAVw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20240129.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240129.0.tgz",
-			"integrity": "sha512-O7q7htHaFRp8PgTqNJx1/fYc3+LnvAo6kWWB9a14C5OWak6AAZk42PNpKPx+DXTmGvI+8S1+futBGUeJ8NPDXg==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20240129.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240129.0.tgz",
-			"integrity": "sha512-YqGno0XSqqqkDmNoGEX6M8kJlI2lEfWntbTPVtHaZlaXVR9sWfoD7TEno0NKC95cXFz+ioyFLbgbOdnfWwmVAA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=16"
@@ -2137,55 +2072,44 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
-		"node_modules/@edge-runtime/cookies": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-3.4.1.tgz",
-			"integrity": "sha512-z27BvgPxI73CgSlxU/NAUf1Q/shnqi6cobHEowf6VuLdSjGR3NjI2Y5dZUIBbK2zOJVZbXcHsVzJjz8LklteFQ==",
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@edge-runtime/format": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.2.0.tgz",
-			"integrity": "sha512-gPrS6AVw/qJJL0vcxMXv4kFXCU3ZTCD1uuJpwX15YxHV8BgU9OG5v9LrkkXcr96PBT/9epypfNJMhlWADuEziw==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.2.1.tgz",
+			"integrity": "sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==",
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@edge-runtime/node-utils": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.2.1.tgz",
-			"integrity": "sha512-RUl/439BHKshkhSGFRlZ1kzy68wL4mn8VNKDSZr3p0tciyZ33Mjfpl+vofqnHqXRmDI6nLnZpfJvhY3D88o0pA==",
-			"dependencies": {
-				"@edge-runtime/cookies": "3.4.1"
-			},
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.3.0.tgz",
+			"integrity": "sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==",
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@edge-runtime/ponyfill": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@edge-runtime/ponyfill/-/ponyfill-2.4.1.tgz",
-			"integrity": "sha512-ZbR/EViY3gg2rmEAQTKPa6mXl4aR1/+cFcQe4r1segCjEbTAxT6PWu40odbu/KlZKSysEb2O/BWIC2lJgSJOMQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@edge-runtime/ponyfill/-/ponyfill-2.4.2.tgz",
+			"integrity": "sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==",
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@edge-runtime/primitives": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.0.5.tgz",
-			"integrity": "sha512-t7QiN5d/KpXgCvIfSt6Nm9Hj3WVdNgc5CpOD73jasY+9EvTI7Ngdj5cXvjcHrPcmYWJZMySPgeEeoL/1N/Llag==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
+			"integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@edge-runtime/vm": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.1.7.tgz",
-			"integrity": "sha512-hUMFbDQ/nZN+1TLMi6iMO1QFz9RSV8yGG8S42WFPFma1d7VSNE0eMdJUmwjmtav22/iQkzHMmu6oTSfAvRGS8g==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
+			"integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
 			"dependencies": {
-				"@edge-runtime/primitives": "4.0.5"
+				"@edge-runtime/primitives": "4.1.0"
 			},
 			"engines": {
 				"node": ">=16"
@@ -2256,11 +2180,10 @@
 		},
 		"node_modules/@esbuild/darwin-arm64": {
 			"version": "0.18.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.12.tgz",
-			"integrity": "sha512-zUZMep7YONnp6954QOOwEBwFX9svlKd3ov6PkxKd53LGTHsp/gy7vHaPGhhjBmEpqXEXShi6dddjIkmd+NgMsA==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -3411,6 +3334,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -3422,9 +3346,9 @@
 			}
 		},
 		"node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-			"integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
 			"dependencies": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
@@ -4065,8 +3989,7 @@
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
 			}
@@ -4498,9 +4421,9 @@
 			}
 		},
 		"node_modules/@vercel/build-utils": {
-			"version": "7.2.5",
-			"resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-7.2.5.tgz",
-			"integrity": "sha512-rlXL7Kjwfl8c8CQ9fYpP/+AunFZbaXXf89OT+7G8E/CGRM+hAYrGF+N3Kz1X8TfwfNlSCqPs7VQriOKKajUS0g=="
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-8.3.6.tgz",
+			"integrity": "sha512-EPwr8tXu41aoXg9QBiF98clu5AHbKtwbp3SeX/W6c8L0fhLwiT+H/s3WDuOL/UMz0TT3B8JAdY4PZioWNEAf6g=="
 		},
 		"node_modules/@vercel/error-utils": {
 			"version": "2.0.2",
@@ -4509,8 +4432,7 @@
 		},
 		"node_modules/@vercel/fun": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@vercel/fun/-/fun-1.1.0.tgz",
-			"integrity": "sha512-SpuPAo+MlAYMtcMcC0plx7Tv4Mp7SQhJJj1iIENlOnABL24kxHpL09XLQMGzZIzIW7upR8c3edwgfpRtp+dhVw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@tootallnate/once": "2.0.0",
 				"async-listen": "1.2.0",
@@ -4539,17 +4461,14 @@
 		},
 		"node_modules/@vercel/fun/node_modules/debug": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
 		},
 		"node_modules/@vercel/fun/node_modules/execa": {
 			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz",
-			"integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
+			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
 				"get-stream": "^5.0.0",
@@ -4568,8 +4487,7 @@
 		},
 		"node_modules/@vercel/fun/node_modules/fs-extra": {
 			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^4.0.0",
@@ -4581,8 +4499,7 @@
 		},
 		"node_modules/@vercel/fun/node_modules/get-stream": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -4595,16 +4512,14 @@
 		},
 		"node_modules/@vercel/fun/node_modules/human-signals": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8.12.0"
 			}
 		},
 		"node_modules/@vercel/fun/node_modules/lru-cache": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -4614,13 +4529,11 @@
 		},
 		"node_modules/@vercel/fun/node_modules/ms": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+			"license": "MIT"
 		},
 		"node_modules/@vercel/fun/node_modules/node-fetch": {
 			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"license": "MIT",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -4638,8 +4551,7 @@
 		},
 		"node_modules/@vercel/fun/node_modules/semver": {
 			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -4652,17 +4564,14 @@
 		},
 		"node_modules/@vercel/fun/node_modules/uuid": {
 			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"license": "MIT",
 			"bin": {
 				"uuid": "bin/uuid"
 			}
 		},
 		"node_modules/@vercel/fun/node_modules/yallist": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+			"license": "ISC"
 		},
 		"node_modules/@vercel/gatsby-plugin-vercel-analytics": {
 			"version": "1.0.11",
@@ -4673,12 +4582,12 @@
 			}
 		},
 		"node_modules/@vercel/gatsby-plugin-vercel-builder": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.0.11.tgz",
-			"integrity": "sha512-2G83Rj1gxL6X1/Cc0di+10xQ/ZYaaI1Mhi7kC8rUVApWY4cNJfFPsogB+DQ/fC6m+YAh3qajcbF6pnmVZk5K3Q==",
+			"version": "2.0.40",
+			"resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.0.40.tgz",
+			"integrity": "sha512-j3pZch8Qk2jfM87+dXX+xZXtdD+T2cMOmHhQWzO4oX3issxfBkkk2mAmY4o3Cxry5Xxe5iDQo6VsvY2IrWpCuA==",
 			"dependencies": {
 				"@sinclair/typebox": "0.25.24",
-				"@vercel/build-utils": "7.2.5",
+				"@vercel/build-utils": "8.3.6",
 				"@vercel/routing-utils": "3.1.0",
 				"esbuild": "0.14.47",
 				"etag": "1.8.1",
@@ -4757,35 +4666,36 @@
 			}
 		},
 		"node_modules/@vercel/go": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.0.4.tgz",
-			"integrity": "sha512-hMIJm2xwU1HT56YRNF8HNOnIFNH7WnGl1l2D6lc6UJk7XdCCh1Dm0nsqLqki2SprTUh3I+53pTQaqgRsFGf06A=="
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.1.1.tgz",
+			"integrity": "sha512-mrzomNYltxkjvtUmaYry5YEyvwTz6c/QQHE5Gr/pPGRIniUiP6T6OFOJ49RBN7e6pRXaNzHPVuidiuBhvHh5+Q=="
 		},
 		"node_modules/@vercel/hydrogen": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.0.1.tgz",
-			"integrity": "sha512-4PYk4LeIWPTjGtgnxvB0Hdw7aqCau843/96K2xX3z9pa0Hn//pUnZBMz2jrs5MRseCm1Li1LdQAK3u8/vaUnVQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.0.4.tgz",
+			"integrity": "sha512-Sc0lpmI/J6O3o2cL75k8klL7ir2gi6kYI92O5+MrR3hh4fwz/atUIL9UWsTGuFjKTm69VAoJrmn3VKf0/0SGLw==",
 			"dependencies": {
 				"@vercel/static-config": "3.0.0",
 				"ts-morph": "12.0.0"
 			}
 		},
 		"node_modules/@vercel/next": {
-			"version": "4.0.15",
-			"resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.0.15.tgz",
-			"integrity": "sha512-BxMxIJrya7MS6IWrQIaQaYHPmq7WoZFLX909RBpNoAG5wgzrTrW756d2EsibBwGo7sQYBv2atyI5GqBIHzYbWg==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.3.6.tgz",
+			"integrity": "sha512-qUHp79xX07qYtz7DGSogyWgEMrf+eu/IGV/92YnVA1xzDBogIFc8XFvMlN8QwDrsWWsR+I2eMSiGD+P8znlsaA==",
 			"dependencies": {
-				"@vercel/nft": "0.24.2"
+				"@vercel/nft": "0.27.3"
 			}
 		},
 		"node_modules/@vercel/nft": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.24.2.tgz",
-			"integrity": "sha512-KhY3Ky/lCqE+fHpOXiKOLnXYJ49PZh1dyDSfVtZhmYtmica0NQgyO6kPOAGDNWqD9IOBx8hb65upxxjfnfa1JA==",
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.27.3.tgz",
+			"integrity": "sha512-oySTdDSzUAFDXpsSLk9Q943o+/Yu/+TCFxnehpFQEf/3khi2stMpTHPVNwFdvZq/Z4Ky93lE+MGHpXCRpMkSCA==",
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "^1.0.5",
 				"@rollup/pluginutils": "^4.0.0",
 				"acorn": "^8.6.0",
+				"acorn-import-attributes": "^1.9.5",
 				"async-sema": "^3.1.1",
 				"bindings": "^1.4.0",
 				"estree-walker": "2.0.2",
@@ -4803,35 +4713,36 @@
 			}
 		},
 		"node_modules/@vercel/node": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@vercel/node/-/node-3.0.11.tgz",
-			"integrity": "sha512-J6ETfnfHNCnomEaEVTdbr/J1t1+SDYTx7nawCRux+Gn2JDrQ6y1K0YIi61FLLd7uIhShqJ4DzfImih7zKxxeeg==",
+			"version": "3.2.8",
+			"resolved": "https://registry.npmjs.org/@vercel/node/-/node-3.2.8.tgz",
+			"integrity": "sha512-mINg3ab1FHIqupZlLVpmCvyqGtkafnyNesgs7ZoCbNxqbb4ZrHtPj1kHv9cvTrFlDkFapkV/Ez8nbSsHeAxtOw==",
 			"dependencies": {
-				"@edge-runtime/node-utils": "2.2.1",
-				"@edge-runtime/primitives": "4.0.5",
-				"@edge-runtime/vm": "3.1.7",
-				"@types/node": "14.18.33",
-				"@vercel/build-utils": "7.2.5",
+				"@edge-runtime/node-utils": "2.3.0",
+				"@edge-runtime/primitives": "4.1.0",
+				"@edge-runtime/vm": "3.2.0",
+				"@types/node": "16.18.11",
+				"@vercel/build-utils": "8.3.6",
 				"@vercel/error-utils": "2.0.2",
-				"@vercel/nft": "0.24.2",
+				"@vercel/nft": "0.27.3",
 				"@vercel/static-config": "3.0.0",
 				"async-listen": "3.0.0",
-				"edge-runtime": "2.5.7",
+				"cjs-module-lexer": "1.2.3",
+				"edge-runtime": "2.5.9",
+				"es-module-lexer": "1.4.1",
 				"esbuild": "0.14.47",
 				"etag": "1.8.1",
-				"exit-hook": "2.2.1",
 				"node-fetch": "2.6.9",
 				"path-to-regexp": "6.2.1",
 				"ts-morph": "12.0.0",
 				"ts-node": "10.9.1",
 				"typescript": "4.9.5",
-				"undici": "5.26.5"
+				"undici": "5.28.4"
 			}
 		},
 		"node_modules/@vercel/node/node_modules/@types/node": {
-			"version": "14.18.33",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-			"integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg=="
+			"version": "16.18.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
+			"integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA=="
 		},
 		"node_modules/@vercel/node/node_modules/async-listen": {
 			"version": "3.0.0",
@@ -4888,9 +4799,9 @@
 			}
 		},
 		"node_modules/@vercel/node/node_modules/undici": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
-			"integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
+			"version": "5.28.4",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+			"integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
 			},
@@ -4899,18 +4810,20 @@
 			}
 		},
 		"node_modules/@vercel/python": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@vercel/python/-/python-4.1.0.tgz",
-			"integrity": "sha512-EIQXK5zL6fce0Barh74gc7xyLtRyvgmLZDIVQ8yJLtFxPlPCRY3GXkdJ7Jdcw8Pd0uuVF0vIHatv18xSLbcwtg=="
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@vercel/python/-/python-4.3.1.tgz",
+			"integrity": "sha512-pWRApBwUsAQJS8oZ7eKMiaBGbYJO71qw2CZqDFvkTj34FNBZtNIUcWSmqGfJJY5m2pU/9wt8z1CnKIyT9dstog=="
 		},
 		"node_modules/@vercel/redwood": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.0.5.tgz",
-			"integrity": "sha512-9iWTxfMkC7yNnwN2xxOdptiIDAgXe1V1fh3aw92MWt5PBRcFY9RqgIPF7Q3Qa7yzQFgpbHwCnSTqWO+HCEuFtw==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.1.3.tgz",
+			"integrity": "sha512-lpsdQSHS2hvSX29/rJNm4q38dVXKstS4MVg875KE6zyXpACwviXuet0Cadyv0E60w7f2B6Ra+nJMpwKz6oJ5xg==",
 			"dependencies": {
-				"@vercel/nft": "0.24.2",
+				"@vercel/nft": "0.27.3",
 				"@vercel/routing-utils": "3.1.0",
-				"semver": "6.3.1"
+				"@vercel/static-config": "3.0.0",
+				"semver": "6.3.1",
+				"ts-morph": "12.0.0"
 			}
 		},
 		"node_modules/@vercel/redwood/node_modules/semver": {
@@ -4922,11 +4835,12 @@
 			}
 		},
 		"node_modules/@vercel/remix-builder": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-2.0.12.tgz",
-			"integrity": "sha512-tm0dIJJcVm5CuJmWYJMqqz9h2gI2rysOTmbPdzEjZmFFzwcrI+745crFMbCXN++LJCLhyhXaMuktdWqQ4laimg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-2.2.3.tgz",
+			"integrity": "sha512-rXb0cgCIe8xCSl6gw+j5cjMEcmgQc5nbnpyMuaQ8+lRBSN0eEl8RkufkVQ4FblGQbnPnPFBCmraUx58HxKxfZw==",
 			"dependencies": {
-				"@vercel/nft": "0.24.2",
+				"@vercel/error-utils": "2.0.2",
+				"@vercel/nft": "0.27.3",
 				"@vercel/static-config": "3.0.0",
 				"ts-morph": "12.0.0"
 			}
@@ -4948,17 +4862,17 @@
 			"integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="
 		},
 		"node_modules/@vercel/ruby": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.0.3.tgz",
-			"integrity": "sha512-INZjBvBxQlANvj7LvHeXtfjpU+ZtwGL45vyys5+hI594MokpkrKdzUaTuK4kUX+KsEJUR7Xule5JiS89fW77BA=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.1.0.tgz",
+			"integrity": "sha512-UZYwlSEEfVnfzTmgkD+kxex9/gkZGt7unOWNyWFN7V/ZnZSsGBUgv6hXLnwejdRi3EztgRQEBd1kUKlXdIeC0Q=="
 		},
 		"node_modules/@vercel/static-build": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.0.13.tgz",
-			"integrity": "sha512-2+8v7QsRBVF31St8+OVZpJQHwOroXgP4ZoGX8/ppZhBh/Y7qfQds0mlECEnjdLHEdMIFwXCfuvUvcD5LfmjjAA==",
+			"version": "2.5.18",
+			"resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.5.18.tgz",
+			"integrity": "sha512-UgF/wrx5j07PMidvCVTjlTw1C47Ly+tpWihQyAH42xzf9BHtM+8S9UwOPdM5GYhtBuq2fmpPxFi9DCQ5sg4g7Q==",
 			"dependencies": {
 				"@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
-				"@vercel/gatsby-plugin-vercel-builder": "2.0.11",
+				"@vercel/gatsby-plugin-vercel-builder": "2.0.40",
 				"@vercel/static-config": "3.0.0",
 				"ts-morph": "12.0.0"
 			}
@@ -5145,6 +5059,14 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+			"peerDependencies": {
+				"acorn": "^8"
+			}
+		},
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
 			"license": "MIT",
@@ -5238,8 +5160,7 @@
 		},
 		"node_modules/any-promise": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+			"license": "MIT"
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
@@ -5261,6 +5182,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
 			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"deprecated": "This package is no longer supported.",
 			"dependencies": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^3.6.0"
@@ -5271,8 +5193,7 @@
 		},
 		"node_modules/arg": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
-			"integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+			"license": "MIT"
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -5337,16 +5258,6 @@
 				"printable-characters": "^1.0.42"
 			}
 		},
-		"node_modules/assert": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"es6-object-assign": "^1.1.0",
-				"is-nan": "^1.2.1",
-				"object-is": "^1.0.1",
-				"util": "^0.12.0"
-			}
-		},
 		"node_modules/assertion-error": {
 			"version": "1.1.0",
 			"license": "MIT",
@@ -5366,8 +5277,7 @@
 		},
 		"node_modules/async-listen": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/async-listen/-/async-listen-1.2.0.tgz",
-			"integrity": "sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA=="
+			"license": "MIT"
 		},
 		"node_modules/async-sema": {
 			"version": "3.1.1",
@@ -5376,6 +5286,7 @@
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.5",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -5581,7 +5492,8 @@
 		},
 		"node_modules/bindings": {
 			"version": "1.5.0",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -5600,8 +5512,7 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
 			},
@@ -5724,8 +5635,7 @@
 		},
 		"node_modules/bytes": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -5739,6 +5649,7 @@
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1",
@@ -5881,9 +5792,7 @@
 		},
 		"node_modules/chokidar/node_modules/fsevents": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -5894,8 +5803,7 @@
 		},
 		"node_modules/chownr": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+			"license": "ISC"
 		},
 		"node_modules/chromium-bidi": {
 			"version": "0.4.16",
@@ -5922,10 +5830,9 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.2.2",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -5989,8 +5896,7 @@
 		},
 		"node_modules/commander": {
 			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-			"integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=16"
 			}
@@ -6013,8 +5919,7 @@
 		},
 		"node_modules/content-type": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -6219,6 +6124,7 @@
 		},
 		"node_modules/define-properties": {
 			"version": "1.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-property-descriptors": "^1.0.0",
@@ -6238,8 +6144,7 @@
 		},
 		"node_modules/depd": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -6257,8 +6162,9 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.1",
-			"license": "Apache-2.0",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
 			"engines": {
 				"node": ">=8"
 			}
@@ -6323,13 +6229,13 @@
 			}
 		},
 		"node_modules/edge-runtime": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.7.tgz",
-			"integrity": "sha512-gA4qSVP0sNwJlkdQ2nahDPASlSl8twUd17o+JolPa1EtXpLTGzIpOETvodgJwXIxa+zaD8bnAXCdsWrx2PhlVQ==",
+			"version": "2.5.9",
+			"resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.9.tgz",
+			"integrity": "sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==",
 			"dependencies": {
-				"@edge-runtime/format": "2.2.0",
-				"@edge-runtime/ponyfill": "2.4.1",
-				"@edge-runtime/vm": "3.1.7",
+				"@edge-runtime/format": "2.2.1",
+				"@edge-runtime/ponyfill": "2.4.2",
+				"@edge-runtime/vm": "3.2.0",
 				"async-listen": "3.0.1",
 				"mri": "1.2.0",
 				"picocolors": "1.0.0",
@@ -6457,6 +6363,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w=="
+		},
 		"node_modules/es-set-tostringtag": {
 			"version": "2.0.1",
 			"dev": true,
@@ -6493,10 +6404,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es6-object-assign": {
-			"version": "1.1.0",
-			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.18.12",
@@ -7258,8 +7165,7 @@
 		},
 		"node_modules/events-intercept": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/events-intercept/-/events-intercept-2.0.0.tgz",
-			"integrity": "sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q=="
+			"license": "MIT"
 		},
 		"node_modules/execa": {
 			"version": "5.1.1",
@@ -7437,12 +7343,12 @@
 		},
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -7501,6 +7407,7 @@
 		},
 		"node_modules/for-each": {
 			"version": "0.3.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-callable": "^1.1.3"
@@ -7521,8 +7428,7 @@
 		},
 		"node_modules/fs-minipass": {
 			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^2.6.0"
 			}
@@ -7533,10 +7439,7 @@
 		},
 		"node_modules/fsevents": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-			"deprecated": "\"Please update to latest v2.3 or v2.2\"",
-			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -7547,8 +7450,7 @@
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -7582,6 +7484,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
 			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"deprecated": "This package is no longer supported.",
 			"dependencies": {
 				"aproba": "^1.0.3 || ^2.0.0",
 				"color-support": "^1.1.2",
@@ -7599,8 +7502,7 @@
 		},
 		"node_modules/generic-pool": {
 			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
-			"integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -7630,6 +7532,7 @@
 		},
 		"node_modules/get-intrinsic": {
 			"version": "1.2.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1",
@@ -7767,6 +7670,7 @@
 		},
 		"node_modules/gopd": {
 			"version": "1.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"get-intrinsic": "^1.1.3"
@@ -7797,6 +7701,7 @@
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.1"
@@ -7822,6 +7727,7 @@
 		},
 		"node_modules/has-property-descriptors": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"get-intrinsic": "^1.1.1"
@@ -7832,6 +7738,7 @@
 		},
 		"node_modules/has-proto": {
 			"version": "1.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -7842,6 +7749,7 @@
 		},
 		"node_modules/has-symbols": {
 			"version": "1.0.3",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -7852,6 +7760,7 @@
 		},
 		"node_modules/has-tostringtag": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.2"
@@ -7870,8 +7779,7 @@
 		},
 		"node_modules/hasown": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -7902,8 +7810,7 @@
 		},
 		"node_modules/http-errors": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
-			"integrity": "sha512-oLjPqve1tuOl5aRhv8GK5eHpqP1C9fb+Ol+XTLjKfLltE44zdDbEdjPSbU7Ch5rSNsVFqZn97SrMmZLdu1/YMw==",
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "2.0.1",
 				"statuses": ">= 1.2.1 < 2"
@@ -7914,8 +7821,7 @@
 		},
 		"node_modules/http-errors/node_modules/inherits": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-			"integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
+			"license": "ISC"
 		},
 		"node_modules/https-proxy-agent": {
 			"version": "5.0.1",
@@ -8068,22 +7974,7 @@
 		},
 		"node_modules/ip": {
 			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-			"integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
-		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+			"license": "MIT"
 		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.2",
@@ -8140,6 +8031,7 @@
 		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -8161,8 +8053,7 @@
 		},
 		"node_modules/is-core-module": {
 			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.0"
 			},
@@ -8207,19 +8098,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/is-generator-function": {
-			"version": "1.0.10",
-			"license": "MIT",
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"license": "MIT",
@@ -8228,20 +8106,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-negative-zero": {
@@ -8257,8 +8121,7 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -8376,6 +8239,7 @@
 		},
 		"node_modules/is-typed-array": {
 			"version": "1.1.10",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.5",
@@ -8412,8 +8276,7 @@
 		},
 		"node_modules/isarray": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -9037,10 +8900,8 @@
 		},
 		"node_modules/jest-haste-map/node_modules/fsevents": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
-			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -10131,8 +9992,7 @@
 		},
 		"node_modules/micro": {
 			"version": "9.3.5-canary.3",
-			"resolved": "https://registry.npmjs.org/micro/-/micro-9.3.5-canary.3.tgz",
-			"integrity": "sha512-viYIo9PefV+w9dvoIBh1gI44Mvx1BOk67B4BpC2QK77qdY0xZF0Q+vWLt/BII6cLkIc8rLmSIcJaB/OrXXKe1g==",
+			"license": "MIT",
 			"dependencies": {
 				"arg": "4.1.0",
 				"content-type": "1.0.4",
@@ -10158,8 +10018,7 @@
 		},
 		"node_modules/mime": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"license": "MIT",
 			"bin": {
 				"mime": "cli.js"
 			},
@@ -10184,8 +10043,7 @@
 		},
 		"node_modules/miniflare": {
 			"version": "3.20240129.2",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240129.2.tgz",
-			"integrity": "sha512-BPUg8HsPmWQlRFUeiQk274i8M9L0gOvzbkjryuTvCX+M53EwBpP0gM2wyrRr/HokQoJcxWGh3InBu6L8+0bbPw==",
+			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"acorn": "^8.8.0",
@@ -10209,8 +10067,7 @@
 		},
 		"node_modules/miniflare/node_modules/undici": {
 			"version": "5.28.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-			"integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+			"license": "MIT",
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
 			},
@@ -10250,8 +10107,7 @@
 		},
 		"node_modules/minipass": {
 			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+			"license": "ISC",
 			"dependencies": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -10259,8 +10115,7 @@
 		},
 		"node_modules/minizlib": {
 			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+			"license": "MIT",
 			"dependencies": {
 				"minipass": "^2.9.0"
 			}
@@ -10279,8 +10134,7 @@
 		},
 		"node_modules/mkdirp": {
 			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.6"
 			},
@@ -10416,9 +10270,9 @@
 			}
 		},
 		"node_modules/node-gyp-build": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
-			"integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+			"integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
 			"bin": {
 				"node-gyp-build": "bin.js",
 				"node-gyp-build-optional": "optional.js",
@@ -10491,6 +10345,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
 			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"deprecated": "This package is no longer supported.",
 			"dependencies": {
 				"are-we-there-yet": "^2.0.0",
 				"console-control-strings": "^1.1.0",
@@ -10627,22 +10482,9 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object-is": {
-			"version": "1.1.5",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -10702,8 +10544,7 @@
 		},
 		"node_modules/os-paths": {
 			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
-			"integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6.0"
 			}
@@ -10742,8 +10583,7 @@
 		},
 		"node_modules/p-finally": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-			"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -10796,8 +10636,6 @@
 		},
 		"node_modules/package-manager-manager": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/package-manager-manager/-/package-manager-manager-0.2.0.tgz",
-			"integrity": "sha512-V02gl0bafXJ2gcY6j+5IHM7UdnYwmF+2OsFZuqVcha6iMSStD4dpIOBOsypnUIwOi4jLcPz6RQuyifmAE3mG8g==",
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^4.1.0",
@@ -10875,8 +10713,7 @@
 		},
 		"node_modules/path-match": {
 			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/path-match/-/path-match-1.2.4.tgz",
-			"integrity": "sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==",
+			"license": "MIT",
 			"dependencies": {
 				"http-errors": "~1.4.0",
 				"path-to-regexp": "^1.0.0"
@@ -10884,8 +10721,7 @@
 		},
 		"node_modules/path-match/node_modules/path-to-regexp": {
 			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+			"license": "MIT",
 			"dependencies": {
 				"isarray": "0.0.1"
 			}
@@ -11001,8 +10837,6 @@
 		},
 		"node_modules/postcss": {
 			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -11017,6 +10851,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",
@@ -11279,8 +11114,7 @@
 		},
 		"node_modules/promisepipe": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/promisepipe/-/promisepipe-3.0.0.tgz",
-			"integrity": "sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA=="
+			"license": "MIT"
 		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
@@ -11306,8 +11140,7 @@
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -11388,8 +11221,7 @@
 		},
 		"node_modules/raw-body": {
 			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-			"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+			"license": "MIT",
 			"dependencies": {
 				"bytes": "3.1.0",
 				"http-errors": "1.7.3",
@@ -11402,8 +11234,7 @@
 		},
 		"node_modules/raw-body/node_modules/http-errors": {
 			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+			"license": "MIT",
 			"dependencies": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.4",
@@ -11509,7 +11340,8 @@
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -11527,6 +11359,30 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/recast": {
+			"version": "0.23.9",
+			"license": "MIT",
+			"dependencies": {
+				"ast-types": "^0.16.1",
+				"esprima": "~4.0.0",
+				"source-map": "~0.6.1",
+				"tiny-invariant": "^1.3.3",
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/recast/node_modules/ast-types": {
+			"version": "0.16.1",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/redent": {
@@ -11588,8 +11444,7 @@
 		},
 		"node_modules/resolve": {
 			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"license": "MIT",
 			"dependencies": {
 				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
@@ -11654,8 +11509,7 @@
 		},
 		"node_modules/rollup": {
 			"version": "3.29.4",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-			"integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+			"license": "MIT",
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
@@ -11707,9 +11561,7 @@
 		},
 		"node_modules/rollup/node_modules/fsevents": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -11822,8 +11674,7 @@
 		},
 		"node_modules/setprototypeof": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+			"license": "ISC"
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -12016,8 +11867,7 @@
 		},
 		"node_modules/socks/node_modules/ip": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-			"integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+			"license": "MIT"
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
@@ -12178,13 +12028,11 @@
 		},
 		"node_modules/stat-mode": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.3.0.tgz",
-			"integrity": "sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng=="
+			"license": "MIT"
 		},
 		"node_modules/statuses": {
 			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -12203,16 +12051,14 @@
 		},
 		"node_modules/stream-to-array": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
-			"integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.1.0"
 			}
 		},
 		"node_modules/stream-to-promise": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
-			"integrity": "sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==",
+			"license": "MIT",
 			"dependencies": {
 				"any-promise": "~1.3.0",
 				"end-of-stream": "~1.1.0",
@@ -12221,16 +12067,14 @@
 		},
 		"node_modules/stream-to-promise/node_modules/end-of-stream": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-			"integrity": "sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==",
+			"license": "MIT",
 			"dependencies": {
 				"once": "~1.3.0"
 			}
 		},
 		"node_modules/stream-to-promise/node_modules/once": {
 			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-			"integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -12260,7 +12104,8 @@
 		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -12424,8 +12269,7 @@
 		},
 		"node_modules/tar": {
 			"version": "4.4.18",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.18.tgz",
-			"integrity": "sha512-ZuOtqqmkV9RE1+4odd+MhBpibmCxNP6PJhH/h2OqNuotTX7/XHPZQJv2pKvWMplFH9SIZZhitehh6vBH6LO8Pg==",
+			"license": "ISC",
 			"dependencies": {
 				"chownr": "^1.1.4",
 				"fs-minipass": "^1.2.7",
@@ -12502,6 +12346,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/tiny-invariant": {
+			"version": "1.3.3",
+			"license": "MIT"
+		},
 		"node_modules/tinybench": {
 			"version": "2.5.0",
 			"license": "MIT"
@@ -12548,8 +12396,7 @@
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -12559,8 +12406,7 @@
 		},
 		"node_modules/toidentifier": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.6"
 			}
@@ -12579,8 +12425,7 @@
 		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"license": "MIT",
 			"bin": {
 				"tree-kill": "cli.js"
 			}
@@ -12833,11 +12678,10 @@
 		},
 		"node_modules/tsm/node_modules/esbuild-darwin-arm64": {
 			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -13202,9 +13046,8 @@
 		},
 		"node_modules/turbo": {
 			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/turbo/-/turbo-1.11.3.tgz",
-			"integrity": "sha512-RCJOUFcFMQNIGKSjC9YmA5yVP1qtDiBA0Lv9VIgrXraI5Da1liVvl3VJPsoDNIR9eFMyA/aagx1iyj6UWem5hA==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"bin": {
 				"turbo": "bin/turbo"
 			},
@@ -13217,82 +13060,16 @@
 				"turbo-windows-arm64": "1.11.3"
 			}
 		},
-		"node_modules/turbo-darwin-64": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.11.3.tgz",
-			"integrity": "sha512-IsOOg2bVbIt3o/X8Ew9fbQp5t1hTHN3fGNQYrPQwMR2W1kIAC6RfbVD4A9OeibPGyEPUpwOH79hZ9ydFH5kifw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
 		"node_modules/turbo-darwin-arm64": {
 			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.11.3.tgz",
-			"integrity": "sha512-FsJL7k0SaPbJzI/KCnrf/fi3PgCDCjTliMc/kEFkuWVA6Httc3Q4lxyLIIinz69q6JTx8wzh6yznUMzJRI3+dg==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
-		},
-		"node_modules/turbo-linux-64": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.11.3.tgz",
-			"integrity": "sha512-SvW7pvTVRGsqtSkII5w+wriZXvxqkluw5FO/MNAdFw0qmoov+PZ237+37/NgArqE3zVn1GX9P6nUx9VO+xcQAg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/turbo-linux-arm64": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.11.3.tgz",
-			"integrity": "sha512-YhUfBi1deB3m+3M55X458J6B7RsIS7UtM3P1z13cUIhF+pOt65BgnaSnkHLwETidmhRh8Dl3GelaQGrB3RdCDw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/turbo-windows-64": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.11.3.tgz",
-			"integrity": "sha512-s+vEnuM2TiZuAUUUpmBHDr6vnNbJgj+5JYfnYmVklYs16kXh+EppafYQOAkcRIMAh7GjV3pLq5/uGqc7seZeHA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/turbo-windows-arm64": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.11.3.tgz",
-			"integrity": "sha512-ZR5z5Zpc7cASwfdRAV5yNScCZBsgGSbcwiA/u3farCacbPiXsfoWUkz28iyrx21/TRW0bi6dbsB2v17swa8bjw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
 			]
 		},
 		"node_modules/type-check": {
@@ -13352,8 +13129,7 @@
 		},
 		"node_modules/uid-promise": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/uid-promise/-/uid-promise-1.0.0.tgz",
-			"integrity": "sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig=="
+			"license": "MIT"
 		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
@@ -13401,8 +13177,7 @@
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -13449,20 +13224,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
-			}
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
@@ -13510,21 +13275,21 @@
 			}
 		},
 		"node_modules/vercel": {
-			"version": "32.6.1",
-			"resolved": "https://registry.npmjs.org/vercel/-/vercel-32.6.1.tgz",
-			"integrity": "sha512-isEjDN1/rZEEHV2HVe2lGHkxuzvmih2luBAB42fDhhecIYs2gGKRLy+vIkJweRWRTlFMHjOHGPTYo7VfzQ10Ug==",
+			"version": "35.2.3",
+			"resolved": "https://registry.npmjs.org/vercel/-/vercel-35.2.3.tgz",
+			"integrity": "sha512-sfDUnP7dmerNZ/2PrUXLC9dJnJASFMy/UGW7Y2W0LVZbMtwH+jdLnViioRUEQaA2zbkkAipKza6w9rvD4sDvrA==",
 			"dependencies": {
-				"@vercel/build-utils": "7.2.5",
+				"@vercel/build-utils": "8.3.6",
 				"@vercel/fun": "1.1.0",
-				"@vercel/go": "3.0.4",
-				"@vercel/hydrogen": "1.0.1",
-				"@vercel/next": "4.0.15",
-				"@vercel/node": "3.0.11",
-				"@vercel/python": "4.1.0",
-				"@vercel/redwood": "2.0.5",
-				"@vercel/remix-builder": "2.0.12",
-				"@vercel/ruby": "2.0.3",
-				"@vercel/static-build": "2.0.13",
+				"@vercel/go": "3.1.1",
+				"@vercel/hydrogen": "1.0.4",
+				"@vercel/next": "4.3.6",
+				"@vercel/node": "3.2.8",
+				"@vercel/python": "4.3.1",
+				"@vercel/redwood": "2.1.3",
+				"@vercel/remix-builder": "2.2.3",
+				"@vercel/ruby": "2.1.0",
+				"@vercel/static-build": "2.5.18",
 				"chokidar": "3.3.1"
 			},
 			"bin": {
@@ -13537,8 +13302,7 @@
 		},
 		"node_modules/vercel/node_modules/chokidar": {
 			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-			"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
@@ -13557,8 +13321,7 @@
 		},
 		"node_modules/vercel/node_modules/readdirp": {
 			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-			"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^2.0.7"
 			},
@@ -13568,8 +13331,7 @@
 		},
 		"node_modules/vite": {
 			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
-			"integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
+			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.18.10",
 				"postcss": "^8.4.27",
@@ -13622,9 +13384,7 @@
 		},
 		"node_modules/vite/node_modules/fsevents": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -13862,6 +13622,7 @@
 		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.5",
@@ -13909,9 +13670,8 @@
 		},
 		"node_modules/workerd": {
 			"version": "1.20240129.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240129.0.tgz",
-			"integrity": "sha512-t4pnsmjjk/u+GdVDgH2M1AFmJaBUABshYK/vT/HNrAXsHSwN6VR8Yqw0JQ845OokO34VLkuUtYQYyxHHKpdtsw==",
 			"hasInstallScript": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -13928,8 +13688,7 @@
 		},
 		"node_modules/wrangler": {
 			"version": "3.28.2",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.28.2.tgz",
-			"integrity": "sha512-hlD4f2avBZuR1+qo9Um6D1prdWrSRtGTo9h6o/AKce+bHQEJWoJgJKHeLmrpZlLtHg/gGR1Xa1xzrexhuIzeJw==",
+			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.3.1",
 				"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
@@ -13967,8 +13726,7 @@
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/kv-asset-handler": {
 			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.1.tgz",
-			"integrity": "sha512-lKN2XCfKCmpKb86a1tl4GIwsJYDy9TGuwjhDELLmpKygQhw8X2xR4dusgpC5Tg7q1pB96Eb0rBo81kxSILQMwA==",
+			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"mime": "^3.0.0"
 			}
@@ -14038,11 +13796,10 @@
 		},
 		"node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
 			"version": "0.17.19",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-			"integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -14358,9 +14115,7 @@
 		},
 		"node_modules/wrangler/node_modules/fsevents": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -14371,8 +14126,7 @@
 		},
 		"node_modules/wrangler/node_modules/resolve.exports": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
-			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -14457,8 +14211,7 @@
 		},
 		"node_modules/xdg-app-paths": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz",
-			"integrity": "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==",
+			"license": "MIT",
 			"dependencies": {
 				"xdg-portable": "^7.0.0"
 			},
@@ -14468,8 +14221,7 @@
 		},
 		"node_modules/xdg-portable": {
 			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
-			"integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+			"license": "MIT",
 			"dependencies": {
 				"os-paths": "^4.0.1"
 			},
@@ -14539,8 +14291,7 @@
 		},
 		"node_modules/yauzl-clone": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/yauzl-clone/-/yauzl-clone-1.0.4.tgz",
-			"integrity": "sha512-igM2RRCf3k8TvZoxR2oguuw4z1xasOnA31joCqHIyLkeWrvAc2Jgay5ISQ2ZplinkoGaJ6orCz56Ey456c5ESA==",
+			"license": "MIT",
 			"dependencies": {
 				"events-intercept": "^2.0.0"
 			},
@@ -14550,8 +14301,7 @@
 		},
 		"node_modules/yauzl-promise": {
 			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/yauzl-promise/-/yauzl-promise-2.1.3.tgz",
-			"integrity": "sha512-A1pf6fzh6eYkK0L4Qp7g9jzJSDrM6nN0bOn5T0IbY4Yo3w+YkWlHFkJP7mzknMXjqusHFHlKsK2N+4OLsK2MRA==",
+			"license": "MIT",
 			"dependencies": {
 				"yauzl": "^2.9.1",
 				"yauzl-clone": "^1.0.4"
@@ -14615,7 +14365,7 @@
 			}
 		},
 		"packages/eslint-plugin-next-on-pages": {
-			"version": "1.11.3",
+			"version": "1.13.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree-jsx": "^1.0.0",
@@ -14653,7 +14403,7 @@
 		},
 		"packages/next-on-pages": {
 			"name": "@cloudflare/next-on-pages",
-			"version": "1.11.3",
+			"version": "1.13.1",
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -14667,6 +14417,7 @@
 				"miniflare": "^3.20231218.1",
 				"package-manager-manager": "^0.2.0",
 				"pcre-to-regexp": "^1.1.0",
+				"recast": "^0.23.4",
 				"semver": "^7.5.2"
 			},
 			"bin": {
@@ -14790,11 +14541,10 @@
 		},
 		"packages/next-on-pages/node_modules/esbuild-darwin-arm64": {
 			"version": "0.15.18",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
-			"integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
 			"cpu": [
 				"arm64"
 			],
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -15064,30 +14814,6 @@
 				"recast": "^0.23.4",
 				"vercel": "latest",
 				"vitest": "0.32.4"
-			}
-		},
-		"pages-e2e/node_modules/ast-types": {
-			"version": "0.16.1",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"pages-e2e/node_modules/recast": {
-			"version": "0.23.4",
-			"license": "MIT",
-			"dependencies": {
-				"assert": "^2.0.0",
-				"ast-types": "^0.16.1",
-				"esprima": "~4.0.0",
-				"source-map": "~0.6.1",
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 4"
 			}
 		}
 	}

--- a/packages/next-on-pages/package.json
+++ b/packages/next-on-pages/package.json
@@ -65,7 +65,8 @@
 		"miniflare": "^3.20231218.1",
 		"package-manager-manager": "^0.2.0",
 		"pcre-to-regexp": "^1.1.0",
-		"semver": "^7.5.2"
+		"semver": "^7.5.2",
+		"recast": "^0.23.4"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.26.0",


### PR DESCRIPTION
This PR replaces the regex replacements introduced in the `iifefyFunctionFile` function in https://github.com/cloudflare/next-on-pages/pull/836 with with more proper AST code modding

As part of this I also noticed that we do not want to update `_ENTRIES` identifiers if they are actually declared in the file (as it happens in older Vercel CLI releases) so I've addressed this too.

> [!NOTE]
> This PR does not include a changeset since the changes in https://github.com/cloudflare/next-on-pages/pull/836 have not yet been released and this PR simply improves that solution