### PR TITLE
Allow import of node:* and cloudflare:* in worker custom entrypoint

### DIFF
--- a/.changeset/sweet-chairs-explode.md
+++ b/.changeset/sweet-chairs-explode.md
@@ -2,4 +2,4 @@
 '@cloudflare/next-on-pages': patch
 ---
 
-Allow import of node:_ and cloudflare:_ in worker custom entrypoint
+Allow import of `node:*` and `cloudflare:*` in worker custom entrypoint

--- a/.changeset/sweet-chairs-explode.md
+++ b/.changeset/sweet-chairs-explode.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Allow import of node:_ and cloudflare:_ in worker custom entrypoint

--- a/packages/next-on-pages/src/buildApplication/buildWorkerFile.ts
+++ b/packages/next-on-pages/src/buildApplication/buildWorkerFile.ts
@@ -109,6 +109,7 @@ export async function buildWorkerFile(
 			outfile: outputFile,
 			allowOverwrite: true,
 			bundle: true,
+			external: ['node:*', 'cloudflare:*'],
 			plugins: [
 				{
 					name: 'custom-entrypoint-import-plugin',


### PR DESCRIPTION
This PR fixes an issue where when using a custom entrypoint, it's not possible to import `node:` or `cloudflare:` packages.