### PR TITLE
Extract module name

### DIFF
--- a/.changeset/modern-spoons-speak.md
+++ b/.changeset/modern-spoons-speak.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/next-on-pages": patch
+'@cloudflare/next-on-pages': patch
 ---
 
 chore: Extract module name in dynamic imports

--- a/.changeset/modern-spoons-speak.md
+++ b/.changeset/modern-spoons-speak.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/next-on-pages": patch
+---
+
+chore: Extract module name in dynamic imports

--- a/packages/next-on-pages/templates/_worker.js/utils/cache.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/cache.ts
@@ -117,7 +117,8 @@ export async function getSuspenseCacheAdaptor(): Promise<CacheAdaptor> {
 async function getInternalCacheAdaptor(
 	type: 'kv' | 'cache-api',
 ): Promise<CacheAdaptor> {
-	const adaptor = await import(`./__next-on-pages-dist__/cache/${type}.js`);
+	const moduleName = `./__next-on-pages-dist__/cache/${type}.js`
+	const adaptor = await import(moduleName);
 	return new adaptor.default();
 }
 

--- a/packages/next-on-pages/templates/_worker.js/utils/cache.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/cache.ts
@@ -117,7 +117,7 @@ export async function getSuspenseCacheAdaptor(): Promise<CacheAdaptor> {
 async function getInternalCacheAdaptor(
 	type: 'kv' | 'cache-api',
 ): Promise<CacheAdaptor> {
-	const moduleName = `./__next-on-pages-dist__/cache/${type}.js`
+	const moduleName = `./__next-on-pages-dist__/cache/${type}.js`;
 	const adaptor = await import(moduleName);
 	return new adaptor.default();
 }

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -49,8 +49,9 @@ async function handleInlineAssetRequest(request: Request) {
 	if (request.url.startsWith('blob:')) {
 		try {
 			const url = new URL(request.url);
+			const moduleName = `./__next-on-pages-dist__/assets/${url.pathname}.bin`
 			const binaryContent = (
-				await import(`./__next-on-pages-dist__/assets/${url.pathname}.bin`)
+				await import(moduleName)
 			).default;
 
 			// Note: we can't generate a real Response object here because this fetch might be called

--- a/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
+++ b/packages/next-on-pages/templates/_worker.js/utils/fetch.ts
@@ -49,10 +49,8 @@ async function handleInlineAssetRequest(request: Request) {
 	if (request.url.startsWith('blob:')) {
 		try {
 			const url = new URL(request.url);
-			const moduleName = `./__next-on-pages-dist__/assets/${url.pathname}.bin`
-			const binaryContent = (
-				await import(moduleName)
-			).default;
+			const moduleName = `./__next-on-pages-dist__/assets/${url.pathname}.bin`;
+			const binaryContent = (await import(moduleName)).default;
 
 			// Note: we can't generate a real Response object here because this fetch might be called
 			//       at the top level of a dynamically imported module, and such cases produce the following


### PR DESCRIPTION
Newer versions of esbuild try to resolve dynamic imports by [crawling the filesystem for matching modules](https://esbuild.github.io/api/#glob). This doesn't work with the code `next-on-pages` generates, because the modules don't necessarily exist on the filesystem.

This PR extracts a `moduleName` variable so that esbuild doesn't try to look for matching modules on the filesystem.