### PR TITLE
fix: webpack chunks not deduping with sentry

### DIFF
--- a/.changeset/nasty-kids-tickle.md
+++ b/.changeset/nasty-kids-tickle.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Fix the Webpack chunk deduplication when Sentry is used, as it changes the AST node structure for Webpack chunks.


### PR DESCRIPTION
When using sentry, you get a SequenceExpression with the CallExpression inside it. We need to find that CallExpression so we can use it for deduping.

fixes #860

<img width="466" alt="image" src="https://github.com/user-attachments/assets/6fed2bba-5596-4d76-ac57-b280c8b07497">
