### PR TITLE
Define process.env.__NEXT_BUILD_ID in edge functions to be Next 14.2.8+ compatible

### DIFF
--- a/.changeset/real-wolves-destroy.md
+++ b/.changeset/real-wolves-destroy.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Provide \_\_NEXT_BUILD_ID env var to functions, making them compatible with Next v14.2.8 and newer.


### PR DESCRIPTION
Tested locally in a repo where we encountered the bug (caused by https://github.com/vercel/next.js/pull/65426) and as far as I can tell this should be backwards compatible / pretty safe.

~~I'm not 100% sure this is the right approach but it is an easy fix at least.~~ I now actually think this is a neat way to fix it.

Fixes #876.