### PR TITLE
Let no-unsupported-configs rule check in next.config.ts

### DIFF
--- a/packages/eslint-plugin-next-on-pages/src/rules/no-unsupported-configs.ts
+++ b/packages/eslint-plugin-next-on-pages/src/rules/no-unsupported-configs.ts
@@ -97,7 +97,7 @@ const ruleSchema = {
 const rule: Rule.RuleModule = {
 	create: context => {
 		const code = context.sourceCode;
-		const exportedConfigName = context.filename.match(/next\.config\.m?js$/)
+		const exportedConfigName = context.filename.match(/next\.config\.(js|cjs|mjs|ts|cts|mts)$/)
 			? getConfigVariableName(code)
 			: null;
 

--- a/packages/eslint-plugin-next-on-pages/tests/rules/no-unsupported-configs.test.ts
+++ b/packages/eslint-plugin-next-on-pages/tests/rules/no-unsupported-configs.test.ts
@@ -497,4 +497,38 @@ describe('no-unsupported-configs', () => {
 			],
 		});
 	});
+
+	test('should work with .ts config file extension', () => {
+		tester.run('', rule, {
+			valid: [
+				{
+					filename: 'next.config.ts',
+					code: `
+						const nextConfig = {
+						}
+
+						export default nextConfig;
+					`,
+				},
+			],
+			invalid: [
+				{
+					filename: 'next.config.ts',
+					code: `
+						const nextConfig = {
+							compress: true,
+						}
+
+						export default nextConfig;
+					`,
+					errors: [
+						{
+							message:
+								'The "compress" configuration is not supported by next-on-pages (and is unlikely to be supported in the future).',
+						},
+					],
+				},
+			],
+		});
+	});
 });


### PR DESCRIPTION
Let the eslint rule that checks the next config file also check for the typescript variants, [which is now stable in next 15.](https://nextjs.org/docs/app/building-your-application/configuring/typescript#type-checking-nextconfigts) 

One could argue that only `js|mjs|ts` are needed since `mts|cts|cjs` are currently [not supported yet](https://github.com/vercel/next.js/pull/70376). But it shouldn't hurt to allow them in the regex for when/if they are supported.