### PR TITLE
Fix next.config.ts using await in the top-level, breaking `npm run dev` in new projects

### DIFF
--- a/pages-e2e/fixtures/issue797app/next.config.mjs
+++ b/pages-e2e/fixtures/issue797app/next.config.mjs
@@ -4,9 +4,7 @@ import { setupDevPlatform } from '@cloudflare/next-on-pages/next-dev';
 // (when running the application with `next dev`), for more information see:
 // https://github.com/cloudflare/next-on-pages/blob/5712c57ea7/internal-packages/next-dev/README.md
 if (process.env.NODE_ENV === 'development') {
-  (async () => {
-    await setupDevPlatform();
-  })();
+  setupDevPlatform().catch(console.error);
 }
 
 /** @type {import('next').NextConfig} */

--- a/pages-e2e/fixtures/issue797app/next.config.mjs
+++ b/pages-e2e/fixtures/issue797app/next.config.mjs
@@ -4,7 +4,9 @@ import { setupDevPlatform } from '@cloudflare/next-on-pages/next-dev';
 // (when running the application with `next dev`), for more information see:
 // https://github.com/cloudflare/next-on-pages/blob/5712c57ea7/internal-packages/next-dev/README.md
 if (process.env.NODE_ENV === 'development') {
-	await setupDevPlatform();
+  (async () => {
+    await setupDevPlatform();
+  })();
 }
 
 /** @type {import('next').NextConfig} */


### PR DESCRIPTION
This PR removes the awaiting of `setupDevPlatform` and instead adds a catch to log to the console.

Currently, next-on-pages is broken for new projects, since you cannot run `npm run dev` because of this issue.

Fixes #927 and https://github.com/cloudflare/next-on-pages/issues/925