### PR TITLE
avoid tweaking `_ENTRIES` if an `_ENTRIES` declaration is present

### DIFF
--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/dedupeEdgeFunctions.ts
@@ -293,7 +293,7 @@ function iifefyFunctionFile(
 	chunksExportsMap: Map<string, Set<string>>,
 ): string {
 	const fileContentsContainEntriesDeclaration =
-		/(let|var|const)\s+_ENTRIES\s*=/g.test(fileContents);
+		/(let|var|const)\s+_ENTRIES\s*=/.test(fileContents);
 
 	// it looks like there can be direct references to _ENTRIES (i.e. `_ENTRIES` instead of `globalThis._ENTRIES` etc...)
 	// we have to update all such references otherwise our proxying won't take effect on those, but only if the file doesn't


### PR DESCRIPTION
The `iifefyFunctionFile` function introduced in https://github.com/cloudflare/next-on-pages/pull/836 incorrectly modified `_ENTRIES` when they are actually declared in the function file (they should be modified only when they are global references), this PR fixes such issue

> [!NOTE]
> This PR does not include a changeset since the changes in https://github.com/cloudflare/next-on-pages/pull/836 have not yet been released and this PR simply improves that solution