### PR TITLE
avoid re-instantiating `Response` when not required

### DIFF
--- a/packages/next-on-pages/templates/_worker.js/handleRequest.ts
+++ b/packages/next-on-pages/templates/_worker.js/handleRequest.ts
@@ -114,15 +114,17 @@ async function generateResponse(
 		});
 	}
 
-	const newHeaders = headers.normal;
-	applyHeaders(newHeaders, resp.headers);
-	applyHeaders(newHeaders, headers.important);
+	if (status || resp.status !== 101) {
+		const newHeaders = headers.normal;
+		applyHeaders(newHeaders, resp.headers);
+		applyHeaders(newHeaders, headers.important);
 
-	resp = new Response(resp.body, {
-		...resp,
-		status: status || resp.status,
-		headers: newHeaders,
-	});
+		resp = new Response(resp.body, {
+			...resp,
+			status: status || resp.status,
+			headers: newHeaders,
+		});
+	}
 
 	return resp;
 }

--- a/packages/next-on-pages/templates/_worker.js/utils/routing.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/routing.ts
@@ -131,6 +131,9 @@ export async function runOrFetchBuildOutputItem(
 		return new Response('Internal Server Error', { status: 500 });
 	}
 
+	if (resp.status === 101) {
+		return resp;
+	}
 	return createMutableResponse(resp);
 }
 


### PR DESCRIPTION
The problem is described here: https://github.com/cloudflare/next-on-pages/issues/894
You may ignore the rest and just read the last comment