### PR TITLE
fix: mark `async_hooks` as external

### DIFF
--- a/.changeset/stupid-dragons-brake.md
+++ b/.changeset/stupid-dragons-brake.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/next-on-pages': patch
+---
+
+Mark `async_hooks` as external.

--- a/packages/next-on-pages/src/buildApplication/buildWorkerFile.ts
+++ b/packages/next-on-pages/src/buildApplication/buildWorkerFile.ts
@@ -81,7 +81,12 @@ export async function buildWorkerFile(
 		banner: { js: generateGlobalJs() },
 		bundle: true,
 		inject: [functionsFile],
-		external: ['node:*', './__next-on-pages-dist__/*', 'cloudflare:*'],
+		external: [
+			'node:*',
+			'async_hooks',
+			'./__next-on-pages-dist__/*',
+			'cloudflare:*',
+		],
 		define: {
 			__CONFIG__: JSON.stringify(vercelConfig),
 			__NODE_ENV__: JSON.stringify(getNodeEnv()),

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/build.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/build.ts
@@ -36,7 +36,13 @@ export async function buildFile(
 		platform: 'neutral',
 		outfile: filePath,
 		bundle: true,
-		external: ['node:*', `${relativeNopDistPath}/*`, '*.wasm', 'cloudflare:*'],
+		external: [
+			'node:*',
+			'async_hooks',
+			`${relativeNopDistPath}/*`,
+			'*.wasm',
+			'cloudflare:*',
+		],
 		minify: true,
 		plugins: [builtInModulesPlugin],
 		define: {

--- a/packages/next-on-pages/src/buildApplication/processVercelFunctions/build.ts
+++ b/packages/next-on-pages/src/buildApplication/processVercelFunctions/build.ts
@@ -101,21 +101,24 @@ type RelativePathOpts = {
  * breaks at runtime. The following fixes this by updating the dynamic require to a standard esm
  * import from the built-in module.
  *
- * This applies to `require("node:*")` and `require("cloudflare:*")`.
+ * This applies to `require("node:*")`, `require("cloudflare:*")`, and `require("async_hooks")`.
  */
 export const builtInModulesPlugin: Plugin = {
 	name: 'built-in:modules',
 	setup(build) {
-		build.onResolve({ filter: /^(node|cloudflare):/ }, ({ kind, path }) => {
-			/**
-			 * This plugin converts `require("<PREFIX>:*")` calls, those are the only ones that need
-			 * updating (esm imports to "<PREFIX>:*" are totally valid), so here we tag with the
-			 * built-in-modules namespace only imports that are require calls.
-			 */
-			return kind === 'require-call'
-				? { path, namespace: 'built-in-modules' }
-				: undefined;
-		});
+		build.onResolve(
+			{ filter: /^(node:|cloudflare:|async_hooks)/ },
+			({ kind, path }) => {
+				/**
+				 * This plugin converts `require("<PREFIX>:*")` calls, those are the only ones that need
+				 * updating (esm imports to "<PREFIX>:*" are totally valid), so here we tag with the
+				 * built-in-modules namespace only imports that are require calls.
+				 */
+				return kind === 'require-call'
+					? { path, namespace: 'built-in-modules' }
+					: undefined;
+			},
+		);
 
 		/**
 		 * We convert the imports we tagged with the built-in-modules namespace so that instead of


### PR DESCRIPTION
fixes #908

Latest Vercel dependency broke the build because they didn't use the node prefix so we weren't accounting for it.

![image](https://github.com/user-attachments/assets/4c52326b-3e63-46f5-8826-cdcf7f3ed694)
