### PR TITLE
Fix bug when building huge projects

### DIFF
--- a/packages/next-on-pages/src/buildApplication/buildSummary.ts
+++ b/packages/next-on-pages/src/buildApplication/buildSummary.ts
@@ -147,7 +147,7 @@ export async function writeBuildInfo(
 	try{
 		buildLogText = JSON.stringify(buildLogObject, null, 2);
 	} catch(e) {
-		cliLog("Build log is too big, there fore it is not saved");
+		cliLog("Build log too large to save");
 	}
 
 	await mkdir(outputDir, { recursive: true });

--- a/packages/next-on-pages/src/buildApplication/buildSummary.ts
+++ b/packages/next-on-pages/src/buildApplication/buildSummary.ts
@@ -143,7 +143,12 @@ export async function writeBuildInfo(
 			},
 		},
 	};
-	const buildLogText = JSON.stringify(buildLogObject, null, 2);
+	let buildLogText = ""
+	try{
+		buildLogText = JSON.stringify(buildLogObject, null, 2);
+	} catch(e) {
+		cliLog("Build log is too big, there fore it is not saved");
+	}
 
 	await mkdir(outputDir, { recursive: true });
 	await writeFile(buildLogFilePath, buildLogText);


### PR DESCRIPTION
For large projects this fails with RangeError: Invalid string length thrown from JSON.stringify, this is a simple fix for it.

<img width="1099" height="799" alt="image" src="https://github.com/user-attachments/assets/00382625-805c-4ef1-93ae-b9f81f5fd95b" />
