### PR TITLE
Add CLI option to ignore invalid functions

### DIFF
--- a/.changeset/hot-forks-try.md
+++ b/.changeset/hot-forks-try.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': minor
+---
+
+Add `force` CLI option to ignore invalid functions

--- a/packages/next-on-pages/src/buildApplication/buildApplication.ts
+++ b/packages/next-on-pages/src/buildApplication/buildApplication.ts
@@ -30,6 +30,7 @@ export async function buildApplication({
 	watch,
 	outdir: outputDir,
 	customEntrypoint,
+	force,
 }: Pick<
 	CliOptions,
 	| 'skipBuild'
@@ -38,6 +39,7 @@ export async function buildApplication({
 	| 'watch'
 	| 'outdir'
 	| 'customEntrypoint'
+	| 'force'
 >) {
 	const pm = await getPackageManager();
 
@@ -87,6 +89,7 @@ export async function buildApplication({
 		disableChunksDedup,
 		disableWorkerMinification,
 		customEntrypoint,
+		force,
 	});
 
 	const totalBuildTime = ((Date.now() - buildStartTime) / 1000).toFixed(2);
@@ -99,9 +102,13 @@ async function prepareAndBuildWorker(
 		disableChunksDedup,
 		disableWorkerMinification,
 		customEntrypoint,
+		force,
 	}: Pick<
 		CliOptions,
-		'disableChunksDedup' | 'disableWorkerMinification' | 'customEntrypoint'
+		| 'disableChunksDedup'
+		| 'disableWorkerMinification'
+		| 'customEntrypoint'
+		| 'force'
 	>,
 ): Promise<void> {
 	let vercelConfig: VercelConfig;
@@ -137,6 +144,7 @@ async function prepareAndBuildWorker(
 			nopDistDir,
 			disableChunksDedup,
 			vercelConfig,
+			ignoreInvalidFunctions: force,
 		});
 	}
 

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/index.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/index.ts
@@ -37,6 +37,7 @@ export type ProcessVercelFunctionsOpts = {
 	nopDistDir: string;
 	disableChunksDedup?: boolean;
 	vercelConfig: VercelConfig;
+	ignoreInvalidFunctions: boolean;
 };
 
 export type ProcessedVercelFunctions = {

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/invalidFunctions.ts
@@ -14,7 +14,7 @@ import { isUsingAppRouter, isUsingPagesRouter } from '../getVercelConfig';
 type InvalidFunctionsOpts = Pick<
 	ProcessVercelFunctionsOpts,
 	'functionsDir' | 'vercelConfig'
->;
+> & { ignoreInvalidFunctions?: boolean };
 
 /**
  * Checks if there are any invalid functions from the Vercel build output.
@@ -46,7 +46,10 @@ export async function checkInvalidFunctions(
 	await tryToFixInvalidFuncsWithValidIndexAlternative(collectedFunctions);
 	await tryToFixInvalidDynamicISRFuncs(collectedFunctions);
 
-	if (collectedFunctions.invalidFunctions.size > 0) {
+	if (
+		collectedFunctions.invalidFunctions.size > 0 &&
+		!opts.ignoreInvalidFunctions
+	) {
 		await printInvalidFunctionsErrorMessage(
 			collectedFunctions.invalidFunctions,
 		);

--- a/packages/next-on-pages/src/cli.ts
+++ b/packages/next-on-pages/src/cli.ts
@@ -62,6 +62,7 @@ program
 		'--custom-entrypoint <path>',
 		'Wrap the generated worker for your application in a custom worker entrypoint',
 	)
+	.option('-f, --force', 'Ignore checks for edge runtime compatibility', false)
 	.enablePositionalOptions(false)
 	.version(
 		nextOnPagesVersion,
@@ -79,6 +80,7 @@ export type CliOptions = {
 	info?: boolean;
 	outdir: string;
 	customEntrypoint?: string;
+	force: boolean;
 };
 
 export function parseCliArgs(): CliOptions {

--- a/packages/next-on-pages/tests/_helpers/index.ts
+++ b/packages/next-on-pages/tests/_helpers/index.ts
@@ -223,6 +223,7 @@ export async function createRouterTestData(
 		nopDistDir: join(workerJsDir, '__next-on-pages-dist__'),
 		disableChunksDedup: true,
 		vercelConfig: { version: 3 },
+		ignoreInvalidFunctions: false,
 	});
 
 	const staticAssets = await getVercelStaticAssets();


### PR DESCRIPTION
The presence of invalid functions shouldn't force a build failure as a deployment can still be valid (and even correct as outlined in #845) with invalid functions.

This commit adds a `--force` cli option (discussion welcomed!) that allows users to opt to ignore invalid functions (and skip more checks in the future?).

Closes #845