### PR TITLE
Fix prerendered dynamic ISR functions with catch-all segments

### DIFF
--- a/.changeset/odd-lemons-jog.md
+++ b/.changeset/odd-lemons-jog.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix prerendered dynamic ISR functions with catch-all segments

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
@@ -339,7 +339,7 @@ async function tryToFixInvalidDynamicISRFuncs({
 
 		const isDynamicISRFunc =
 			fnInfo.config.operationType === 'ISR' &&
-			/\/\[[\w-]+\]$/.test(fnPathWithoutRscOrFuncExt);
+			/\/\[(?:\.\.\.)?[\w-]+\]$/.test(fnPathWithoutRscOrFuncExt);
 
 		if (isDynamicISRFunc) {
 			const matchingPrerenderedChildFunc = prerenderedFunctionEntries.find(


### PR DESCRIPTION
This expands on the change in #834 to fix prerendered routes with catch-all (e.g. blog/[...slug]/page.tsx -> blog/foo and blog/category/bar) routes.

I ran into an issue trying to get [timlrx/tailwind-nextjs-starter-blog](https://github.com/timlrx/tailwind-nextjs-starter-blog) working on Cloudflare Pages. For the most part, everything worked, but for blog posts in particular, there were two issues: first, somewhere in the stack code is `eval`-ed, so posts cannot be rendered on the edge runtime and must be prerendered. The second: next-on-pages wasn't doing whatever magic it usually does for a typical blog/[slog]/page.tsx, so I was getting an error telling me to add `runtime = 'edge'`.

This change applies the same fix to `[...param]` routes as it does `[param]` routes. I readily admit, I am a backend developer/data engineer not familiar with this codebase, Next.js, Cloudflare Pages, etc. This is working for me, but please validate my assumptions before merging.

I released this package on [@benmanns/next-on-pages](https://www.npmjs.com/package/@benmanns/next-on-pages) if anyone (like me) wants to use the changes immediately.