### PR TITLE
Update cli.ts to fix uri

### DIFF
--- a/packages/next-on-pages/src/cli.ts
+++ b/packages/next-on-pages/src/cli.ts
@@ -124,7 +124,7 @@ export function cliError(
 	);
 	if (showReport) {
 		cliError(
-			'Please report this at https://github.com/cloudflare/next-on-pages/issues.',
+			'Please report this at https://github.com/cloudflare/next-on-pages/issues/',
 			{ fromVercelCli },
 		);
 	}


### PR DESCRIPTION
I recently faced this issue, and when I clicked the URL, I got a 404 error.

This was because I was being redirected `https://github.com/cloudflare/next-on-pages/issues.` and not `https://github.com/cloudflare/next-on-pages/issues/`
(Different is a full stop)

This PR fixes it